### PR TITLE
chore(cs): require http or https protocol on commitstatus url

### DIFF
--- a/api/v1alpha1/commitstatus_types.go
+++ b/api/v1alpha1/commitstatus_types.go
@@ -49,6 +49,7 @@ type CommitStatusSpec struct {
 
 	// Url is a URL that the user can follow to see more details about the status
 	// +kubebuilder:validation:Pattern="^https?://.*$"
+	// +kubebuilder:validation:Optional
 	Url string `json:"url"`
 }
 

--- a/api/v1alpha1/commitstatus_types.go
+++ b/api/v1alpha1/commitstatus_types.go
@@ -48,6 +48,7 @@ type CommitStatusSpec struct {
 	// (Bitbucket: INPROGRESS, STOPPED, SUCCESSFUL, FAILED)
 
 	// Url is a URL that the user can follow to see more details about the status
+	// +kubebuilder:validation:Pattern="^https?://.*$"
 	Url string `json:"url"`
 }
 

--- a/api/v1alpha1/commitstatus_types.go
+++ b/api/v1alpha1/commitstatus_types.go
@@ -50,7 +50,7 @@ type CommitStatusSpec struct {
 	// Url is a URL that the user can follow to see more details about the status
 	// +kubebuilder:validation:Pattern="^https?://.*$"
 	// +kubebuilder:validation:Optional
-	Url string `json:"url"`
+	Url string `json:"url,omitempty"`
 }
 
 // CommitStatusStatus defines the observed state of CommitStatus

--- a/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
@@ -81,7 +81,6 @@ spec:
             - name
             - phase
             - sha
-            - url
             type: object
           status:
             description: CommitStatusStatus defines the observed state of CommitStatus

--- a/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
@@ -73,6 +73,7 @@ spec:
               url:
                 description: Url is a URL that the user can follow to see more details
                   about the status
+                pattern: ^https?://.*$
                 type: string
             required:
             - description

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -942,7 +942,6 @@ spec:
             - name
             - phase
             - sha
-            - url
             type: object
           status:
             description: CommitStatusStatus defines the observed state of CommitStatus

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -934,6 +934,7 @@ spec:
               url:
                 description: Url is a URL that the user can follow to see more details
                   about the status
+                pattern: ^https?://.*$
                 type: string
             required:
             - description


### PR DESCRIPTION
Just provides a bit of defense-in-depth agains someone trying to get a `script:` url into the UI via a CommitStatus CR.