### PR TITLE
wip: feat: walk hydrated manfiest for commit messages that matter

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -103,7 +103,7 @@ type CommitMetadata struct {
 	// Date is the date of the commit, formatted as by `git show -s --format=%aI`.
 	Date *metav1.Time `json:"date,omitempty"`
 	// Subject is the subject line of the commit message, i.e. `git show --format=%s`.
-	Subject string `json:"message,omitempty"`
+	Subject string `json:"subject,omitempty"`
 	// Body is the body of the commit message, excluding the subject line, i.e. `git show --format=%b`.
 	Body string `json:"body,omitempty"`
 	// Sha is the commit hash.

--- a/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
@@ -178,16 +178,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -242,16 +242,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -399,16 +399,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -463,16 +463,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object

--- a/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
@@ -315,16 +315,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -382,16 +382,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -507,16 +507,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -574,16 +574,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -447,16 +447,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -511,16 +511,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -668,16 +668,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -732,16 +732,16 @@ spec:
                                     as by `git show -s --format=%aI`.
                                   format: date-time
                                   type: string
-                                message:
-                                  description: Subject is the subject line of the
-                                    commit message, i.e. `git show --format=%s`.
-                                  type: string
                                 repoURL:
                                   description: RepoURL is the URL of the repository
                                     where the commit is located.
                                   type: string
                                 sha:
                                   description: Sha is the commit hash.
+                                  type: string
+                                subject:
+                                  description: Subject is the subject line of the
+                                    commit message, i.e. `git show --format=%s`.
                                   type: string
                               type: object
                           type: object
@@ -1637,16 +1637,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -1704,16 +1704,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -1829,16 +1829,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object
@@ -1896,16 +1896,16 @@ spec:
                                           formatted as by `git show -s --format=%aI`.
                                         format: date-time
                                         type: string
-                                      message:
-                                        description: Subject is the subject line of
-                                          the commit message, i.e. `git show --format=%s`.
-                                        type: string
                                       repoURL:
                                         description: RepoURL is the URL of the repository
                                           where the commit is located.
                                         type: string
                                       sha:
                                         description: Sha is the commit hash.
+                                        type: string
+                                      subject:
+                                        description: Subject is the subject line of
+                                          the commit message, i.e. `git show --format=%s`.
                                         type: string
                                     type: object
                                 type: object

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	gitlab.com/gitlab-org/api/client-go v0.137.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/net v0.41.0
 	golang.org/x/sync v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.3
@@ -99,7 +100,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.18.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
-	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -278,13 +278,13 @@ func (e *TooManyMatchingShaError) Error() string {
 }
 
 func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, gitOperations *git.EnvironmentOperations, activeHydratedSha, proposedHydratedSha string) error {
-	activeCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, activeHydratedSha)
+	activeCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ActiveBranch)
 	if err != nil {
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}
 	ctp.Status.Active.Dry = activeCommitMetadata
 
-	proposedCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, proposedHydratedSha)
+	proposedCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ProposedBranch)
 	if err != nil {
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -287,6 +287,7 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}
 	ctp.Status.Active.Dry = activeCommitMetadata
+	ctp.Status.Active.Dry = latestActiveCommitMetadata // Remove to test new feature
 
 	latestProposedCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, proposedHydratedSha)
 	if err != nil {
@@ -297,6 +298,7 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}
 	ctp.Status.Proposed.Dry = proposedCommitMetadata
+	ctp.Status.Proposed.Dry = latestProposedCommitMetadata // Remove to test new feature
 
 	activeCommitMetadata, err = gitOperations.GetShaMetadataFromGit(ctx, activeHydratedSha)
 	if err != nil {

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -288,9 +288,9 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 	}
 	ctp.Status.Active.Dry = activeCommitMetadata
 
-	latestProposedCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, activeHydratedSha)
+	latestProposedCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, proposedHydratedSha)
 	if err != nil {
-		return fmt.Errorf("failed to get commit metadata for active SHA %q: %w", activeHydratedSha, err)
+		return fmt.Errorf("failed to get commit metadata for proposed SHA %q: %w", proposedHydratedSha, err)
 	}
 	proposedCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ProposedBranch, latestProposedCommitMetadata.Sha)
 	if err != nil {

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -278,13 +278,21 @@ func (e *TooManyMatchingShaError) Error() string {
 }
 
 func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, gitOperations *git.EnvironmentOperations, activeHydratedSha, proposedHydratedSha string) error {
-	activeCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ActiveBranch)
+	latestActiveCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, activeHydratedSha)
+	if err != nil {
+		return fmt.Errorf("failed to get commit metadata for active SHA %q: %w", activeHydratedSha, err)
+	}
+	activeCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ActiveBranch, latestActiveCommitMetadata.Sha)
 	if err != nil {
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}
 	ctp.Status.Active.Dry = activeCommitMetadata
 
