### PR TITLE
fix(acdcs): disallow empty syncSource.targetBranch

### DIFF
--- a/api/v1alpha1/argocdcommitstatus_types.go
+++ b/api/v1alpha1/argocdcommitstatus_types.go
@@ -119,8 +119,11 @@ type ApplicationsSelected struct {
 	// +kubebuilder:validation:Optional
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime"`
 	// Environment is the syncSource.targetBranch of the Argo CD application (in effect, its environment).
+	// +required
+	// +kubebuilder:validation:MinLength=1
 	Environment string `json:"environment,omitempty"`
-	// ClusterName is the name of the cluster that the application manifest is deployed to.
+	// ClusterName is the name of the cluster that the application manifest is deployed to. An empty string indicates
+	// the local cluster.
 	ClusterName string `json:"clusterName"`
 }
 

--- a/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
@@ -164,12 +164,14 @@ spec:
                     that are selected by the commit status.
                   properties:
                     clusterName:
-                      description: ClusterName is the name of the cluster that the
-                        application manifest is deployed to.
+                      description: |-
+                        ClusterName is the name of the cluster that the application manifest is deployed to. An empty string indicates
+                        the local cluster.
                       type: string
                     environment:
                       description: Environment is the syncSource.targetBranch of the
                         Argo CD application (in effect, its environment).
+                      minLength: 1
                       type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the phase transitioned.
@@ -190,6 +192,7 @@ spec:
                       type: string
                   required:
                   - clusterName
+                  - environment
                   - name
                   - namespace
                   - phase

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -176,12 +176,14 @@ spec:
                     that are selected by the commit status.
                   properties:
                     clusterName:
-                      description: ClusterName is the name of the cluster that the
-                        application manifest is deployed to.
+                      description: |-
+                        ClusterName is the name of the cluster that the application manifest is deployed to. An empty string indicates
+                        the local cluster.
                       type: string
                     environment:
                       description: Environment is the syncSource.targetBranch of the
                         Argo CD application (in effect, its environment).
+                      minLength: 1
                       type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the phase transitioned.
@@ -202,6 +204,7 @@ spec:
                       type: string
                   required:
                   - clusterName
+                  - environment
                   - name
                   - namespace
                   - phase

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -330,6 +330,11 @@ func (r *ArgoCDCommitStatusReconciler) groupArgoCDApplicationsWithPhase(promotio
 				return map[string][]*aggregate{}, errors.New("all applications must have the same repo configured")
 			}
 
+			// Check that TargetBranch is not empty
+			if application.Spec.SourceHydrator.SyncSource.TargetBranch == "" {
+				return map[string][]*aggregate{}, fmt.Errorf("application %s/%s spec.sourceHydrator.syncSource.targetBranch must not be empty", application.GetNamespace(), application.GetName())
+			}
+
 			aggregateItem := &aggregate{
 				application: &application,
 			}

--- a/internal/controller/argocdcommitstatus_controller_test.go
+++ b/internal/controller/argocdcommitstatus_controller_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	_ "embed"
 
+	"github.com/argoproj-labs/gitops-promoter/internal/types/argocd"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 )
@@ -29,13 +36,96 @@ import (
 var testArgoCDCommitStatusYAML string
 
 var _ = Describe("ArgoCDCommitStatus Controller", func() {
-	Context("When reconciling a resource", func() {
-	})
-
 	Context("When unmarshalling the test data", func() {
 		It("should unmarshal the ArgoCDCommitStatus resource", func() {
 			err := unmarshalYamlStrict(testArgoCDCommitStatusYAML, &promoterv1alpha1.ArgoCDCommitStatus{})
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When reconciling a resource", func() {
+		It("should fail if the application's SyncSource.TargetBranch is empty", func() {
+			// Create an Application resource with empty TargetBranch
+			app := &argocd.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-app",
+					Labels: map[string]string{
+						"app": "demo",
+					},
+				},
+				Spec: argocd.ApplicationSpec{
+					SourceHydrator: &argocd.SourceHydrator{
+						SyncSource: argocd.SyncSource{
+							TargetBranch: "",
+						},
+						DrySource: argocd.DrySource{
+							RepoURL: "https://example.com/repo.git",
+						},
+					},
+				},
+				Status: argocd.ApplicationStatus{
+					Health: argocd.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: argocd.SyncStatus{
+						Status:   "Synced",
+						Revision: "abc123",
+					},
+				},
+			}
+			ctx := context.TODO()
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			// Create a PromotionStrategy resource for the ArgoCDCommitStatus to reference
+			promotionStrategy := &promoterv1alpha1.PromotionStrategy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-promotion-strategy",
+				},
+				Spec: promoterv1alpha1.PromotionStrategySpec{
+					RepositoryReference: promoterv1alpha1.ObjectReference{
+						Name: "example-repo",
+					},
+					Environments: []promoterv1alpha1.Environment{
+						{
+							Branch: "environment/staging",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, promotionStrategy)).To(Succeed())
+
+			// Create a minimal ArgoCDCommitStatus referencing the app
+			commitStatus := &promoterv1alpha1.ArgoCDCommitStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-status",
+				},
+				Spec: promoterv1alpha1.ArgoCDCommitStatusSpec{
+					PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: "example-promotion-strategy"},
+					ApplicationSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "demo"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, commitStatus)).To(Succeed())
+
+			// Wait for reconciliation and check status condition
+			Eventually(func(g Gomega) {
+				updated := &promoterv1alpha1.ArgoCDCommitStatus{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-status", Namespace: "default"}, updated)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				c := meta.FindStatusCondition(updated.Status.Conditions, string(promoterConditions.Ready))
+				g.Expect(c).ToNot(BeNil())
+				g.Expect(c.Message).To(ContainSubstring("spec.sourceHydrator.syncSource.targetBranch must not be empty"))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, promotionStrategy)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, commitStatus)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Argo CD's Application CRD doesn't block the invalid configuration of leaving syncSource.targetBranch blank.

Right now the failure mode is an obscure error about trying to get the SHA for an empty branch name.

This change makes the failure explicit.