### PR TITLE
chore(acdcs): clean up revision map

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -471,9 +471,11 @@ func lookupArgoCDCommitStatusFromArgoCDApplication(mgr mcmanager.Manager) mchand
 				return nil
 			}
 
-			rwMutex.Lock()
-			revMap[appKey] = application.Status.Sync.Revision
-			rwMutex.Unlock()
+			if appRef != application.Status.Sync.Revision {
+				rwMutex.Lock()
+				revMap[appKey] = application.Status.Sync.Revision
+				rwMutex.Unlock()
+			}
 
 			// lookup the ArgoCDCommitStatus objects in the local cluster
 			var argoCDCommitStatusList promoterv1alpha1.ArgoCDCommitStatusList


### PR DESCRIPTION
Clean up old apps from the revision map when they're deleted and only update the map when necessary to reduce lock contention.