### PR TITLE
fix: wrap pull request creation error

### DIFF
--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -271,7 +271,7 @@ func (r *PullRequestReconciler) createPullRequest(ctx context.Context, pr *promo
 		pr.Spec.Description,
 		pr)
 	if err != nil {
-		return fmt.Errorf("failed to create pull request")
+		return fmt.Errorf("failed to create pull request: %w", err)
 	}
 
 	pr.Status.State = promoterv1alpha1.PullRequestOpen


### PR DESCRIPTION
Very minor fix, but I was trying to figure out why it was failing to open the request but the underlying error was hidden. I'm assuming this is just an oversight, I don't see a reason not to forward the error.