### PR TITLE
fix: only log errors on non-404s for app lookup

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -265,7 +265,11 @@ func lookupArgoCDCommitStatusFromArgoCDApplication(c client.Client) func(ctx con
 	return func(ctx context.Context, argoCDApplication client.Object) []reconcile.Request {
 		var application argocd.Application
 		if err := c.Get(ctx, client.ObjectKey{Namespace: argoCDApplication.GetNamespace(), Name: argoCDApplication.GetName()}, &application, &client.GetOptions{}); err != nil {
-			log.FromContext(ctx).Error(err, "failed to get Application")
+			if k8s_errors.IsNotFound(err) {
+				log.FromContext(ctx).V(4).Info("Application not found", "application", argoCDApplication.GetName(), "app-namespace", argoCDApplication.GetNamespace())
+				return nil
+			}
+			log.FromContext(ctx).Error(err, "failed to get Application", "application", argoCDApplication.GetName(), "app-namespace", argoCDApplication.GetNamespace())
 			return nil
 		}
 


### PR DESCRIPTION
I'm seeing a lot of error logs for 404s where the app was probably just deleted before the lookup function ran.