### PR TITLE
fix(ui): hide unpopulated commit info

### DIFF
--- a/ui/components-lib/src/components/Card.tsx
+++ b/ui/components-lib/src/components/Card.tsx
@@ -3,7 +3,7 @@ import { StatusType } from './StatusIcon';
 import React, { useState, useMemo } from 'react';
 import CommitInfo from './CommitInfo';
 import HistoryNavigation from './HistoryNavigation';
-import { enrichFromEnvironments } from '@shared/utils/PSData';
+import {EnrichedEnvDetails, enrichFromEnvironments} from '@shared/utils/PSData';
 import type { Environment } from '@shared/types/promotion';
 import './Card.scss';
 
@@ -43,7 +43,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
   return (
     <div className="env-cards-container">
       <div className={`env-cards-wrapper ${isHorizontalLayout ? 'horizontal-layout' : ''}`}>
-        {enrichedEnvs.map((env: any) => {
+        {enrichedEnvs.map((env: EnrichedEnvDetails) => {
           const branch = env.branch;
           const proposedStatus = env.promotionStatus;
           const inHistoryMode = isInHistoryMode(branch);
@@ -60,28 +60,12 @@ const Card: React.FC<CardProps> = ({ environments }) => {
             date: env.activeCommitDate
           };
 
-          const activeCodeCommit = {
-            sha: env.activeReferenceSha,
-            author: env.activeReferenceCommitAuthor,
-            subject: env.activeReferenceCommitSubject,
-            body: env.activeReferenceCommitBody || '',
-            date: env.activeReferenceCommitDate
-          };
-
           const proposedDeploymentCommit = {
             sha: env.proposedSha,
             author: env.proposedDryCommitAuthor,
             subject: env.proposedDryCommitSubject,
             body: env.proposedDryCommitBody,
             date: env.proposedDryCommitDate
-          };
-
-          const proposedCodeCommit = {
-            sha: env.proposedReferenceSha,
-            author: env.proposedReferenceCommitAuthor,
-            subject: env.proposedReferenceCommitSubject,
-            body: env.proposedReferenceCommitBody || '',
-            date: env.proposedReferenceCommitDate
           };
 
           return (
@@ -122,7 +106,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
                 <CommitInfo
                   title="Active"
                   deploymentCommit={activeDeploymentCommit}
-                  codeCommit={activeCodeCommit}
+                  codeCommit={env.activeReferenceCommit}
                   isActive={true}
                   status={env.activeStatus as StatusType}
                   deploymentCommitUrl={env.activeCommitUrl}
@@ -139,7 +123,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
                   <CommitInfo
                     title="Proposed"
                     deploymentCommit={proposedDeploymentCommit}
-                    codeCommit={proposedCodeCommit}
+                    codeCommit={env.proposedReferenceCommit}
                     isActive={false}
                     status={env.proposedStatus as StatusType}
                     className="proposed"

--- a/ui/components-lib/src/components/CommitInfo.tsx
+++ b/ui/components-lib/src/components/CommitInfo.tsx
@@ -6,19 +6,20 @@ import React, { useState, useRef, useCallback } from 'react';
 import TimeAgo from './TimeAgo';
 import HealthSummary from './HealthSummary';
 import './CommitInfo.scss';
+import {ReferenceCommit} from "@shared/types/promotion";
 
 export interface CommitInfoProps {
   title?: string;
   deploymentCommit: any;
-  codeCommit: any;
+  codeCommit: ReferenceCommit | null;
   isActive?: boolean;
   status?: StatusType;
   className?: string;
   deploymentCommitUrl?: string;
-  codeCommitUrl?: string;
+  codeCommitUrl: string | null;
   checks?: any[];
   healthSummary?: { successCount: number; totalCount: number; shouldDisplay: boolean };
-  prUrl?: string;
+  prUrl: string | null;
   prNumber?: string;
 }
 
@@ -54,7 +55,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
 
   const renderSha = (commit: any, commitUrl?: string) => {
     const sha = commit.sha?.substring(0, 8) || 'N/A';
-    if (commitUrl && commit.sha && commit.sha !== '-' && commitUrl !== '-') {
+    if (commitUrl && commit.sha) {
       return (
         <a 
           href={commitUrl} 
@@ -134,7 +135,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
             </div>
             <div className="commit-meta">
               <span className="commit-author">by {commit.author || 'N/A'}</span>
-              {commit.date && commit.date !== '-' && (
+              {commit.date && (
                 <span className="commit-date">
                   authored <span title={commit.date}><TimeAgo date={commit.date} /></span>
                 </span>
@@ -179,7 +180,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
     return (
       <div className="commits-section">
         {renderCommit(deploymentCommit, 'deployment', deploymentCommitUrl)}
-        {renderCommit(codeCommit, 'code', codeCommitUrl)}
+        {codeCommit && renderCommit(codeCommit, 'code', codeCommitUrl || '')}
       </div>
     );
   }
@@ -207,7 +208,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
       </div>
       <div className="commits-section">
         {renderCommit(deploymentCommit, 'deployment', deploymentCommitUrl)}
-        {renderCommit(codeCommit, 'code', codeCommitUrl)}
+        {codeCommit && renderCommit(codeCommit, 'code', codeCommitUrl || '')}
       </div>
       
       {/* Display checks for this section */}

--- a/ui/shared/src/types/promotion.ts
+++ b/ui/shared/src/types/promotion.ts
@@ -13,15 +13,18 @@ export interface Commit {
   commitTime?: string | null;
   repoURL?: string;
   references?: Array<{
-    commit: {
-      author?: string;
-      sha?: string;
-      subject?: string;
-      date?: string;
-      body?: string;
-      repoURL?: string;
-    };
+    commit: ReferenceCommit;
   }>;
+}
+
+export interface ReferenceCommit  {
+  sha?: string;
+  author?: string;
+  subject?: string;
+  body?: string;
+  date?: string;
+  url?: string;
+  repoURL?: string;
 }
 
 export interface PullRequest {
@@ -113,12 +116,8 @@ export interface EnrichedEnvDetails {
   activePrUrl: string | null;
   activePrNumber: number | null;
   
-  activeReferenceSha: string;
-  activeReferenceCommitAuthor: string;
-  activeReferenceCommitSubject: string;
-  activeReferenceCommitDate: string;
-  activeReferenceCommitUrl: string;
-  activeReferenceCommitBody: string;
+  activeReferenceCommit: ReferenceCommit | null;
+  activeReferenceCommitUrl: string | null;
   
   // Proposed commits
   proposedSha: string;
@@ -133,12 +132,8 @@ export interface EnrichedEnvDetails {
   proposedChecksSummary: { successCount: number; totalCount: number; shouldDisplay: boolean };
   proposedStatus: 'success' | 'failure' | 'pending' | 'unknown';
 
-  proposedReferenceSha: string;
-  proposedReferenceCommitAuthor: string;
-  proposedReferenceCommitSubject: string;
-  proposedReferenceCommitDate: string;
-  proposedReferenceCommitUrl: string;
-  proposedReferenceCommitBody: string;
+  proposedReferenceCommit: ReferenceCommit | null;
+  proposedReferenceCommitUrl: string | null;
 }
 
 export type PromotionPhase = 'promoted' | 'failure' | 'pending' | 'unknown'; 

--- a/ui/shared/src/utils/PSData.ts
+++ b/ui/shared/src/utils/PSData.ts
@@ -1,13 +1,13 @@
 import { getCommitUrl, extractNameOnly, extractBodyPreTrailer, formatDate } from './util';
 import { getEnvironmentStatus, getHealthStatus } from './getStatus';
-import type { 
-  CommitStatus, 
-  Commit, 
-  Environment, 
-  PromotionStrategy, 
-  Check, 
+import type {
+  CommitStatus,
+  Commit,
+  Environment,
+  PromotionStrategy,
+  Check,
   EnrichedEnvDetails,
-  PromotionPhase
+  PromotionPhase, ReferenceCommit
 } from '../types/promotion';
 
 
@@ -29,25 +29,11 @@ function calculateHealthSummary(checks: Check[]): { successCount: number; totalC
 }
 
 // Extract reference commit data
-function extractReferenceCommitData(dryCommit: Commit): {
-  sha: string;
-  author: string;
-  subject: string;
-  body: string;
-  date: string;
-  url: string;
-} {
+function extractReferenceCommitData(dryCommit: Commit): null | ReferenceCommit {
   const referenceCommit = dryCommit.references && dryCommit.references[0]?.commit;
   
   if (!referenceCommit) {
-    return {
-      sha: '-',
-      author: '-',
-      subject: '-',
-      body: '-',
-      date: '-',
-      url: ''
-    };
+    return null;
   }
   
   const sha = referenceCommit.sha ? referenceCommit.sha.slice(0, 7) : '-';
@@ -116,12 +102,8 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
     activeCommitDate: activeCommitInfo.commitTime ? formatDate(activeCommitInfo.commitTime) : '-',
     activeCommitUrl: getCommitUrl(activeCommitInfo.repoURL ?? '', activeCommitInfo.sha ?? ''),
     activeSha: activeCommitInfo.sha ? activeCommitInfo.sha.slice(0, 7) : '-',
-    activeReferenceCommitSubject: activeReferenceData.subject,
-    activeReferenceCommitBody: activeReferenceData.body,
-    activeReferenceCommitAuthor: activeReferenceData.author,
-    activeReferenceCommitDate: activeReferenceData.date,
-    activeReferenceCommitUrl: activeReferenceData.url,
-    activeReferenceSha: activeReferenceData.sha,
+    activeReferenceCommit: activeReferenceData,
+    activeReferenceCommitUrl: activeReferenceData ? getCommitUrl(activeCommitInfo.repoURL ?? '', activeReferenceData.sha ?? '') : null,
     activeChecks: historicalChecks,
     activeChecksSummary,
 
@@ -135,12 +117,8 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
     proposedDryCommitDate: proposedDry.commitTime ? formatDate(proposedDry.commitTime) : '-',
     proposedDryCommitUrl: getCommitUrl(proposedDry.repoURL ?? '', proposedDry.sha ?? ''),
     proposedSha: proposedDry.sha ? proposedDry.sha.slice(0, 7) : '-',
-    proposedReferenceCommitSubject: proposedReferenceData.subject,
-    proposedReferenceCommitBody: proposedReferenceData.body,
-    proposedReferenceCommitAuthor: proposedReferenceData.author,
-    proposedReferenceCommitDate: proposedReferenceData.date,
-    proposedReferenceCommitUrl: proposedReferenceData.url,
-    proposedReferenceSha: proposedReferenceData.sha,
+    proposedReferenceCommit: proposedReferenceData,
+    proposedReferenceCommitUrl: proposedReferenceData ? getCommitUrl(proposedDry.repoURL ?? '', proposedReferenceData.sha ?? '') : null,
     proposedChecks,
     proposedChecksSummary,
   };


### PR DESCRIPTION
Before: 

<img width="528" height="424" alt="image" src="https://github.com/user-attachments/assets/31dee632-83df-4624-b16f-38f13599bd70" />


After:

<img width="538" height="361" alt="image" src="https://github.com/user-attachments/assets/4e06ba9f-9e5e-4090-be6c-2cd2e2e9abda" />
