### PR TITLE
test(acdcs): detect app change even if health doesn't change

### DIFF
--- a/internal/controller/argocdcommitstatus_controller_test.go
+++ b/internal/controller/argocdcommitstatus_controller_test.go
@@ -271,7 +271,7 @@ var _ = Describe("ArgoCDCommitStatus Controller", func() {
 
 			// Step 2: Create a new commit in the git repository
 			testFile := workTreePath + "/test-change.txt"
-			err = os.WriteFile(testFile, []byte("test change for bug reproduction"), 0x644)
+			err = os.WriteFile(testFile, []byte("test change for bug reproduction"), 0o644)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = runGitCmd(ctx, workTreePath, "add", "test-change.txt")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This tests to avoid regression for an issue that Sean Liao discovered: the ArgoCDCommitStatus controller failed to detect Argo CD Apps going from OutOfSync -> Synced for Apps that contained only resources without health checks (e.g. only a ConfigMap).

We fixed the bug with this PR: https://github.com/argoproj-labs/gitops-promoter/pull/810

I'm adding this test to make sure we don't reintroduce the bug. I've confirmed that this test fails on the commit before #810 was merged.