### PR TITLE
fix(ui): loading spinner should only show if no data is available

### DIFF
--- a/ui/extension/AppViewExtension.tsx
+++ b/ui/extension/AppViewExtension.tsx
@@ -40,8 +40,7 @@ const AppViewExtension = ({ tree, application }: AppViewComponentProps) => {
         throw new Error("Error fetching promotion strategy data: " + err);
       });
   }, [promotionStrategyNodes]);
-
-  if (isLoading || !promotionStrategy) {
+  if (isLoading && !promotionStrategy) {
     return <div>Loading...</div>;
   }
   return (


### PR DESCRIPTION
Changes behavior to allow for stale state to remain while fetching for updated state.