### PR TITLE
fix: initalize multi-cluster provider and use new schema for tests to match main

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -160,6 +160,7 @@ func runController(
 		Namespace:             controllerNamespace,
 		KubeconfigSecretLabel: constants.KubeconfigSecretLabel,
 		KubeconfigSecretKey:   constants.KubeconfigSecretKey,
+		Scheme:                scheme,
 	}
 
 	// Create the provider first, then the manager with the provider
@@ -287,6 +288,9 @@ func runController(
 	whr := webhookreceiver.NewWebhookReceiver(localManager)
 
 	g, ctx := errgroup.WithContext(processSignals)
+
+	// Initialize the provider controller with the manager
+	provider.SetupWithManager(ctx, mcMgr)
 
 	g.Go(func() error {
 		setupLog.Info("starting manager")

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/client-go v0.33.2
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/controller-runtime v0.21.0
-	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250705163125-05a6f78c3d0e
+	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250715171424-5a71e2a8172e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytI
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250705163125-05a6f78c3d0e h1:JggWY12tkZmpW6euTD/LWVKPnTEWvdWtkI4LB13OdY0=
-sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250705163125-05a6f78c3d0e/go.mod h1:CpBzLMLQKdm+UCchd2FiGPiDdCxM5dgCCPKuaQ6Fsv0=
+sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250715171424-5a71e2a8172e h1:XKXNjMGHFM2rXBijV81laP8KHM/30GUtvkRG1vK/05w=
+sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7.0.20250715171424-5a71e2a8172e/go.mod h1:CpBzLMLQKdm+UCchd2FiGPiDdCxM5dgCCPKuaQ6Fsv0=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -38,7 +38,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -47,8 +46,8 @@ import (
 
 	"github.com/argoproj-labs/gitops-promoter/internal/git"
 	"github.com/argoproj-labs/gitops-promoter/internal/settings"
-	"github.com/argoproj-labs/gitops-promoter/internal/types/argocd"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,7 +85,7 @@ var (
 	cancel           context.CancelFunc
 	ctx              context.Context
 	gitServerPort    string
-	scheme           = &runtime.Scheme{}
+	scheme           = utils.GetScheme()
 )
 
 func TestControllers(t *testing.T) {
@@ -108,13 +107,6 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.Level(-4))))
 	var err error
-
-	//+kubebuilder:scaffold:scheme
-	err = promoterv1alpha1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = argocd.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
 
 	By("setting up git server")
 	var errMkDir error
@@ -138,6 +130,7 @@ var _ = BeforeSuite(func() {
 		Namespace:             constants.KubeconfigSecretNamespace,
 		KubeconfigSecretLabel: constants.KubeconfigSecretLabel,
 		KubeconfigSecretKey:   constants.KubeconfigSecretKey,
+		Scheme:                scheme,
 	})
 
 	//nolint:fatcontext

--- a/internal/utils/scheme.go
+++ b/internal/utils/scheme.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	argocd "github.com/argoproj-labs/gitops-promoter/internal/types/argocd"
+)
+
+// GetScheme returns a scheme with all the necessary types added to it.
+// This is used to use same scheme in both controller and test suite.
+func GetScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(promoterv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(argocd.AddToScheme(scheme))
+
+	return scheme
+}


### PR DESCRIPTION
* Fix initilization of multi-cluster kubeconfig provider
* Update tests to use a new schema instead of appending to existing