### PR TITLE
fix: preserve errors when they can't be written to conditions

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -281,7 +281,7 @@ func HandleReconciliationResult(
 		recorder.Eventf(obj, "Warning", "ReconcileError", "Reconciliation failed: %v", *err)
 	}
 	if updateErr := updateReadyCondition(ctx, obj, client, conditions, metav1.ConditionFalse, string(promoterConditions.ReconciliationError), fmt.Sprintf("Reconciliation failed: %s", *err)); updateErr != nil {
-		*err = fmt.Errorf("failed to update status with error condition: %w", updateErr)
+		*err = fmt.Errorf("failed to update status with error condition with error %q: %w", *err, updateErr)
 	}
 }
 


### PR DESCRIPTION
I noticed in test error logs that if there was an error writing the ready condition, the upstream error is lost. This change embeds the upstream error message so it's passed along to controller-runtime for logging.