### PR TITLE
feat: url template for commit statuses

### DIFF
--- a/api/v1alpha1/argocdcommitstatus_types.go
+++ b/api/v1alpha1/argocdcommitstatus_types.go
@@ -32,6 +32,29 @@ type ArgoCDCommitStatusSpec struct {
 	// ApplicationSelector is a label selector that selects the Argo CD applications to which this commit status applies.
 	// +kubebuilder:validation:Required
 	ApplicationSelector *metav1.LabelSelector `json:"applicationSelector,omitempty"`
+
+	// URLTemplate generates the URL to use in the CommitStatus, for example a link to the Argo CD UI. The template
+	// is a go text template and receives .Environment and .ArgoCDCommitStatus variables. A function called urlQueryEscape
+	// is available to escape url query parameters.
+	//
+	// Example:
+	//
+	// {{- $baseURL := "https://dev.argocd.local" -}}
+	// {{- if eq .Environment "environment/development" -}}
+	// {{- $baseURL = "https://dev.argocd.local" -}}
+	// {{- else if eq .Environment "environment/staging" -}}
+	// {{- $baseURL = "https://staging.argocd.local" -}}
+	// {{- else if eq .Environment "environment/production" -}}
+	// {{- $baseURL = "https://prod.argocd.local" -}}
+	// {{- end -}}
+	// {{- $labels := "" -}}
+	// {{- range $key, $value := .ArgoCDCommitStatus.Spec.ApplicationSelector.MatchLabels -}}
+	// {{- $labels = printf "%s%s=%s," $labels $key $value -}}
+	// {{- end -}}
+	// {{ printf "%s/applications?labels=%s" $baseURL (urlQueryEscape $labels) }}
+	//
+	// +kubebuilder:validation:Optional
+	URLTemplate string `json:"urlTemplate,omitempty"`
 }
 
 // ArgoCDCommitStatusStatus defines the observed state of ArgoCDCommitStatus.
