### PR TITLE
fix: use common parent when diffing diff

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -268,7 +268,7 @@ func (g *GitOperations) IsPullRequestRequired(ctx context.Context, environmentNe
 	logger.V(4).Info("Fetched branch", "branch", environmentNextBranch)
 
 	// Get the diff between the two branches
-	stdout, stderr, err := g.runCmd(ctx, gitpaths.Get(g.gap.GetGitHttpsRepoUrl(*g.gitRepo)+g.pathContext), "diff", fmt.Sprintf("origin/%s", environmentBranch), fmt.Sprintf("origin/%s", environmentNextBranch), "--name-only", "--diff-filter=ACMRT")
+	stdout, stderr, err := g.runCmd(ctx, gitpaths.Get(g.gap.GetGitHttpsRepoUrl(*g.gitRepo)+g.pathContext), "diff", fmt.Sprintf("origin/%s...origin/%s", environmentBranch, environmentNextBranch), "--name-only", "--diff-filter=ACMRT")
 	if err != nil {
 		logger.Error(err, "could not get diff", "gitError", stderr)
 		return false, err


### PR DESCRIPTION
fixes: https://github.com/argoproj-labs/gitops-promoter/issues/280

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons