### PR TITLE
chore(ci): update deprecated format field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,7 +72,7 @@ docker_manifests:
 
 archives:
   - id: binary
-    format: tar.gz
+    formats: [tar.gz]
     builds:
       - "gitops-promoter"
     # this name template makes the OS and Arch compatible with the results of `uname`.


### PR DESCRIPTION
From the most recent release build:

```
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```
