### PR TITLE
fix: empty username in git askpass

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -310,7 +310,7 @@ func (g *GitOperations) runCmd(ctx context.Context, directory string, args ...st
 	cmd := exec.Command("git", args...)
 	cmd.Env = []string{
 		"GIT_ASKPASS=promoter_askpass.sh", // Needs to be on path
-		fmt.Sprintf("GIT_USER=%s", user),
+		fmt.Sprintf("GIT_USERNAME=%s", user),
 		fmt.Sprintf("GIT_PASSWORD=%s", token),
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		"GIT_TERMINAL_PROMPT=0",


### PR DESCRIPTION
Prerequisite for #141

This PR aligns the environment variable for git username with `promoter_askpass.sh`.

Background:
GitLab requires a non-empty Git username to be configured, whereas GitHub does not verify when access tokens are used.