### PR TITLE
fix: avoid invalid examples for github domain

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 type GitHub struct {
+	// Domain is the GitHub domain, such as "github.mycompany.com". If using the default GitHub domain, leave this field
+	// empty.
+	// +kubebuilder:validation:XValidation:rule=`self != "github.com"`, message="Instead of setting the domain to github.com, leave the field blank"
 	Domain string `json:"domain,omitempty"`
 	// AppID is the GitHub App ID.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/promoter.argoproj.io_clusterscmproviders.yaml
+++ b/config/crd/bases/promoter.argoproj.io_clusterscmproviders.yaml
@@ -54,7 +54,14 @@ spec:
                     format: int64
                     type: integer
                   domain:
+                    description: |-
+                      Domain is the GitHub domain, such as "github.mycompany.com". If using the default GitHub domain, leave this field
+                      empty.
                     type: string
+                    x-kubernetes-validations:
+                    - message: Instead of setting the domain to github.com, leave
+                        the field blank
+                      rule: self != "github.com"
                   installationID:
                     description: InstallationID is the GitHub App Installation ID.
                     format: int64

--- a/config/crd/bases/promoter.argoproj.io_scmproviders.yaml
+++ b/config/crd/bases/promoter.argoproj.io_scmproviders.yaml
@@ -53,7 +53,14 @@ spec:
                     format: int64
                     type: integer
                   domain:
+                    description: |-
+                      Domain is the GitHub domain, such as "github.mycompany.com". If using the default GitHub domain, leave this field
+                      empty.
                     type: string
+                    x-kubernetes-validations:
+                    - message: Instead of setting the domain to github.com, leave
+                        the field blank
+                      rule: self != "github.com"
                   installationID:
                     description: InstallationID is the GitHub App Installation ID.
                     format: int64

--- a/config/samples/promoter_v1alpha1_clusterscmprovider.yaml
+++ b/config/samples/promoter_v1alpha1_clusterscmprovider.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: clusterscmprovider-sample
 spec:
-  github:
-    domain: github.com
+  github: {}
   secretRef:
     name: my-auth

--- a/config/samples/promoter_v1alpha1_scmprovider.yaml
+++ b/config/samples/promoter_v1alpha1_scmprovider.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: scmprovider-sample
 spec:
-  github:
-    domain: github.com
+  github: {}
   secretRef:
     name: my-auth

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -395,7 +395,14 @@ spec:
                     format: int64
                     type: integer
                   domain:
+                    description: |-
+                      Domain is the GitHub domain, such as "github.mycompany.com". If using the default GitHub domain, leave this field
+                      empty.
                     type: string
+                    x-kubernetes-validations:
+                    - message: Instead of setting the domain to github.com, leave
+                        the field blank
+                      rule: self != "github.com"
                   installationID:
                     description: InstallationID is the GitHub App Installation ID.
                     format: int64
@@ -1253,7 +1260,14 @@ spec:
                     format: int64
                     type: integer
                   domain:
+                    description: |-
+                      Domain is the GitHub domain, such as "github.mycompany.com". If using the default GitHub domain, leave this field
+                      empty.
                     type: string
+                    x-kubernetes-validations:
+                    - message: Instead of setting the domain to github.com, leave
+                        the field blank
+                      rule: self != "github.com"
                   installationID:
                     description: InstallationID is the GitHub App Installation ID.
                     format: int64

--- a/docs/example-resources/ClusterScmProvider.yaml
+++ b/docs/example-resources/ClusterScmProvider.yaml
@@ -11,7 +11,7 @@ spec:
   # If you do not need to specify any sub-fields, just set the field to {}.
 
   github:
-    domain: github.com # Optional
+    domain: github.com # Optional, leave empty for default github.com
     appID: <your-app-id>
     installationID: <your-installation-id>
 

--- a/docs/example-resources/ClusterScmProvider.yaml
+++ b/docs/example-resources/ClusterScmProvider.yaml
@@ -11,7 +11,7 @@ spec:
   # If you do not need to specify any sub-fields, just set the field to {}.
 
   github:
-    domain: github.com # Optional, leave empty for default github.com
+    domain: github.example.com # Optional, leave empty for default github.com
     appID: <your-app-id>
     installationID: <your-installation-id>
 

--- a/docs/example-resources/ScmProvider.yaml
+++ b/docs/example-resources/ScmProvider.yaml
@@ -10,7 +10,7 @@ spec:
   # If you do not need to specify any sub-fields, just set the field to {}.
 
   github:
-    domain: github.com # Optional
+    domain: github.example.com # Optional, leave empty for default github.com
     appID: <your-app-id>
     installationID: <your-installation-id>
 

--- a/internal/scms/github/git_operations.go
+++ b/internal/scms/github/git_operations.go
@@ -29,7 +29,7 @@ func NewGithubGitAuthenticationProvider(scmProvider v1alpha1.GenericScmProvider,
 		panic(err)
 	}
 
-	if scmProvider.GetSpec().GitHub != nil && scmProvider.GetSpec().GitHub.Domain != "" && scmProvider.GetSpec().GitHub.Domain != "github.com" {
+	if scmProvider.GetSpec().GitHub != nil && scmProvider.GetSpec().GitHub.Domain != "" {
 		itr.BaseURL = fmt.Sprintf("https://%s/api/v3", scmProvider.GetSpec().GitHub.Domain)
 	}
 

--- a/internal/scms/github/git_operations.go
+++ b/internal/scms/github/git_operations.go
@@ -29,7 +29,7 @@ func NewGithubGitAuthenticationProvider(scmProvider v1alpha1.GenericScmProvider,
 		panic(err)
 	}
 
-	if scmProvider.GetSpec().GitHub != nil && scmProvider.GetSpec().GitHub.Domain != "" {
+	if scmProvider.GetSpec().GitHub != nil && scmProvider.GetSpec().GitHub.Domain != "" && scmProvider.GetSpec().GitHub.Domain != "github.com" {
 		itr.BaseURL = fmt.Sprintf("https://%s/api/v3", scmProvider.GetSpec().GitHub.Domain)
 	}
 


### PR DESCRIPTION
Setting github.domain to github.com causes it to use an incorrect API endpoint. Avoid using the invalid example in docs.