### PR TITLE
fix: remove status  schema validation

### DIFF
--- a/api/v1alpha1/commitstatus_types.go
+++ b/api/v1alpha1/commitstatus_types.go
@@ -59,9 +59,12 @@ type CommitStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Id is the unique identifier of the commit status, set by the SCM
-	Id    string            `json:"id"`
-	Sha   string            `json:"sha"`
-	Phase CommitStatusPhase `json:"phase"`
+	Id  string `json:"id"`
+	Sha string `json:"sha"`
+	// +kubebuilder:default:=pending
+	// +kubebuilder:validation:Enum:=pending;success;failure;
+	// +kubebuilder:validation:Optional
+	Phase CommitStatusPhase `json:"phase,omitempty"`
 
 	// Conditions Represents the observations of the current state.
 	// +patchMergeKey=type

--- a/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
@@ -151,13 +151,17 @@ spec:
                   by the SCM
                 type: string
               phase:
+                default: pending
                 description: CommitStatusPhase represents the phase of a commit status.
+                enum:
+                - pending
+                - success
+                - failure
                 type: string
               sha:
                 type: string
             required:
             - id
-            - phase
             - sha
             type: object
         type: object

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1060,13 +1060,17 @@ spec:
                   by the SCM
                 type: string
               phase:
+                default: pending
                 description: CommitStatusPhase represents the phase of a commit status.
+                enum:
+                - pending
+                - success
+                - failure
                 type: string
               sha:
                 type: string
             required:
             - id
-            - phase
             - sha
             type: object
         type: object


### PR DESCRIPTION
I noticed a bunch of failures in tests because when we call the HandleReconciliationResult function, we get an empty status.phase also if we set the phase to pending there it breaks a lot of tests.

Doing something like
```
	var cs promoterv1alpha1.CommitStatus
	defer func() {
		cs.Status.Phase = promoterv1alpha1.CommitPhasePending // This has schema validation, so it should never be empty not sure status gets defaults at least during tests.
		utils.HandleReconciliationResult(ctx, startTime, &cs, r.Client, r.Recorder, &err)
	}()
``` 