### PR TITLE
feat: add annotation for on copied active commit status

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -32,3 +32,6 @@ const PreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 
 // ReconcileAtAnnotation is the annotation used to indicate when the webhook triggered a reconcile
 const ReconcileAtAnnotation = "promoter.argoproj.io/reconcile-at"
+
+// CommitStatusDeAggregationLabel is the label used to identify commit statuses that make up the aggregated active commit status
+const CommitStatusDeAggregationLabel = "promoter.argoproj.io/commit-status-de-aggregation"

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -33,5 +33,5 @@ const PreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 // ReconcileAtAnnotation is the annotation used to indicate when the webhook triggered a reconcile
 const ReconcileAtAnnotation = "promoter.argoproj.io/reconcile-at"
 
-// CommitStatusDeAggregationAnnotation is the label used to identify commit statuses that make up the aggregated active commit status
-const CommitStatusDeAggregationAnnotation = "promoter.argoproj.io/previous-environment-statuses"
+// CommitStatusPreviousEnvironmentStatusesAnnotation is the label used to identify commit statuses that make up the aggregated active commit status
+const CommitStatusPreviousEnvironmentStatusesAnnotation = "promoter.argoproj.io/previous-environment-statuses"

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -33,5 +33,5 @@ const PreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 // ReconcileAtAnnotation is the annotation used to indicate when the webhook triggered a reconcile
 const ReconcileAtAnnotation = "promoter.argoproj.io/reconcile-at"
 
-// CommitStatusDeAggregationLabel is the label used to identify commit statuses that make up the aggregated active commit status
-const CommitStatusDeAggregationLabel = "promoter.argoproj.io/commit-status-de-aggregation"
+// CommitStatusDeAggregationAnnotation is the label used to identify commit statuses that make up the aggregated active commit status
+const CommitStatusDeAggregationAnnotation = "promoter.argoproj.io/commit-status-de-aggregation"

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -34,4 +34,4 @@ const PreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 const ReconcileAtAnnotation = "promoter.argoproj.io/reconcile-at"
 
 // CommitStatusDeAggregationAnnotation is the label used to identify commit statuses that make up the aggregated active commit status
-const CommitStatusDeAggregationAnnotation = "promoter.argoproj.io/commit-status-de-aggregation"
+const CommitStatusDeAggregationAnnotation = "promoter.argoproj.io/previous-environment-statuses"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	go.uber.org/zap v1.27.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
@@ -79,7 +79,6 @@ require (
 	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -349,7 +349,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 			return fmt.Errorf("failed to unmarshal previous environments CommitStatus: %w", err)
 		}
 	} else {
-		return fmt.Errorf("previous environments CommitStatus does not have a de-aggregation annotation")
+		return fmt.Errorf("previous environments CommitStatus does not have a previous environment annotation")
 	}
 
 	if updatedCS.Spec.Phase != phase || updatedCS.Spec.Sha != ctp.Status.Proposed.Hydrated.Sha || !reflect.DeepEqual(statusMap, updatedYamlStatusMap) {

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -315,7 +315,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 				promoterv1alpha1.CommitStatusLabel: promoterv1alpha1.PreviousEnvironmentCommitStatusKey,
 			},
 			Annotations: map[string]string{
-				promoterv1alpha1.CommitStatusDeAggregationLabel: string(yamlStatusMap),
+				promoterv1alpha1.CommitStatusDeAggregationAnnotation: string(yamlStatusMap),
 			},
 			Namespace:       proposedCSObjectKey.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*controllerRef},
@@ -343,7 +343,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 	}
 
 	updatedYamlStatusMap := make(map[string]string)
-	err = yaml.Unmarshal([]byte(updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationLabel]), &updatedYamlStatusMap)
+	err = yaml.Unmarshal([]byte(updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationAnnotation]), &updatedYamlStatusMap)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal previous environments CommitStatus: %w", err)
 	}
@@ -353,7 +353,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 		updatedCS.Spec.Sha = ctp.Status.Proposed.Hydrated.Sha
 		updatedCS.Spec.Description = commitStatus.Spec.Description
 		updatedCS.Spec.Name = commitStatus.Spec.Name
-		updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationLabel] = string(yamlStatusMap)
+		updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationAnnotation] = string(yamlStatusMap)
 
 		err = r.Update(ctx, updatedCS)
 		if err != nil {

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -349,7 +349,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 			return fmt.Errorf("failed to unmarshal previous environments CommitStatus: %w", err)
 		}
 	} else {
-		return fmt.Errorf("previous environments CommitStatus does not have a previous environment annotation")
+		return fmt.Errorf("previous environments CommitStatus does not have a previous environment commit statuses annotation")
 	}
 
 	if updatedCS.Spec.Phase != phase || updatedCS.Spec.Sha != ctp.Status.Proposed.Hydrated.Sha || !reflect.DeepEqual(statusMap, updatedYamlStatusMap) {

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"k8s.io/client-go/util/retry"
 

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -19,10 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"reflect"
 	"slices"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"k8s.io/client-go/util/retry"
 
@@ -407,7 +408,6 @@ func (r *PromotionStrategyReconciler) updatePreviousEnvironmentCommitStatus(ctx 
 			if err != nil {
 				return fmt.Errorf("failed to create or update previous environment commit status for branch %s: %w", environment.Branch, err)
 			}
-
 		}
 	}
 

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -315,7 +315,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 				promoterv1alpha1.CommitStatusLabel: promoterv1alpha1.PreviousEnvironmentCommitStatusKey,
 			},
 			Annotations: map[string]string{
-				"commitStatuses": string(yamlStatusMap),
+				promoterv1alpha1.CommitStatusDeAggregationLabel: string(yamlStatusMap),
 			},
 			Namespace:       proposedCSObjectKey.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*controllerRef},
@@ -343,7 +343,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 	}
 
 	updatedYamlStatusMap := make(map[string]string)
-	err = yaml.Unmarshal([]byte(updatedCS.Annotations["commitStatuses"]), &updatedYamlStatusMap)
+	err = yaml.Unmarshal([]byte(updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationLabel]), &updatedYamlStatusMap)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal previous environments CommitStatus: %w", err)
 	}
@@ -353,7 +353,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 		updatedCS.Spec.Sha = ctp.Status.Proposed.Hydrated.Sha
 		updatedCS.Spec.Description = commitStatus.Spec.Description
 		updatedCS.Spec.Name = commitStatus.Spec.Name
-		updatedCS.Annotations["commitStatuses"] = string(yamlStatusMap)
+		updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationLabel] = string(yamlStatusMap)
 
 		err = r.Update(ctx, updatedCS)
 		if err != nil {

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -353,7 +353,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 		updatedCS.Spec.Sha = ctp.Status.Proposed.Hydrated.Sha
 		updatedCS.Spec.Description = commitStatus.Spec.Description
 		updatedCS.Spec.Name = commitStatus.Spec.Name
-		updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationAnnotation] = string(yamlStatusMap)
+		updatedCS.Annotations[promoterv1alpha1.CommitStatusDeAggregationAnnotation] = commitStatus.Annotations[promoterv1alpha1.CommitStatusDeAggregationAnnotation]
 
 		err = r.Update(ctx, updatedCS)
 		if err != nil {


### PR DESCRIPTION
Adds an annotation called `promoter.argoproj.io/previous-environment-statuses` to the copied previous environments aggregated commit status, with a breakdown of all the active commit statuses configured and their state.

```
apiVersion: promoter.argoproj.io/v1alpha1
kind: CommitStatus
metadata:
  annotations:
    promoter.argoproj.io/previous-environment-statuses: |
      automated-testing: pending
      performance-test: pending
```