-	proposedCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ProposedBranch)
+	latestProposedCommitMetadata, err := gitOperations.GetShaMetadataFromFile(ctx, activeHydratedSha)
+	if err != nil {
+		return fmt.Errorf("failed to get commit metadata for active SHA %q: %w", activeHydratedSha, err)
+	}
+	proposedCommitMetadata, err := gitOperations.GetShaMetadataFromFileFiltered(ctx, ctp.Spec.ProposedBranch, latestProposedCommitMetadata.Sha)
 	if err != nil {
 		return fmt.Errorf("failed to get commit metadata for hydrated SHA %q: %w", activeHydratedSha, err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -234,8 +234,8 @@ func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Conte
 		return v1alpha1.CommitShaState{}, fmt.Errorf("no repo path found for repo %q", g.gitRepo.Name)
 	}
 
-	// List all commits on the branch (newest first)
-	out, stderr, err := g.runCmd(ctx, gitPath, "rev-list", "--max-count=25", "origin/"+branch)
+	// List all commits on the branch (newest first) we can limit with "--max-count=25"
+	out, stderr, err := g.runCmd(ctx, gitPath, "rev-list", "origin/"+branch)
 	if err != nil {
 		return v1alpha1.CommitShaState{}, fmt.Errorf("could not list commits: %w\n%s", err, stderr)
 	}
@@ -257,6 +257,10 @@ func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Conte
 		if foundSha != "" {
 			break
 		}
+	}
+
+	if foundSha == "" {
+		return v1alpha1.CommitShaState{}, fmt.Errorf("no commit with yaml file changes found on branch %q", branch)
 	}
 
 	metadataFileStdout, stderr, err := g.runCmd(ctx, gitPath, "show", foundSha+":hydrator.metadata")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -250,7 +250,7 @@ func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Conte
 		}
 		logger.V(4).Info("Diff walking commits", "diff", stdout)
 
-		if ContainsYamlFileSuffix(ctx, strings.Split(stdout, "\n")) {
+		if containsYamlFileSuffix(ctx, strings.Split(stdout, "\n")) {
 			logger.V(4).Info("Found commit with yaml file changes", "sha", sha)
 			foundSha = sha
 		}
@@ -498,7 +498,7 @@ func (g *EnvironmentOperations) IsPullRequestRequired(ctx context.Context, envir
 	}
 	logger.V(4).Info("Got diff", "diff", stdout)
 
-	return ContainsYamlFileSuffix(ctx, strings.Split(stdout, "\n")), nil
+	return containsYamlFileSuffix(ctx, strings.Split(stdout, "\n")), nil
 }
 
 // LsRemote returns a map of branch names to SHAs for the given branches using git ls-remote.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -226,7 +226,7 @@ func (g *EnvironmentOperations) GetShaMetadataFromFile(ctx context.Context, sha 
 }
 
 // GetShaMetadataFromFileFiltered retrieves commit metadata from the hydrator.metadata file for a given SHA.
-func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Context, branch string) (v1alpha1.CommitShaState, error) {
+func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Context, branch string, topDrySha string) (v1alpha1.CommitShaState, error) {
 	logger := log.FromContext(ctx)
 
 	gitPath := gitpaths.Get(g.gap.GetGitHttpsRepoUrl(*g.gitRepo) + g.activeBranch)
@@ -277,7 +277,7 @@ func (g *EnvironmentOperations) GetShaMetadataFromFileFiltered(ctx context.Conte
 	}
 
 	commitState := v1alpha1.CommitShaState{
-		Sha:        hydratorFile.DrySha,
+		Sha:        topDrySha,
 		CommitTime: hydratorFile.Date,
 		RepoURL:    hydratorFile.RepoURL,
 		Author:     hydratorFile.Author,

--- a/internal/git/utils.go
+++ b/internal/git/utils.go
@@ -1,12 +1,13 @@
 package git
 
 import (
+	"strings"
+
 	"github.com/go-logr/logr"
 	"golang.org/x/net/context"
-	"strings"
 )
 
-func ContainsYamlFileSuffix(ctx context.Context, files []string) bool {
+func containsYamlFileSuffix(ctx context.Context, files []string) bool {
 	logger := logr.FromContextOrDiscard(ctx)
 	for _, file := range files {
 		if strings.HasSuffix(file, ".yaml") || strings.HasSuffix(file, ".yml") {

--- a/internal/git/utils.go
+++ b/internal/git/utils.go
@@ -1,0 +1,18 @@
+package git
+
+import (
+	"github.com/go-logr/logr"
+	"golang.org/x/net/context"
+	"strings"
+)
+
+func ContainsYamlFileSuffix(ctx context.Context, files []string) bool {
+	logger := logr.FromContextOrDiscard(ctx)
+	for _, file := range files {
+		if strings.HasSuffix(file, ".yaml") || strings.HasSuffix(file, ".yml") {
+			logger.V(4).Info("YAML file changed", "file", file)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/git/utils.go
+++ b/internal/git/utils.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+// containsYamlFileSuffix Check if the provided list of files contains any file with a .yaml or .yml suffix.
+// TODO: This is temporary check we should add some path globbing support to the specs
 func containsYamlFileSuffix(ctx context.Context, files []string) bool {
 	logger := logr.FromContextOrDiscard(ctx)
 	for _, file := range files {


### PR DESCRIPTION
When populating commit messages in the CTP we should only display messages that would have resulted in a a PullRequest being opened which today is controled by did hydration generate a .yam|.yml file.

This means that in a mono repo setup commit messages will be correct for each environment and we will not just always show the HEAD dry commit message but the message that has the state of the actually environment.  