### PR TITLE
chore!: privateKey -> githubAppPrivateKey in Secret

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ metadata:
   name: <your-secret-name>
 type: Opaque
 stringData:
-  privateKey: <your-private-key>
+  githubAppPrivateKey: <your-private-key>
 ```
 
 !!! note 

--- a/internal/scms/github/git_operations.go
+++ b/internal/scms/github/git_operations.go
@@ -12,6 +12,11 @@ import (
 	"github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 )
 
+const (
+	// githubAppPrivateKeySecretKey is the key in the secret that contains the private key for the GitHub App.
+	githubAppPrivateKeySecretKey = "githubAppPrivateKey"
+)
+
 type GitAuthenticationProvider struct {
 	scmProvider *v1alpha1.ScmProvider
 	secret      *v1.Secret
@@ -19,7 +24,7 @@ type GitAuthenticationProvider struct {
 }
 
 func NewGithubGitAuthenticationProvider(scmProvider *v1alpha1.ScmProvider, secret *v1.Secret) GitAuthenticationProvider {
-	itr, err := ghinstallation.New(http.DefaultTransport, scmProvider.Spec.GitHub.AppID, scmProvider.Spec.GitHub.InstallationID, secret.Data["privateKey"])
+	itr, err := ghinstallation.New(http.DefaultTransport, scmProvider.Spec.GitHub.AppID, scmProvider.Spec.GitHub.InstallationID, secret.Data[githubAppPrivateKeySecretKey])
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +60,7 @@ func (gh GitAuthenticationProvider) GetUser(ctx context.Context) (string, error)
 }
 
 func GetClient(scmProvider *v1alpha1.ScmProvider, secret v1.Secret) (*github.Client, error) {
-	itr, err := ghinstallation.New(http.DefaultTransport, scmProvider.Spec.GitHub.AppID, scmProvider.Spec.GitHub.InstallationID, secret.Data["privateKey"])
+	itr, err := ghinstallation.New(http.DefaultTransport, scmProvider.Spec.GitHub.AppID, scmProvider.Spec.GitHub.InstallationID, secret.Data[githubAppPrivateKeySecretKey])
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub installation transport: %w", err)
 	}


### PR DESCRIPTION
`githubAppPrivateKey` is better because 1) it's more explicit, and 2) it's the same as Argo CD's key, making it easier to reuse config.