### PR TITLE
chore remove a nil dereference

### DIFF
--- a/internal/scms/gitlab/pullrequest.go
+++ b/internal/scms/gitlab/pullrequest.go
@@ -248,16 +248,16 @@ func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRe
 
 	start := time.Now()
 	mrs, resp, err := pr.client.MergeRequests.ListMergeRequests(options)
-	if err != nil {
-		return false, "", time.Time{}, fmt.Errorf("failed to list pull requests: %w", err)
-	}
 	if resp == nil {
+		statusCode := -1
+		metrics.RecordSCMCall(repo, metrics.SCMAPIPullRequest, metrics.SCMOperationList, statusCode, time.Since(start), nil)
 		logger.V(4).Info("gitlab response status", "status", "nil response")
 		return false, "", time.Time{}, errors.New("received nil response from GitLab API")
 	}
-
 	metrics.RecordSCMCall(repo, metrics.SCMAPIPullRequest, metrics.SCMOperationList, resp.StatusCode, time.Since(start), nil)
-
+	if err != nil {
+		return false, "", time.Time{}, fmt.Errorf("failed to list pull requests: %w", err)
+	}
 	logGitLabRateLimitsIfAvailable(
 		logger,
 		pullRequest.Spec.RepositoryReference.Name,


### PR DESCRIPTION
## What 

Return error if resp is nil

## Why

Nilway detected 

```
/Users/nolan/Documents/oss/gitops-promoter/internal/scms/gitlab/utils.go:14:11: error: Potential nil panic detected. Observed nil flow from source to dereference point: 
        - client-go@v1.5.0/merge_requests.go:327:23: unassigned variable `resp` returned from `ListMergeRequests()` in position 1
        - client-go@v1.5.0/merge_requests.go:28:3: returned as result 1 from interface method `MergeRequestsServiceInterface.ListMergeRequests()` (implemented by `MergeRequestsService.ListMergeRequests()`)
        - gitlab/pullrequest.go:259:3: result 1 of `ListMergeRequests()` passed as arg `resp` to `logGitLabRateLimitsIfAvailable()` via the assignment(s):
                - `pr.client.MergeRequests.ListMergeRequests(...)` to `resp` at gitlab/pullrequest.go:249:7
        - gitlab/utils.go:14:11: function parameter `resp` accessed field `Header`
```