### PR TITLE
docs: nil check in deep links condition

### DIFF
--- a/docs/argocd-integrations.md
+++ b/docs/argocd-integrations.md
@@ -55,11 +55,11 @@ To enable these deep links, add the following to your `argocd-cm` ConfigMap:
     - url: '{{.resource.status.url}}'
       title: Pull Request
       icon.class: fa-code-pull-request
-      if: resource.apiVersion == "promoter.argoproj.io/v1alpha1" && resource.kind == "PullRequest" && resource.status.url != ""
+      if: resource.apiVersion == "promoter.argoproj.io/v1alpha1" && resource.kind == "PullRequest" && resource.status.url != nil && resource.status.url != ""
     - url: '{{.resource.status.pullRequest.url}}'
       title: Pull Request
       icon.class: fa-code-pull-request
-      if: resource.apiVersion == "promoter.argoproj.io/v1alpha1" && resource.kind == "ChangeTransferPolicy" && resource.status.pullRequest != nil && resource.status.pullRequest.url != ""
+      if: resource.apiVersion == "promoter.argoproj.io/v1alpha1" && resource.kind == "ChangeTransferPolicy" && resource.status.pullRequest != nil && resource.status.pullRequest.url != nil && resource.status.pullRequest.url != ""
 ```
 
 ## Commit Status Keys in Resource Tree


### PR DESCRIPTION
The library evaluating the if condition treats empty strings as nils, so this covers both cases.

If you don't do this, you'll get broken links with "" as the target.