### PR TITLE
internal/scms/github: allow any merge method for Github PRs

### DIFF
--- a/internal/scms/github/pullrequest.go
+++ b/internal/scms/github/pullrequest.go
@@ -168,7 +168,6 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 		prNumber,
 		pullRequest.Spec.Commit.Message,
 		&github.PullRequestOptions{
-			MergeMethod:        "merge",
 			DontDefaultIfBlank: false,
 			SHA:                pullRequest.Spec.MergeSha,
 		})


### PR DESCRIPTION
The MergeMethod parameter is optional, and already defaults to `merge` if left unset.
Unsetting it should allow it to work with any other merge method if `merge` was disabled in settings.
https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#merge-a-pull-request

Fixes #673