### PR TITLE
docs: reformat GitHub app documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,19 @@ kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/downl
 You will need to [create a GitHub App](https://docs.github.com/en/developers/apps/creating-a-github-app) and configure
 it to allow the GitOps Promoter to interact with your GitHub repository.
 
+
+During the creation the GitHub App, you will need to configure the following settings:
+
+### Permissions
+
+| Action            | Permission     |
+| ----------------- | -------------- |
+| `Commit statuses` | Read and write |
+| `Contents`        | Read and write |
+| `Pull requests`   | Read and write |
+
+### Webhooks (Optional - but highly recommended)
+
 !!! note "Configure your webhook ingress"
 
     We do support configuration of a GitHub App webhook that triggers PR creation upon Push. However, we do not configure
@@ -32,14 +45,9 @@ it to allow the GitOps Promoter to interact with your GitHub repository.
     you might want to adjust the auto reconciliation interval to a lower value using these CLI flags `--promotion-strategy-requeue-duration` and
     `--change-transfer-policy-requeue-duration`.
 
-During the creation the GitHub App, you will need to configure the following settings:
+Webhook URL: `https://<your-promoter-webhook-receiver-ingress>/`
 
-* Permissions
-  * Commit statuses - Read & write
-  * Contents - Read & write
-  * Pull requests - Read & write
-* Webhook URL (Optional - but highly recommended)
-  * `https://<your-promoter-webhook-receiver-service>/`
+### Usage
 
 The GitHub App will generate a private key that you will need to save. You will also need to get the App ID and the
 installation ID in a secret as follows:


### PR DESCRIPTION
Just trying to fix the formatting in the GitHub app docs, the bullets points were not rendering properly and the webhook info was a bit hidden.

Before: 
<img width="729" alt="image" src="https://github.com/user-attachments/assets/3d74582f-2ab5-41a9-acac-b935f38dc745" />

After: 
<img width="717" alt="image" src="https://github.com/user-attachments/assets/bf58e7fc-293c-4cab-82b7-a2f5986b76e1" />

