### PR TITLE
chore(refactor): simplify by enforcing consistent order

### DIFF
--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -77,7 +77,7 @@ func (r *PromotionStrategyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("failed to get PromitionStrategy %q: %w", req.Name, err)
 	}
 
-	// If a ChangeTransferPolicy does not exist, create it otherwise get it and store the ChangeTransferPolicy in a slide with the same order as ps.Spec.Environments.
+	// If a ChangeTransferPolicy does not exist, create it otherwise get it and store the ChangeTransferPolicy in a slice with the same order as ps.Spec.Environments.
 	ctps := make([]*promoterv1alpha1.ChangeTransferPolicy, len(ps.Spec.Environments))
 	for i, environment := range ps.Spec.Environments {
 		var ctp *promoterv1alpha1.ChangeTransferPolicy

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -77,7 +77,7 @@ func (r *PromotionStrategyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("failed to get PromitionStrategy %q: %w", req.Name, err)
 	}
 
-	// If a ChangeTransferPolicy does not exist, create it otherwise get it and store the ChangeTransferPolicy in a map with the branch as the key.
+	// If a ChangeTransferPolicy does not exist, create it otherwise get it and store the ChangeTransferPolicy in a slide with the same order as ps.Spec.Environments.
 	ctps := make([]*promoterv1alpha1.ChangeTransferPolicy, len(ps.Spec.Environments))
 	for i, environment := range ps.Spec.Environments {
 		var ctp *promoterv1alpha1.ChangeTransferPolicy

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -223,6 +223,7 @@ func (r *PromotionStrategyReconciler) calculateStatus(ps *promoterv1alpha1.Promo
 		for _, environmentStatus := range ps.Status.Environments {
 			if environmentStatus.Branch == environment.Branch {
 				environmentStatuses[i] = environmentStatus
+				break
 			}
 		}
 	}

--- a/internal/controller/promotionstrategy_controller_test.go
+++ b/internal/controller/promotionstrategy_controller_test.go
@@ -312,30 +312,30 @@ var _ = Describe("PromotionStrategy Controller", func() {
 				g.Expect(promotionStrategy.Status.Environments).To(HaveLen(3))
 
 				// By("Checking that the ChangeTransferPolicy for development has shas that are not empty, meaning we have reconciled the resource")
-				// Active dry sha should be empty because hydrator.metadata is not present
+				// Active dry sha should be the same as proposed dry sha because we should have merged the branch with hydrator.metadata.
 				g.Expect(ctpDev.Status.Proposed.Dry.Sha).To(Not(BeEmpty()))
-				g.Expect(ctpDev.Status.Active.Dry.Sha).To(BeEmpty())
+				g.Expect(ctpDev.Status.Active.Dry.Sha).To(Equal(ctpDev.Status.Proposed.Dry.Sha))
 				g.Expect(ctpDev.Status.Proposed.Hydrated.Sha).To(Not(BeEmpty()))
 				g.Expect(ctpDev.Status.Active.Hydrated.Sha).To(Not(BeEmpty()))
 
 				// By("Checking that the ChangeTransferPolicy for staging has shas that are not empty, meaning we have reconciled the resource")
-				// Active dry sha should be empty because hydrator.metadata is not present
+				// Active dry sha should be the same as proposed dry sha because we should have merged the branch with hydrator.metadata.
 				g.Expect(ctpStaging.Status.Proposed.Dry.Sha).To(Not(BeEmpty()))
-				g.Expect(ctpStaging.Status.Active.Dry.Sha).To(BeEmpty())
+				g.Expect(ctpStaging.Status.Active.Dry.Sha).To(Equal(ctpStaging.Status.Proposed.Dry.Sha))
 				g.Expect(ctpStaging.Status.Proposed.Hydrated.Sha).To(Not(BeEmpty()))
 				g.Expect(ctpStaging.Status.Active.Hydrated.Sha).To(Not(BeEmpty()))
 
 				// By("Checking that the ChangeTransferPolicy for production has shas that are not empty, meaning we have reconciled the resource")
-				// Active dry sha should be empty because hydrator.metadata is not present
+				// Active dry sha should be the same as proposed dry sha because we should have merged the branch with hydrator.metadata.
 				g.Expect(ctpProd.Status.Proposed.Dry.Sha).To(Not(BeEmpty()))
-				g.Expect(ctpProd.Status.Active.Dry.Sha).To(BeEmpty())
+				g.Expect(ctpProd.Status.Active.Dry.Sha).To(Equal(ctpProd.Status.Proposed.Dry.Sha))
 				g.Expect(ctpProd.Status.Proposed.Hydrated.Sha).To(Not(BeEmpty()))
 				g.Expect(ctpProd.Status.Active.Hydrated.Sha).To(Not(BeEmpty()))
 
 				// By("Checking that the PromotionStrategy for development environment has the correct sha values from the ChangeTransferPolicy")
 				g.Expect(ctpDev.Spec.ActiveBranch).To(Equal("environment/development"))
 				g.Expect(ctpDev.Spec.ProposedBranch).To(Equal("environment/development-next"))
-				g.Expect(promotionStrategy.Status.Environments[0].Active.Dry.Sha).To(Equal(""))
+				g.Expect(promotionStrategy.Status.Environments[0].Active.Dry.Sha).To(Equal(promotionStrategy.Status.Environments[0].Proposed.Dry.Sha))
 				g.Expect(promotionStrategy.Status.Environments[0].Active.Hydrated.Sha).To(Equal(ctpDev.Status.Active.Hydrated.Sha))
 				g.Expect(promotionStrategy.Status.Environments[0].Active.CommitStatus.Phase).To(Equal(string(promoterv1alpha1.CommitPhaseSuccess)))
 				g.Expect(promotionStrategy.Status.Environments[0].Proposed.Dry.Sha).To(Equal(ctpDev.Status.Proposed.Dry.Sha))
@@ -346,7 +346,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 				// By("Checking that the PromotionStrategy for staging environment has the correct sha values from the ChangeTransferPolicy")
 				g.Expect(ctpStaging.Spec.ActiveBranch).To(Equal("environment/staging"))
 				g.Expect(ctpStaging.Spec.ProposedBranch).To(Equal("environment/staging-next"))
-				g.Expect(promotionStrategy.Status.Environments[1].Active.Dry.Sha).To(Equal(""))
+				g.Expect(promotionStrategy.Status.Environments[1].Active.Dry.Sha).To(Equal(promotionStrategy.Status.Environments[1].Proposed.Dry.Sha))
 				g.Expect(promotionStrategy.Status.Environments[1].Active.Hydrated.Sha).To(Equal(ctpStaging.Status.Active.Hydrated.Sha))
 				g.Expect(promotionStrategy.Status.Environments[1].Active.CommitStatus.Phase).To(Equal(string(promoterv1alpha1.CommitPhaseSuccess)))
 				g.Expect(promotionStrategy.Status.Environments[1].Proposed.Dry.Sha).To(Equal(ctpStaging.Status.Proposed.Dry.Sha))
@@ -357,7 +357,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 				// By("Checking that the PromotionStrategy for production environment has the correct sha values from the ChangeTransferPolicy")
 				g.Expect(ctpProd.Spec.ActiveBranch).To(Equal("environment/production"))
 				g.Expect(ctpProd.Spec.ProposedBranch).To(Equal("environment/production-next"))
-				g.Expect(promotionStrategy.Status.Environments[2].Active.Dry.Sha).To(Equal(""))
+				g.Expect(promotionStrategy.Status.Environments[2].Active.Dry.Sha).To(Equal(promotionStrategy.Status.Environments[2].Proposed.Dry.Sha))
 				g.Expect(promotionStrategy.Status.Environments[2].Active.Hydrated.Sha).To(Equal(ctpProd.Status.Active.Hydrated.Sha))
 				g.Expect(promotionStrategy.Status.Environments[2].Active.CommitStatus.Phase).To(Equal(string(promoterv1alpha1.CommitPhaseSuccess)))
 				g.Expect(promotionStrategy.Status.Environments[2].Proposed.Dry.Sha).To(Equal(ctpProd.Status.Proposed.Dry.Sha))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -158,40 +158,6 @@ func KubeSafeLabel(ctx context.Context, name string) string {
 	return name
 }
 
-func GetEnvironmentsFromStatusInOrder(promotionStrategy promoterv1alpha1.PromotionStrategy) []promoterv1alpha1.EnvironmentStatus {
-	environments := []promoterv1alpha1.EnvironmentStatus{}
-	for _, specEnvironment := range promotionStrategy.Spec.Environments {
-		for _, statusEvents := range promotionStrategy.Status.Environments {
-			if specEnvironment.Branch == statusEvents.Branch {
-				environments = append(environments, statusEvents)
-			}
-		}
-	}
-	return environments
-}
-
-func GetPreviousEnvironmentStatusByBranch(promotionStrategy promoterv1alpha1.PromotionStrategy, currentBranch string) (int, *promoterv1alpha1.EnvironmentStatus) {
-	environments := GetEnvironmentsFromStatusInOrder(promotionStrategy)
-	for i, environment := range environments {
-		if environment.Branch == currentBranch {
-			if i-1 >= 0 && len(environments) > 0 {
-				return i - 1, &environments[i-1]
-			}
-		}
-	}
-	return -1, nil
-}
-
-func GetEnvironmentStatusByBranch(promotionStrategy promoterv1alpha1.PromotionStrategy, branch string) (int, *promoterv1alpha1.EnvironmentStatus) {
-	environments := GetEnvironmentsFromStatusInOrder(promotionStrategy)
-	for i, environment := range environments {
-		if environment.Branch == branch {
-			return i, &environment
-		}
-	}
-	return -1, nil
-}
-
 func GetEnvironmentByBranch(promotionStrategy promoterv1alpha1.PromotionStrategy, branch string) (int, *promoterv1alpha1.Environment) {
 	for i, environment := range promotionStrategy.Spec.Environments {
 		if environment.Branch == branch {
@@ -199,19 +165,6 @@ func GetEnvironmentByBranch(promotionStrategy promoterv1alpha1.PromotionStrategy
 		}
 	}
 	return -1, nil
-}
-
-func UpsertEnvironmentStatus(slice []promoterv1alpha1.EnvironmentStatus, i promoterv1alpha1.EnvironmentStatus) []promoterv1alpha1.EnvironmentStatus {
-	if len(slice) == 0 {
-		slice = append(slice, i)
-		return slice
-	}
-	for index, ele := range slice {
-		if ele.Branch == i.Branch {
-			return slices.Replace(slice, index, index+1, i)
-		}
-	}
-	return append(slice, i)
 }
 
 func UpsertChangeTransferPolicyList(slice []promoterv1alpha1.ChangeTransferPolicy, insertList ...[]promoterv1alpha1.ChangeTransferPolicy) []promoterv1alpha1.ChangeTransferPolicy {


### PR DESCRIPTION
We currently rely on branch names to match environments to CTPs and to env statuses.

This PR switches to only relying on order, which significantly simplifies the code, but also means we have to be careful to enforce order and length consistency among slices.

The Reconcile loop starts by constructing a list of CTPs that exactly matches the length and order of ps.Spec.Environments.

Then it calculates the status, which starts by reconstructing the ps.Status.Environments list to match ps.Spec.Environments.

After that point, any code can use any of the three slices with confidence that they're all in sync.