### PR TITLE
feat: add merge keys for lists

### DIFF
--- a/api/v1alpha1/changetransferpolicy_types.go
+++ b/api/v1alpha1/changetransferpolicy_types.go
@@ -46,10 +46,14 @@ type ChangeTransferPolicySpec struct {
 
 	// ActiveCommitStatuses lists the statuses to be monitored on the active branch
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ActiveCommitStatuses []CommitStatusSelector `json:"activeCommitStatuses"`
 
 	// ProposedCommitStatuses lists the statuses to be monitored on the proposed branch
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ProposedCommitStatuses []CommitStatusSelector `json:"proposedCommitStatuses"`
 }
 
@@ -68,6 +72,8 @@ type CommitBranchState struct {
 	Dry      CommitShaState `json:"dry,omitempty"`
 	Hydrated CommitShaState `json:"hydrated,omitempty"`
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	CommitStatuses []ChangeRequestPolicyCommitStatusPhase `json:"commitStatuses,omitempty"`
 }
 

--- a/api/v1alpha1/promotionstrategy_types.go
+++ b/api/v1alpha1/promotionstrategy_types.go
@@ -37,6 +37,8 @@ type PromotionStrategySpec struct {
 	// The commit statuses specified in this field apply to all environments in the promotion sequence. You can also
 	// specify commit statuses for individual environments in the `environments` field.
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ActiveCommitStatuses []CommitStatusSelector `json:"activeCommitStatuses"`
 
 	// ProposedCommitStatuses are commit statuses describing a proposed dry commit, i.e. one that is not yet running
@@ -46,10 +48,14 @@ type PromotionStrategySpec struct {
 	// The commit statuses specified in this field apply to all environments in the promotion sequence. You can also
 	// specify commit statuses for individual environments in the `environments` field.
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ProposedCommitStatuses []CommitStatusSelector `json:"proposedCommitStatuses"`
 
 	// Environments is the sequence of environments that a dry commit will be promoted through.
 	// +kubebuilder:validation:MinItems:=1
+	// +listType:=map
+	// +listMapKey=branch
 	Environments []Environment `json:"environments"`
 }
 
@@ -67,6 +73,8 @@ type Environment struct {
 	// The commit statuses specified in this field apply to this environment only. You can also specify commit statuses
 	// for all environments in the `spec.activeCommitStatuses` field.
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ActiveCommitStatuses []CommitStatusSelector `json:"activeCommitStatuses"`
 	// ProposedCommitStatuses are commit statuses describing a proposed dry commit, i.e. one that is not yet running
 	// in a live environment. If a proposed commit status is failing for a given environment, the dry commit will not
@@ -75,6 +83,8 @@ type Environment struct {
 	// The commit statuses specified in this field apply to this environment only. You can also specify commit statuses
 	// for all environments in the `spec.proposedCommitStatuses` field.
 	// +kubebuilder:validation:Optional
+	// +listType:=map
+	// +listMapKey=key
 	ProposedCommitStatuses []CommitStatusSelector `json:"proposedCommitStatuses"`
 }
 
@@ -87,12 +97,15 @@ func (e *Environment) GetAutoMerge() bool {
 }
 
 type CommitStatusSelector struct {
+	// +required
 	// +kubebuilder:validation:Pattern:=(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
 	Key string `json:"key"`
 }
 
 // PromotionStrategyStatus defines the observed state of PromotionStrategy
 type PromotionStrategyStatus struct {
+	// +listType:=map
+	// +listMapKey=branch
 	Environments []EnvironmentStatus `json:"environments"`
 }
 

--- a/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
@@ -62,6 +62,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
               autoMerge:
                 default: true
                 type: boolean
@@ -88,6 +91,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
             required:
             - activeBranch
             - gitRepositoryRef
@@ -117,6 +123,9 @@ spec:
                       - phase
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
                   dry:
                     properties:
                       commitTime:
@@ -157,6 +166,9 @@ spec:
                       - phase
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
                   dry:
                     properties:
                       commitTime:

--- a/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
@@ -62,6 +62,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
               environments:
                 description: Environments is the sequence of environments that a dry
                   commit will be promoted through.
@@ -83,6 +86,9 @@ spec:
                         - key
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - key
+                      x-kubernetes-list-type: map
                     autoMerge:
                       default: true
                       description: |-
@@ -108,11 +114,17 @@ spec:
                         - key
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - key
+                      x-kubernetes-list-type: map
                   required:
                   - branch
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - branch
+                x-kubernetes-list-type: map
               gitRepositoryRef:
                 properties:
                   name:
@@ -137,6 +149,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
             required:
             - environments
             - gitRepositoryRef
@@ -244,6 +259,9 @@ spec:
                   - proposed
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - branch
+                x-kubernetes-list-type: map
             required:
             - environments
             type: object

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -209,6 +209,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
               autoMerge:
                 default: true
                 type: boolean
@@ -235,6 +238,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
             required:
             - activeBranch
             - gitRepositoryRef
@@ -264,6 +270,9 @@ spec:
                       - phase
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
                   dry:
                     properties:
                       commitTime:
@@ -304,6 +313,9 @@ spec:
                       - phase
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - key
+                    x-kubernetes-list-type: map
                   dry:
                     properties:
                       commitTime:
@@ -694,6 +706,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
               environments:
                 description: Environments is the sequence of environments that a dry
                   commit will be promoted through.
@@ -715,6 +730,9 @@ spec:
                         - key
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - key
+                      x-kubernetes-list-type: map
                     autoMerge:
                       default: true
                       description: |-
@@ -740,11 +758,17 @@ spec:
                         - key
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - key
+                      x-kubernetes-list-type: map
                   required:
                   - branch
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - branch
+                x-kubernetes-list-type: map
               gitRepositoryRef:
                 properties:
                   name:
@@ -769,6 +793,9 @@ spec:
                   - key
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
             required:
             - environments
             - gitRepositoryRef
@@ -876,6 +903,9 @@ spec:
                   - proposed
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - branch
+                x-kubernetes-list-type: map
             required:
             - environments
             type: object


### PR DESCRIPTION
Worth discussing, not sure we need it yet. It would allow strategic merge patches of individual list items.

It would also enforce no duplicate status keys.