### PR TITLE
feat: CRD Viewer feature

### DIFF
--- a/ui/components-lib/src/components/Card.scss
+++ b/ui/components-lib/src/components/Card.scss
@@ -386,3 +386,25 @@
 .env-cards-wrapper.horizontal-layout {
   @include layouts.horizontal-layout;
 }
+
+
+// Tooltip
+.tooltip-container {
+  position: absolute;
+  top: 100%;
+  z-index: 1000;
+  margin-top: -20px;
+}
+
+.github-tooltip {
+  background: #24292e;
+  color: white;
+  padding: 6px 8px;
+  font-size: 12px;
+  max-width: 250px;
+}
+
+.tooltip-subject {
+  font-weight: 600;
+  margin-bottom: 4px;
+}

--- a/ui/dashboard/src/components/LiveManifestView.scss
+++ b/ui/dashboard/src/components/LiveManifestView.scss
@@ -4,12 +4,14 @@
   background: white;
   border-radius: 8px;
   display: flex;
+  overflow: auto;
 }
 
 .strategy-json-editor-content {
   display: flex;
   flex: 1;
   padding: 20px;
+  min-width: 0;
 }
 
 .line-numbers {
@@ -21,6 +23,7 @@
   font-family: Menlo, Monaco, monospace;
   font-size: 12px;
   line-height: 18px;
+  flex-shrink: 0;
 }
 
 .line-number {
@@ -33,13 +36,13 @@
   font-family: Menlo, Monaco, monospace;
   font-size: 12px;
   line-height: 18px;
-  white-space: pre-wrap;
-  word-break: break-word;
-  overflow-wrap: break-word;
+  overflow-x: auto;
+  white-space: pre;
+  min-width: 0;
 }
 
 .json-line {
-  height: auto;
+  height: 18px;
 }
 
 .json-key {

--- a/ui/dashboard/src/components/LiveManifestView.scss
+++ b/ui/dashboard/src/components/LiveManifestView.scss
@@ -1,0 +1,58 @@
+.strategy-json-editor {
+  margin: 20px;
+  height: 100%;
+  background: white;
+  border-radius: 8px;
+  display: flex;
+}
+
+.strategy-json-editor-content {
+  display: flex;
+  flex: 1;
+  padding: 20px;
+}
+
+.line-numbers {
+  color: #237893;
+  border-right: 1px solid #e0e0e0;
+  padding-right: 10px;
+  text-align: right;
+  min-width: 50px;
+  font-family: Menlo, Monaco, monospace;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.line-number {
+  height: 18px;
+}
+
+.json-content {
+  flex: 1;
+  padding-left: 10px;
+  font-family: Menlo, Monaco, monospace;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: pre;
+}
+
+.json-line {
+  height: 18px;
+}
+
+.json-key {
+  color: #008080;
+}
+
+.json-value {
+  color: #0451a5;
+}
+
+.strategy-json-editor-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  font-size: 16px;
+  color: #333;
+} 

--- a/ui/dashboard/src/components/LiveManifestView.scss
+++ b/ui/dashboard/src/components/LiveManifestView.scss
@@ -33,11 +33,13 @@
   font-family: Menlo, Monaco, monospace;
   font-size: 12px;
   line-height: 18px;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .json-line {
-  height: 18px;
+  height: auto;
 }
 
 .json-key {

--- a/ui/dashboard/src/components/LiveManifestView.tsx
+++ b/ui/dashboard/src/components/LiveManifestView.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import type { PromotionStrategy } from '@shared/utils/PSData';
+import './LiveManifestView.scss';
+
+interface LiveManifestViewProps {
+  strategy: PromotionStrategy;
+}
+
+export const LiveManifestView: React.FC<LiveManifestViewProps> = ({ strategy }) => {
+  const [lines, setLines] = useState<string[]>([]);
+
+
+  // Convert to JSON
+  useEffect(() => {
+    if (strategy) {
+      const formatted = JSON.stringify(strategy, null, 2);
+      setLines(formatted.split('\n'));
+    }
+  }, [strategy]);
+
+
+  // Not Found
+  if (!strategy) {
+    return <div className="strategy-json-editor-empty">No strategy data available</div>;
+  }
+
+  return (
+    <div className="strategy-json-editor">
+      <div className="strategy-json-editor-content">
+        <div className="line-numbers">
+          {lines.map((_, index) => (
+            <div key={index} className="line-number">{index + 1}</div>
+          ))}
+        </div>
+        <div className="json-content">
+          {lines.map((line, index) => {
+
+
+
+            // Split key and value in CRDs
+            const parts = line.split(/^(\s*)"([^"]+)":\s/);
+            if (parts.length > 2) {
+              return (
+                <div key={index} className="json-line">
+                  {parts[1]}<span className="json-key">"{parts[2]}"</span>:
+                  <span className="json-value">{parts[3]}</span>
+                </div>
+              );
+            }
+            
+            return <div key={index} className="json-line">{line}</div>;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}; 

--- a/ui/dashboard/src/pages/PromotionStrategyPage.scss
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.scss
@@ -35,7 +35,7 @@
   background: transparent;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
   color: #666;
 }
 

--- a/ui/dashboard/src/pages/PromotionStrategyPage.scss
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.scss
@@ -1,0 +1,50 @@
+.strategy-page-header {
+  display: flex;
+  align-items: center;
+  background: white;
+  padding: 5px 0;
+  position: relative;
+}
+
+.strategy-page-header-left {
+  width: 60px;
+}
+
+.strategy-page-header-center {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.strategy-page-header-right {
+  margin-left: auto;
+  margin-right: 16px;
+}
+
+.strategy-page-tabs {
+  display: flex;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 6px;
+  padding: 4px;
+}
+
+.strategy-page-tab {
+  padding: 6px 12px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #666;
+}
+
+.strategy-page-tab:hover {
+  background: rgba(0, 0, 0, 0.1);
+  color: #333;
+}
+
+.strategy-page-tab.active {
+  background: #6d7f8b;
+  color: white;
+} 

--- a/ui/dashboard/src/pages/PromotionStrategyPage.tsx
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.tsx
@@ -5,7 +5,7 @@ import { viewStore } from '../stores/ViewStore';
 import { PromotionStrategyStore } from '../stores/PromotionStrategyStore';
 import BackButton from '../components/BackButton';
 import HeaderBar from '@lib/components/HeaderBar';
-import PromotionStrategyDetailsView from '@lib/components/PromotionStrategyDetailsView';
+import PromotionStrategyDetailsView from '../components/PromotionStrategyDetailsView';
 import { LiveManifestView } from '../components/LiveManifestView';
 import type { PromotionStrategy } from '@shared/utils/PSData';
 import './PromotionStrategyPage.scss';

--- a/ui/dashboard/src/pages/PromotionStrategyPage.tsx
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.tsx
@@ -99,7 +99,7 @@ const PromotionStrategyPage: React.FC<PromotionStrategyPageProps> = ({ namespace
               className={`strategy-page-tab ${currentView === 'json' ? 'active' : ''}`}
               onClick={() => setView('json')}
             >
-              Live Manifest
+              Live<br />Manifest
             </button>
           </div>
         </div>

--- a/ui/dashboard/src/pages/PromotionStrategyPage.tsx
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { namespaceStore } from '../stores/NamespaceStore'
+import { viewStore } from '../stores/ViewStore';
 import { PromotionStrategyStore } from '../stores/PromotionStrategyStore';
 import BackButton from '../components/BackButton';
 import HeaderBar from '@lib/components/HeaderBar';
-import PromotionStrategyDetailsView from '../components/PromotionStrategyDetailsView';
+import PromotionStrategyDetailsView from '@lib/components/PromotionStrategyDetailsView';
+import { LiveManifestView } from '../components/LiveManifestView';
 import type { PromotionStrategy } from '@shared/utils/PSData';
+import './PromotionStrategyPage.scss';
 
 interface NamespaceStore {
   namespace: string;
@@ -26,6 +29,7 @@ const PromotionStrategyPage: React.FC<PromotionStrategyPageProps> = ({ namespace
 
   const currentNamespace = namespaceStore((s: NamespaceStore) => s.namespace);
   const setNamespace = namespaceStore((s: NamespaceStore) => s.setNamespace);
+  const { currentView, setView } = viewStore();
 
   const { items, fetchItems, subscribe, unsubscribe } = PromotionStrategyStore();
 
@@ -39,15 +43,15 @@ const PromotionStrategyPage: React.FC<PromotionStrategyPageProps> = ({ namespace
     if (namespace !== currentNamespace) {
       setNamespace(namespace);
     }
-    // Only fetch if items are empty or selectedStrategy is not found
-    if (!items || items.length === 0 || !selectedStrategy) {
+
+    if (!items.length || !selectedStrategy) {
       fetchItems(namespace);
     }
+    
     subscribe(namespace);
     return () => unsubscribe();
   }, [namespace, currentNamespace, setNamespace, fetchItems, subscribe, unsubscribe, items, selectedStrategy]);
 
-  //Navigation:
   const navigate = useNavigate();
 
   const handleBack = () => {
@@ -55,28 +59,58 @@ const PromotionStrategyPage: React.FC<PromotionStrategyPageProps> = ({ namespace
     navigate('/promotion-strategies');
   };
 
-  
+
+  // Loading State
+  if (items.length === 0) {
+    return <div style={{ textAlign: 'center', marginTop: '20px' }}>Loading strategies...</div>;
+  }
+
+  // Not found state
+  if (!selectedStrategy) {
+    return <div style={{ textAlign: 'center', marginTop: '20px' }}>No strategy found for {strategyName}</div>;
+  }
+
   return (
     <>
-      <div style={{ display: 'flex', alignItems: 'center', position: 'relative', width: '100%', backgroundColor: 'white'}}>
-        <div style={{ flex: '0 0 auto' }}>
+      <div className="strategy-page-header">
+
+
+        <div className="strategy-page-header-left">
           <BackButton onClick={handleBack} />
         </div>
-        <div style={{ flex: 1, display: 'flex', justifyContent: 'center', marginRight: '100px'}}>
+
+
+        <div className="strategy-page-header-center">
           <HeaderBar name={strategyName || ""} />
+        </div>
+
+        
+        <div className="strategy-page-header-right">
+          <div className="strategy-page-tabs">
+            <button
+              className={`strategy-page-tab ${currentView === 'cards' ? 'active' : ''}`}
+              onClick={() => setView('cards')}
+            >
+              Overview
+            </button>
+
+            
+            <button
+              className={`strategy-page-tab ${currentView === 'json' ? 'active' : ''}`}
+              onClick={() => setView('json')}
+            >
+              Live Manifest
+            </button>
+          </div>
         </div>
       </div>
 
-      {items.length === 0 ? (
-        <div style={{ textAlign: 'center', marginTop: '20px' }}>Loading strategies...</div>
-      ) : selectedStrategy ? (
-        <div style = {{marginTop: '40px'}}>
-        <PromotionStrategyDetailsView
-          strategy={selectedStrategy}
-        />
+      {currentView === 'cards' ? (
+        <div style={{ marginTop: '40px' }}>
+          <PromotionStrategyDetailsView strategy={selectedStrategy} />
         </div>
       ) : (
-        <div style={{ textAlign: 'center', marginTop: '20px' }}>No strategy found for {strategyName}</div>
+        <LiveManifestView strategy={selectedStrategy} />
       )}
     </>
   );

--- a/ui/dashboard/src/stores/ViewStore.ts
+++ b/ui/dashboard/src/stores/ViewStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type ViewMode = 'cards' | 'json';
+
+interface ViewStore {
+  currentView: ViewMode;
+  setView: (view: ViewMode) => void;
+}
+
+export const viewStore = create<ViewStore>((set) => ({
+  currentView: 'cards',
+  setView: (view) => set({ currentView: view }),
+})); 

--- a/ui/extension/statusPanel.tsx
+++ b/ui/extension/statusPanel.tsx
@@ -180,9 +180,11 @@ const StatusPanelComponent: React.FC<{ application: Application }> = ({ applicat
         </div>
       )}
       
-      <button onClick={navigateToPromotionStrategyTab} className="argo-button argo-button--base">
-        View Details
-      </button>
+      {!loading && !error && total > 0 && (
+        <button onClick={navigateToPromotionStrategyTab} className="argo-button argo-button--base">
+          View Details
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Summary:
Added a tab to view the see the live manifest of promotion strategies on the standalone dashboard

### Changes:
* New “Live Manifest” tab
* Shows full CRD data 
* Mimic ArgoCD styling
* Read-only
* Added conditional statement for the status panel buttons to appear when promotion strategies exist
* Added Styling on the toolkit