### PR TITLE
fix: avoid unnecessary Update after Create (#583)

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -599,12 +599,12 @@ func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.
 		if client.IgnoreNotFound(err) != nil {
 			return nil, fmt.Errorf("failed to get CommitStatus object: %w", err)
 		}
-		// Create
 		err = r.localClient.Create(ctx, &desiredCommitStatus)
 		logger.Info("Created CommitStatus", "name", desiredCommitStatus.Name, "targetBranch", targetBranch, "sha", sha, "phase", phase, "description", desc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create CommitStatus object: %w", err)
 		}
+		return &desiredCommitStatus, nil
 	}
 
 	if currentCommitStatus.Spec == desiredCommitStatus.Spec {


### PR DESCRIPTION
After Create, we currently immediately call Update. But that Update has only the resource spec (no metadata) and always fails.

This change makes sure we quit immediately after creating the resource to avoid the unnecessary failed reconcile / error.

Related to #583