@@ -68,6 +91,8 @@ type ApplicationsSelected struct {
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime"`
 	// Environment is the syncSource.targetBranch of the Argo CD application (in effect, its environment).
 	Environment string `json:"environment,omitempty"`
+	// ClusterName is the name of the cluster that the application manifest is deployed to.
+	ClusterName string `json:"clusterName"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
@@ -97,6 +97,28 @@ spec:
                 required:
                 - name
                 type: object
+              urlTemplate:
+                description: |-
+                  URLTemplate generates the URL to use in the CommitStatus, for example a link to the Argo CD UI. The template
+                  is a go text template and receives .Environment and .ArgoCDCommitStatus variables. A function called urlQueryEscape
+                  is available to escape url query parameters.
+
+                  Example:
+
+                  {{- $baseURL := "https://dev.argocd.local" -}}
+                  {{- if eq .Environment "environment/development" -}}
+                  {{- $baseURL = "https://dev.argocd.local" -}}
+                  {{- else if eq .Environment "environment/staging" -}}
+                  {{- $baseURL = "https://staging.argocd.local" -}}
+                  {{- else if eq .Environment "environment/production" -}}
+                  {{- $baseURL = "https://prod.argocd.local" -}}
+                  {{- end -}}
+                  {{- $labels := "" -}}
+                  {{- range $key, $value := .ArgoCDCommitStatus.Spec.ApplicationSelector.MatchLabels -}}
+                  {{- $labels = printf "%s%s=%s," $labels $key $value -}}
+                  {{- end -}}
+                  {{ printf "%s/applications?labels=%s" $baseURL (urlQueryEscape $labels) }}
+                type: string
             required:
             - applicationSelector
             - promotionStrategyRef
@@ -112,6 +134,10 @@ spec:
                   description: ApplicationsSelected represents the Argo CD applications
                     that are selected by the commit status.
                   properties:
+                    clusterName:
+                      description: ClusterName is the name of the cluster that the
+                        application manifest is deployed to.
+                      type: string
                     environment:
                       description: Environment is the syncSource.targetBranch of the
                         Argo CD application (in effect, its environment).
@@ -134,6 +160,7 @@ spec:
                         with.
                       type: string
                   required:
+                  - clusterName
                   - name
                   - namespace
                   - phase

--- a/docs/commit-status-controllers/argocd.md
+++ b/docs/commit-status-controllers/argocd.md
@@ -53,6 +53,21 @@ spec:
     name: webservice-tier-1
 ```
 
+### Commit Status URL Template
+To configure setting the url of a commit status, for example, a link to ArgoCD instance, set the 'urlTemplate' field. The template uses [Go templates](https://pkg.go.dev/text/template) syntax and most [sprig](https://masterminds.github.io/sprig/) functions are supported as well as an additional 'urlQueryEscape' function for escaping url query parameters. The template receives `.Environment` and `.ArgoCDCommitStatus` variables. 
+
+This example template generates an ArgoCD link in a multi-cluster setup that filters applications by label selector and environment. 
+
+```yaml
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ArgoCDCommitStatus
+metadata:
+  name: webservice-tier-1
+spec:
+  urlTemplate: |
+    {!docs/example-resources/ArgoCDCommitStatusURL.gotmpl!}
+```
+
 ## Multi-Cluster Support
 
 GitOps promoter can monitor Argo CD Applications across multiple Kubernetes clusters. This is particularly useful when managing promotions across environments that use different Argo CD instances.
@@ -62,9 +77,9 @@ GitOps promoter can monitor Argo CD Applications across multiple Kubernetes clus
 To enable multi-cluster support, you need to configure two components:
 
 #### Kubeconfig Secret
-   - Create a secret with key `kubeconfig` containing a standard `~/.kube/config` file
+   - Create a secret with key `kubeconfig` containing a standard `~/.kube/config` file as its value and label `sigs.k8s.io/multicluster-runtime-kubeconfig: "true"`
    - The secret must be created in the same namespace where gitops-promoter runs
-   - The controller uses the `current context` from the kubeconfig to determine which cluster to uses
+   - The controller uses the `current context` from the kubeconfig to determine which cluster to use
      
     !!! note
         Remove any additional clusters from the `kubeconfig` as they will be ignored

--- a/docs/example-resources/ArgoCDCommitStatusURL.gotmpl
+++ b/docs/example-resources/ArgoCDCommitStatusURL.gotmpl
@@ -1,0 +1,13 @@
+    {{- $baseURL := "https://dev.argocd.local" -}}
+    {{- if eq .Environment "environment/development" -}}
+    {{- $baseURL = "https://dev.argocd.local" -}}
+    {{- else if eq .Environment "environment/staging" -}}
+    {{- $baseURL = "https://staging.argocd.local" -}}
+    {{- else if eq .Environment "environment/production" -}}
+    {{- $baseURL = "https://prod.argocd.local" -}}
+    {{- end -}}
+    {{- $labels := "" -}}
+    {{- range $key, $value := .ArgoCDCommitStatus.Spec.ApplicationSelector.MatchLabels -}}
+    {{- $labels = printf "%s%s=%s," $labels $key $value -}}
+    {{- end -}}
+    {{- printf "%s/applications?labels=%s" $baseURL (urlQueryEscape $labels) }}

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -87,6 +87,11 @@ type ArgoCDCommitStatusReconciler struct {
 	localClient        client.Client
 }
 
+type URLTemplateData struct {
+	Environment        string
+	ArgoCDCommitStatus promoterv1alpha1.ArgoCDCommitStatus
+}
+
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=argocdcommitstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=argocdcommitstatuses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=argocdcommitstatuses/finalizers,verbs=update
@@ -125,7 +130,7 @@ func (r *ArgoCDCommitStatusReconciler) Reconcile(ctx context.Context, req mcreco
 		return ctrl.Result{}, fmt.Errorf("failed to parse label selector: %w", err)
 	}
 	// TODO: we should setup a field index and only list apps related to the currently reconciled app
-	var apps argocd.ApplicationList
+	apps := make(map[string]argocd.ApplicationList)
 
 	// list clusters so we can query argocd applications from all clusters
 	clusters := r.KubeConfigProvider.ListClusters()
@@ -146,10 +151,14 @@ func (r *ArgoCDCommitStatusReconciler) Reconcile(ctx context.Context, req mcreco
 			return ctrl.Result{}, fmt.Errorf("failed to list ArgoCDApplications: %w", err)
 		}
 
-		apps.Items = append(apps.Items, clusterArgoCDApps.Items...)
+		apps[clusterName] = clusterArgoCDApps
 	}
 
-	logger.V(4).Info("Found Applications", "appCount", len(apps.Items))
+	appCount := 0
+	for _, clusterApps := range apps {
+		appCount += len(clusterApps.Items)
+	}
+	logger.V(4).Info("Found Applications", "appCount", appCount)
 
 	promotionStrategy := promoterv1alpha1.PromotionStrategy{}
 	err = r.localClient.Get(ctx, client.ObjectKey{Namespace: argoCDCommitStatus.Namespace, Name: argoCDCommitStatus.Spec.PromotionStrategyRef.Name}, &promotionStrategy)
@@ -218,52 +227,55 @@ func (r *ArgoCDCommitStatusReconciler) getHeadShasForBranches(ctx context.Contex
 // groupArgoCDApplicationsWithPhase returns a map. The key is a branch name. The value is a list of apps configured for that target branch, along with the commit status for that one app.
 // As a side-effect, this function updates argoCDCommitStatus to represent the aggregate status
 // of all matching apps.
-func (r *ArgoCDCommitStatusReconciler) groupArgoCDApplicationsWithPhase(promotionStrategy *promoterv1alpha1.PromotionStrategy, argoCDCommitStatus *promoterv1alpha1.ArgoCDCommitStatus, apps argocd.ApplicationList) (map[string][]*aggregate, error) {
+func (r *ArgoCDCommitStatusReconciler) groupArgoCDApplicationsWithPhase(promotionStrategy *promoterv1alpha1.PromotionStrategy, argoCDCommitStatus *promoterv1alpha1.ArgoCDCommitStatus, apps map[string]argocd.ApplicationList) (map[string][]*aggregate, error) {
 	aggregates := map[string][]*aggregate{}
 	argoCDCommitStatus.Status.ApplicationsSelected = []promoterv1alpha1.ApplicationsSelected{}
 	repo := ""
 
-	for _, application := range apps.Items {
-		if application.Spec.SourceHydrator == nil {
-			return map[string][]*aggregate{}, fmt.Errorf("application %s/%s does not have a SourceHydrator configured", application.GetNamespace(), application.GetName())
-		}
+	for clusterName, clusterApps := range apps {
+		for _, application := range clusterApps.Items {
+			if application.Spec.SourceHydrator == nil {
+				return map[string][]*aggregate{}, fmt.Errorf("application %s/%s does not have a SourceHydrator configured", application.GetNamespace(), application.GetName())
+			}
 
-		// Check that all the applications are configured with the same repo
-		if repo == "" {
-			repo = application.Spec.SourceHydrator.DrySource.RepoURL
-		} else if repo != application.Spec.SourceHydrator.DrySource.RepoURL {
-			return map[string][]*aggregate{}, errors.New("all applications must have the same repo configured")
-		}
+			// Check that all the applications are configured with the same repo
+			if repo == "" {
+				repo = application.Spec.SourceHydrator.DrySource.RepoURL
+			} else if repo != application.Spec.SourceHydrator.DrySource.RepoURL {
+				return map[string][]*aggregate{}, errors.New("all applications must have the same repo configured")
+			}
 
-		aggregateItem := &aggregate{
-			application: &application,
-		}
+			aggregateItem := &aggregate{
+				application: &application,
+			}
 
-		phase := promoterv1alpha1.CommitPhasePending
-		if application.Status.Health.Status == argocd.HealthStatusHealthy && application.Status.Sync.Status == argocd.SyncStatusCodeSynced {
-			phase = promoterv1alpha1.CommitPhaseSuccess
-		} else if application.Status.Health.Status == argocd.HealthStatusDegraded {
-			phase = promoterv1alpha1.CommitPhaseFailure
-		}
+			phase := promoterv1alpha1.CommitPhasePending
+			if application.Status.Health.Status == argocd.HealthStatusHealthy && application.Status.Sync.Status == argocd.SyncStatusCodeSynced {
+				phase = promoterv1alpha1.CommitPhaseSuccess
+			} else if application.Status.Health.Status == argocd.HealthStatusDegraded {
+				phase = promoterv1alpha1.CommitPhaseFailure
+			}
 
-		// This is an in memory version of the desired CommitStatus for a single application, this will be used to figure out
-		// the aggregated phase of all applications for a particular environment
-		aggregateItem.commitStatus = &promoterv1alpha1.CommitStatus{
-			Spec: promoterv1alpha1.CommitStatusSpec{
-				Sha:   application.Status.Sync.Revision,
-				Phase: phase,
-			},
-		}
-		argoCDCommitStatus.Status.ApplicationsSelected = append(argoCDCommitStatus.Status.ApplicationsSelected, promoterv1alpha1.ApplicationsSelected{
-			Namespace:          application.GetNamespace(),
-			Name:               application.GetName(),
-			Phase:              phase,
-			Sha:                application.Status.Sync.Revision,
-			LastTransitionTime: application.Status.Health.LastTransitionTime,
-			Environment:        application.Spec.SourceHydrator.SyncSource.TargetBranch,
-		})
+			// This is an in memory version of the desired CommitStatus for a single application, this will be used to figure out
+			// the aggregated phase of all applications for a particular environment
+			aggregateItem.commitStatus = &promoterv1alpha1.CommitStatus{
+				Spec: promoterv1alpha1.CommitStatusSpec{
+					Sha:   application.Status.Sync.Revision,
+					Phase: phase,
+				},
+			}
+			argoCDCommitStatus.Status.ApplicationsSelected = append(argoCDCommitStatus.Status.ApplicationsSelected, promoterv1alpha1.ApplicationsSelected{
+				Namespace:          application.GetNamespace(),
+				Name:               application.GetName(),
+				Phase:              phase,
+				Sha:                application.Status.Sync.Revision,
+				LastTransitionTime: application.Status.Health.LastTransitionTime,
+				Environment:        application.Spec.SourceHydrator.SyncSource.TargetBranch,
+				ClusterName:        clusterName,
+			})
 
-		aggregates[application.Spec.SourceHydrator.SyncSource.TargetBranch] = append(aggregates[application.Spec.SourceHydrator.SyncSource.TargetBranch], aggregateItem)
+			aggregates[application.Spec.SourceHydrator.SyncSource.TargetBranch] = append(aggregates[application.Spec.SourceHydrator.SyncSource.TargetBranch], aggregateItem)
+		}
 	}
 
 	sortApplicationsSelected(promotionStrategy, argoCDCommitStatus)
@@ -460,8 +472,22 @@ func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.
 			Name:                commitStatusName,
 			Description:         desc,
 			Phase:               phase,
-			// Url:                 "https://example.com",
 		},
+	}
+
+	// Render URL from template if it exists, but don't block commit status update if it fails
+	if argoCDCommitStatus.Spec.URLTemplate != "" {
+		data := URLTemplateData{
+			Environment:        targetBranch,
+			ArgoCDCommitStatus: argoCDCommitStatus,
+		}
+		url, err := utils.RenderStringTemplate(argoCDCommitStatus.Spec.URLTemplate, data)
+		if err == nil {
+			logger.Info("Rendered URL template", "url", url, "environment", targetBranch, "commitStatus", desiredCommitStatus.Name, "namespace", desiredCommitStatus.Namespace)
+			desiredCommitStatus.Spec.Url = url
+		} else {
+			logger.Error(err, "failed to render URL template", "argoCDCommitStatus", argoCDCommitStatus.Name, "namespace", argoCDCommitStatus.Namespace)
+		}
 	}
 
 	currentCommitStatus := promoterv1alpha1.CommitStatus{}

--- a/internal/types/constants/configurations.go
+++ b/internal/types/constants/configurations.go
@@ -10,7 +10,9 @@ const (
 	// KubeconfigSecretNamespace is the namespace where the kubeconfig secret is stored.
 	KubeconfigSecretNamespace = "default"
 	// KubeconfigSecretLabel is the label used to identify the kubeconfig secret.
-	KubeconfigSecretLabel = "kubeconfig"
+	KubeconfigSecretLabel = "sigs.k8s.io/multicluster-runtime-kubeconfig"
 	// KubeconfigSecretKey is the key in the kubeconfig secret that contains the kubeconfig data.
 	KubeconfigSecretKey = "kubeconfig"
+	// ArgoCDURLSecretKey is the key in the KubeConfig secret that contains the base URL.
+	ArgoCDURLSecretKey = "argocdUrl"
 )

--- a/internal/utils/template.go
+++ b/internal/utils/template.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"text/template"
 
 	sprig "github.com/go-task/slim-sprig/v3"
@@ -14,6 +15,7 @@ func init() {
 	delete(sanitizedSprigFuncMap, "env")
 	delete(sanitizedSprigFuncMap, "expandenv")
 	delete(sanitizedSprigFuncMap, "getHostByName")
+	sanitizedSprigFuncMap["urlQueryEscape"] = url.QueryEscape
 }
 
 // RenderStringTemplate renders a string template with the provided data.


### PR DESCRIPTION
Add `urlTemplate` field to ArgoCDCommitStatus CRD.

URLTemplate generates the URL to use in the CommitStatus, for example a link to the Argo CD UI. The template
is a go text template and receives .Environment and .ArgoCDCommitStatus variables. A function called urlQueryEscape
is available to escape url query parameters.

Example:
```go
{{- $baseURL := "https://dev.argocd.local" -}}
{{- if eq .Environment "environment/development" -}}
{{- $baseURL = "https://dev.argocd.local" -}}
{{- else if eq .Environment "environment/staging" -}}
{{- $baseURL = "https://staging.argocd.local" -}}
{{- else if eq .Environment "environment/production" -}}
{{- $baseURL = "https://prod.argocd.local" -}}
{{- end -}}
{{- $labels := "" -}}
{{- range $key, $value := .ArgoCDCommitStatus.Spec.ApplicationSelector.MatchLabels -}}
{{- $labels = printf "%s%s=%s," $labels $key $value -}}
{{- end -}}
{{ printf "%s/applications?labels=%s" $baseURL (urlQueryEscape $labels) }}
```

fix: multi-cluster kubeconfig provider key and docs

