### PR TITLE
fix(ci): set repo name for Renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -49,8 +49,3 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
-          # Enable post-upgrade tasks (only works with self-hosted Renovate)
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: >-
-            ["^go mod tidy$", "^make lint-fix"]
-          # Ensure Renovate uses the proper Git author
-          RENOVATE_GIT_AUTHOR: 'Renovate Bot <bot@renovateapp.com>'

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,12 @@
   "extends": [
     "config:recommended"
   ],
+  "repositories": ["argoproj-labs/gitops-promoter"],
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "allowedPostUpgradeCommands": [
+    "^go mod tidy$",
+    "^make lint-fix"
+  ],
   "timezone": "UTC",
   "schedule": [
     "every weekend"


### PR DESCRIPTION
Also moved some config to the config file instead of splitting it across the config and workflow files.