### PR TITLE
chore(ui): update deprecated import rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the dashboard UI
-FROM node:18-bullseye-slim AS dashboard-builder
+FROM node:20-bullseye-slim AS dashboard-builder
 WORKDIR /workspace
 
 # Copy package files first for better layer caching

--- a/ui/dashboard/src/components/PromotionStrategySummary/PromotionStrategyTiles.scss
+++ b/ui/dashboard/src/components/PromotionStrategySummary/PromotionStrategyTiles.scss
@@ -61,7 +61,7 @@
   }
   
   &__label {
-    color: $argo-color-gray-5;
+    color: $argo-color-gray-7;
     font-weight: 400;
     font-size: 13px;
     font-family: 'Heebo', sans-serif;


### PR DESCRIPTION
## What

Update deprecated import rule


## Before

Running `make  build-dashboard `

```
transforming (67) node_modules/react-dom/index.jsDeprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import '../styles/_colors.scss';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    ../components-lib/src/components/LiveManifestView.scss 1:9  root stylesheet

```


## After

This depreciation warning is gone
```
vite v7.1.11 building for production...
✓ 191 modules transformed.
dist/index.html                                    0.40 kB │ gzip:   0.27 kB
dist/assets/argo-icon-color-square-ld7-s1P7.png  102.25 kB
dist/assets/index-DiOvCHJJ.css                    17.18 kB │ gzip:   3.74 kB
dist/assets/index-Bd45SKAi.js                    934.40 kB │ gzip: 280.35 kB

(!) Some chunks are larger than 500 kB after minification. Consider:                                                                                                                                             
- Using dynamic import() to code-split the application                                                                                                                                                           
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks                                                                               
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.                                                                                                                                      
✓ built in 2.51s
```


Steps 
```
$ npm install -g sass-migrator
$ sass-migrator module --migrate-deps ./ui/components-lib/src/components/LiveManifestView.scss 
```



