### PR TITLE
fix(release-latest): add snapshot flag

### DIFF
--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -44,6 +44,6 @@ jobs:
         with:
           distribution: goreleaser
           version:  v2.13.2
-          args: release -f .goreleaser-latest.yaml --clean --verbose
+          args: release -f .goreleaser-latest.yaml --clean --verbose --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Add --snaphsot flag


## Why

https://github.com/argoproj-labs/gitops-promoter/actions/runs/20868020761/job/59963657007

```
    • git command result                             args=[-c log.showSignature=false describe --tags --abbrev=0 HEAD] stdout= stderr=fatal: No names found, cannot describe anything.
  ⨯ release failed after 0s                          error=git doesn't contain any tags - either add a tag or use --snapshot
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.13.2/x64/goreleaser' failed with exit code 1
```

It tries to create a git release but shouldn't

