### PR TITLE
feat: add enum validation for PR status state

### DIFF
--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -62,6 +62,7 @@ type PullRequestStatus struct {
 	// ID the id of the pull request
 	ID string `json:"id,omitempty"`
 	// State of the merge request closed/merged/open
+	// +kubebuilder:validation:Enum="";closed;merged;open
 	State PullRequestState `json:"state,omitempty"`
 	// PRCreationTime the time the PR was created
 	PRCreationTime metav1.Time `json:"prCreationTime,omitempty"`

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -105,6 +105,11 @@ spec:
                 type: string
               state:
                 description: State of the merge request closed/merged/open
+                enum:
+                - ""
+                - closed
+                - merged
+                - open
                 type: string
             required:
             - observedGeneration

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -991,6 +991,11 @@ spec:
                 type: string
               state:
                 description: State of the merge request closed/merged/open
+                enum:
+                - ""
+                - closed
+                - merged
+                - open
                 type: string
             required:
             - observedGeneration


### PR DESCRIPTION
Probably lower value than the spec field, but still nice to be explicit.