### PR TITLE
fix: use template if no commit message

### DIFF
--- a/internal/scms/gitlab/pullrequest.go
+++ b/internal/scms/gitlab/pullrequest.go
@@ -185,10 +185,12 @@ func (pr *PullRequest) Merge(ctx context.Context, commitMessage string, prObj *v
 	}
 
 	options := &gitlab.AcceptMergeRequestOptions{
-		MergeCommitMessage:        gitlab.Ptr(commitMessage),
 		MergeWhenPipelineSucceeds: gitlab.Ptr(false),
 		ShouldRemoveSourceBranch:  gitlab.Ptr(false),
 		Squash:                    gitlab.Ptr(false),
+	}
+	if commitMessage != "" {
+		options.MergeCommitMessage = gitlab.Ptr(commitMessage)
 	}
 
 	start := time.Now()


### PR DESCRIPTION
with github to use the configured default commit messages on the PR you send an empty string, with gitlab they want us to remove the commit message from the options struct.