### PR TITLE
docs fix serve-docs directive in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ $(GORELEASER): $(LOCALBIN)
 
 .PHONY: serve-docs
 serve-docs:
-	$(CONTAINER_TOOL) run ${MKDOCS_RUN_ARGS} --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install mkdocs; pip install $$(mkdocs get-deps); mkdocs serve -a $$(ip route get 1 | awk '\''{print $$7}'\''):8000'
+	$(CONTAINER_TOOL) run ${MKDOCS_RUN_ARGS} --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs -w /docs --entrypoint "" ${MKDOCS_DOCKER_IMAGE} sh -c 'pip install -r docs/requirements.txt; mkdocs serve -a $$(ip route get 1 | awk '\''{print $$7}'\''):8000'
 
 .PHONY: lint-docs
 lint-docs:  ## Build docs and fail if there are warnings


### PR DESCRIPTION

## What 

Fix `serve-docs` directive

## Before

```
ERROR   -  Config value 'plugins': The "gh-admonitions" plugin is not installed

Aborted with a configuration error!
make: *** [serve-docs] Error 1

```

## After

```
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.17 seconds
INFO    -  [23:36:32] Serving on http://172.17.0.2:8000/
```
