### PR TITLE
chore(acdcs): remove unnecessary reconcile filter

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -73,12 +73,6 @@ type aggregate struct {
 	commitStatus *promoterv1alpha1.CommitStatus
 }
 
-type appRevisionKey struct {
-	clusterName string
-	namespace   string
-	name        string
-}
-
 // ArgoCDCommitStatusReconciler reconciles a ArgoCDCommitStatus object
 type ArgoCDCommitStatusReconciler struct {
 	Manager                mcmanager.Manager


### PR DESCRIPTION
I think now that we have the predicate, this filter isn't needed.

I've tested internally and haven't seen an explosion of ArgoCDCommitStatus reconciles.