### PR TITLE
fix: add nil check for ArgoCD LastTransitionTime

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -295,7 +295,7 @@ func lookupArgoCDCommitStatusFromArgoCDApplication(c client.Client) func(ctx con
 		appRef := revMap[appKey]
 		rwMutex.RUnlock()
 
-		if appRef == application.Status.Sync.Revision && time.Since(application.Status.Health.LastTransitionTime.Time) >= 10*time.Second {
+		if appRef == application.Status.Sync.Revision && (application.Status.Health.LastTransitionTime == nil || time.Since(application.Status.Health.LastTransitionTime.Time) >= 10*time.Second) {
 			// No change in-app revision, and the last transition time is more than 10 seconds ago, let's not add this to the queue
 			return nil
 		}


### PR DESCRIPTION
Causes a panic if an app does not have a LastTransitionTime in its status. Assuming that if the Revision has not changed, we don't need to requeue if the LastTransitionTime is not present.

LastTransitionTime is not always set for versions before this change https://github.com/argoproj/argo-cd/pull/23018