### PR TITLE
Revert "docs: bump manifest versions to v0.15.0"

### DIFF
--- a/docs/argocd-integrations.md
+++ b/docs/argocd-integrations.md
@@ -24,9 +24,9 @@ spec:
             - name: EXTENSION_NAME
               value: gitops-promoter
             - name: EXTENSION_URL
-              value: https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.15.0/gitops-promoter-argocd-extension.tar.gz
+              value: https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.14.0/gitops-promoter-argocd-extension.tar.gz
             - name: EXTENSION_CHECKSUM_URL
-              value: https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.15.0/gitops-promoter_0.12.0_checksums.txt
+              value: https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.14.0/gitops-promoter_0.12.0_checksums.txt
           volumeMounts:
             - name: extensions
               mountPath: /tmp/extensions/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ GitHub, GitHub Enterprise, GitLab and Forgejo (including Codeberg) as the SCM pr
 To install GitOps Promoter, you can use the following command:
 
 ```bash
-kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.15.0/install.yaml
+kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.14.0/install.yaml
 ```
 
 ## GitHub App Configuration

--- a/docs/tutorial-argocd-apps.md
+++ b/docs/tutorial-argocd-apps.md
@@ -66,7 +66,7 @@ Connect with this password for the `admin` user.
 > See [Getting Started](./getting-started.md)
 
 ```bash
-kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.15.0/install.yaml
+kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.14.0/install.yaml
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Reverts argoproj-labs/gitops-promoter#607

quay.io was down during build trying to re-release 0.15.0