### PR TITLE
chore: update linter version in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.0
+          version: v2.5.0
           args: --timeout=5m
           skip-cache: false
 #      # We want to enable this but github seems to cancel the job, might be related to memory limits on the runner.


### PR DESCRIPTION
## What

Update golinter version

## Why 

It is different that the one in the makefile https://github.com/argoproj-labs/gitops-promoter/blob/main/Makefile#L264 , so I would see error locally and not in CI or vice-versa 