### PR TITLE
fix(release): add docker push

### DIFF
--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -47,3 +47,12 @@ jobs:
           args: release -f .goreleaser-latest.yaml --clean --verbose --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker Images Latest
+        run: |
+          docker push quay.io/argoprojlabs/gitops-promoter:latest-amd64
+          docker push quay.io/argoprojlabs/gitops-promoter:latest-arm64
+          docker manifest create quay.io/argoprojlabs/gitops-promoter:latest \
+            quay.io/argoprojlabs/gitops-promoter:latest-amd64 \
+            quay.io/argoprojlabs/gitops-promoter:latest-arm64
+          docker manifest push quay.io/argoprojlabs/gitops-promoter:latest


### PR DESCRIPTION
## What

Add pushing the docker manifest latest 

## Why



It looks that there is not an easy way with the free version
- https://github.com/orgs/goreleaser/discussions/1534
- https://github.com/goreleaser/goreleaser/issues/1538
- https://github.com/orgs/goreleaser/discussions/2786