### PR TITLE
chore: mark generated files as generated to suppress diffs in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+config/crd/bases/*.yaml linguist-generated=true
+dist/install.yaml linguist-generated=true
+go.sum linguist-generated=true


### PR DESCRIPTION
Just makes PR diffs easier to skim.