### PR TITLE
chore(logging): Changed print statement from Info to Error

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -67,7 +67,7 @@ func (g *GitOperations) CloneRepo(ctx context.Context) error {
 
 		stdout, stderr, err := g.runCmd(ctx, path, "clone", "--verbose", "--progress", "--filter=blob:none", g.gap.GetGitHttpsRepoUrl(*g.gitRepo), path)
 		if err != nil {
-			logger.Info("Cloned repo failed", "repo", g.gap.GetGitHttpsRepoUrl(*g.gitRepo), "stdout", stdout, "stderr", stderr)
+			logger.Error(err, "Cloned repo failed", "repo", g.gap.GetGitHttpsRepoUrl(*g.gitRepo), "stdout", stdout, "stderr", stderr)
 			return err
 		}
 


### PR DESCRIPTION
This log statement confused me a bit while debugging.
Now, it matches the rest of the error logs in the `CloneRepo` function :) 