### PR TITLE
chore: update python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python and venv for docs
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Create venv and install MkDocs requirements
         run: |
           python3 -m venv .venv


### PR DESCRIPTION
## What 

Update python version to `3.13` that is used locally when building documentation https://github.com/argoproj-labs/gitops-promoter/blob/main/Makefile#L8