### PR TITLE
chore: don't update resource if already deleted

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -275,7 +275,7 @@ func HandleReconciliationResult(
 	}
 
 	// If the deletion timestamp is set on the object, bail out early.
-	if obj.GetDeletionTimestamp() != nil {
+	if !obj.GetDeletionTimestamp().IsZero() {
 		logger.V(4).Info("resource deleted, skipping handling of the reconciliation result")
 		return
 	}


### PR DESCRIPTION
This reduced the number of errors like `Precondition failed: UID in precondition: 7a65beca-85d0-48be-b58c-fa53de735e9a, UID in object meta` from 37 in one run to 8.