### PR TITLE
fix: setup integration test to have access to settings manager

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -205,8 +205,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&ArgoCDCommitStatusReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:      k8sManager.GetClient(),
+		Scheme:      k8sManager.GetScheme(),
+		SettingsMgr: settingsMgr,
 		// Recorder: k8sManager.GetEventRecorderFor("ArgoCDCommitStatus"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Instead of going into a panic loop for tests, lets use the configured re-queue time.

The reasons tests still passed without this is because we panic and recover and so still do reconcile but that is inefficient 