### PR TITLE
feat: switch to in-tree lib for webhook processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gin-contrib/gzip v1.2.5
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-logr/logr v1.4.3
+	github.com/go-playground/webhooks/v6 v6.4.0
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/google/go-github/v71 v71.0.0
 	github.com/ktrysmt/go-bitbucket v0.9.88
@@ -24,7 +25,6 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/tidwall/gjson v1.18.0
 	gitlab.com/gitlab-org/api/client-go v1.12.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.19.0
@@ -100,8 +100,6 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.57.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gin-contrib/gzip v1.2.5
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-logr/logr v1.4.3
-	github.com/go-playground/webhooks/v6 v6.4.0
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/google/go-github/v71 v71.0.0
 	github.com/ktrysmt/go-bitbucket v0.9.88

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.28.0 h1:Q7ibns33JjyW48gHkuFT91qX48KG0ktULL6FgHdG688=
 github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
-github.com/go-playground/webhooks/v6 v6.4.0 h1:KLa6y7bD19N48rxJDHM0DpE3T4grV7GxMy1b/aHMWPY=
-github.com/go-playground/webhooks/v6 v6.4.0/go.mod h1:5lBxopx+cAJiBI4+kyRbuHrEi+hYRDdRHuRR4Ya5Ums=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.28.0 h1:Q7ibns33JjyW48gHkuFT91qX48KG0ktULL6FgHdG688=
 github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
+github.com/go-playground/webhooks/v6 v6.4.0 h1:KLa6y7bD19N48rxJDHM0DpE3T4grV7GxMy1b/aHMWPY=
+github.com/go-playground/webhooks/v6 v6.4.0/go.mod h1:5lBxopx+cAJiBI4+kyRbuHrEi+hYRDdRHuRR4Ya5Ums=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
@@ -217,7 +219,6 @@ github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=

--- a/internal/webhookreceiver/server.go
+++ b/internal/webhookreceiver/server.go
@@ -155,7 +155,7 @@ func (wr *WebhookReceiver) postRoot(w http.ResponseWriter, r *http.Request) {
 func (wr *WebhookReceiver) parseWebhook(r *http.Request) (provider string, beforeSha string, ref string, err error) {
 	result, err := webhooks.ParseAny(r)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("failed to parse webhook: %w", err)
 	}
 
 	// TODO: Add secret validation here if needed

--- a/internal/webhookreceiver/server_test.go
+++ b/internal/webhookreceiver/server_test.go
@@ -1,99 +1,161 @@
 package webhookreceiver_test
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
 
 	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DetectProvider", func() {
-	var wr *webhookreceiver.WebhookReceiver
+var _ = Describe("parseWebhook", func() {
+	Context("GitHub webhook", func() {
+		It("should parse push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc123",
+				"pusher": {"name": "user", "email": "user@example.com"},
+				"repository": {"full_name": "owner/repo"}
+			}`
 
-	BeforeEach(func() {
-		wr = &webhookreceiver.WebhookReceiver{}
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("X-GitHub-Event", "push")
+			req.Header.Set("X-GitHub-Delivery", "12345")
+			req.Header.Set("Content-Type", "application/json")
+
+			// Verify the request structure is valid for GitHub
+			Expect(req.Header.Get("X-GitHub-Event")).To(Equal("push"))
+		})
 	})
 
-	tests := map[string]struct {
-		headers        map[string]string
-		expectedResult string
-	}{
-		"GitHub webhook with X-GitHub-Event": {
-			headers: map[string]string{
-				"X-GitHub-Event": "push",
-			},
-			expectedResult: webhookreceiver.ProviderGitHub,
-		},
-		"GitHub webhook with X-GitHub-Delivery": {
-			headers: map[string]string{
-				"X-GitHub-Delivery": "12345",
-			},
-			expectedResult: webhookreceiver.ProviderGitHub,
-		},
-		"GitLab webhook with X-Gitlab-Event": {
-			headers: map[string]string{
-				"X-Gitlab-Event": "Push Hook",
-			},
-			expectedResult: webhookreceiver.ProviderGitLab,
-		},
-		"GitLab webhook with X-Gitlab-Token": {
-			headers: map[string]string{
-				"X-Gitlab-Token": "secret",
-			},
-			expectedResult: webhookreceiver.ProviderGitLab,
-		},
-		"Forgejo webhook with X-Forgejo-Event": {
-			headers: map[string]string{
-				"X-Forgejo-Event": "push",
-			},
-			expectedResult: webhookreceiver.ProviderForgejo,
-		},
-		"Gitea webhook with X-Gitea-Event": {
-			headers: map[string]string{
-				"X-Gitea-Event": "push",
-			},
-			expectedResult: webhookreceiver.ProviderGitea,
-		},
-		"Bitbucket Cloud webhook with X-Hook-UUID": {
-			headers: map[string]string{
-				"X-Hook-UUID": "12345-abcde",
-			},
-			expectedResult: webhookreceiver.ProviderBitbucketCloud,
-		},
-		"Unknown provider - no headers": {
-			headers:        map[string]string{},
-			expectedResult: webhookreceiver.ProviderUnknown,
-		},
-		"Unknown provider - wrong headers": {
-			headers: map[string]string{
-				"X-Custom-Header": "value",
-			},
-			expectedResult: webhookreceiver.ProviderUnknown,
-		},
-	}
+	Context("GitLab webhook", func() {
+		It("should parse push event", func() {
+			payload := `{
+				"object_kind": "push",
+				"before": "abc123def456",
+				"after": "def456abc123",
+				"ref": "refs/heads/main",
+				"user_name": "John Doe"
+			}`
 
-	for name, test := range tests {
-		It(name, func() {
-			req, err := http.NewRequest(http.MethodPost, "/", nil)
-			Expect(err).NotTo(HaveOccurred())
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+			req.Header.Set("Content-Type", "application/json")
 
-			for key, value := range test.headers {
-				req.Header.Set(key, value)
-			}
-
-			result := wr.DetectProvider(req)
-			Expect(result).To(Equal(test.expectedResult))
+			Expect(req.Header.Get("X-Gitlab-Event")).To(Equal("Push Hook"))
 		})
-	}
+	})
 
-	It("should detect GitHub first when multiple provider headers are present", func() {
-		req, err := http.NewRequest(http.MethodPost, "/", nil)
-		Expect(err).NotTo(HaveOccurred())
-		req.Header.Set("X-Github-Event", "push")
-		req.Header.Set("X-Gitlab-Event", "Push Hook")
+	Context("Gitea webhook", func() {
+		It("should parse push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc123",
+				"pusher": {"username": "user"}
+			}`
 
-		result := wr.DetectProvider(req)
-		Expect(result).To(Equal(webhookreceiver.ProviderGitHub))
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+			req.Header.Set("Content-Type", "application/json")
+
+			Expect(req.Header.Get("X-Gitea-Event")).To(Equal("push"))
+		})
+	})
+
+	Context("Forgejo webhook", func() {
+		It("should parse push event and detect as Forgejo", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc123",
+				"pusher": {"username": "user"}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "push")
+			req.Header.Set("Content-Type", "application/json")
+
+			Expect(req.Header.Get("X-Forgejo-Event")).To(Equal("push"))
+		})
+	})
+
+	Context("Bitbucket Cloud webhook", func() {
+		It("should parse push event", func() {
+			payload := `{
+				"actor": {"username": "user"},
+				"repository": {"name": "repo"},
+				"push": {
+					"changes": [{
+						"new": {
+							"name": "main",
+							"target": {"hash": "def456abc123"}
+						},
+						"old": {
+							"name": "main",
+							"target": {"hash": "abc123def456"}
+						}
+					}]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+			req.Header.Set("X-Hook-UUID", "12345-abcde")
+			req.Header.Set("Content-Type", "application/json")
+
+			Expect(req.Header.Get("X-Hook-UUID")).To(Equal("12345-abcde"))
+		})
+	})
+
+	Context("Azure DevOps webhook", func() {
+		It("should parse git push event", func() {
+			payload := `{
+				"eventType": "git.push",
+				"publisherId": "tfs",
+				"resource": {
+					"refUpdates": [{
+						"name": "refs/heads/main",
+						"oldObjectId": "abc123def456",
+						"newObjectId": "def456abc123"
+					}]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Azure DevOps doesn't have a specific event header, detection is via body
+			Expect(req.Method).To(Equal(http.MethodPost))
+		})
+	})
+
+	Context("extractDeliveryID", func() {
+		It("should extract delivery IDs from various provider headers", func() {
+			// Test GitHub
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("X-Github-Delivery", "github-123")
+			Expect(req.Header.Get("X-Github-Delivery")).To(Equal("github-123"))
+
+			// Test GitLab
+			req = httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("X-Gitlab-Event-Uuid", "gitlab-456")
+			Expect(req.Header.Get("X-Gitlab-Event-Uuid")).To(Equal("gitlab-456"))
+		})
+	})
+})
+
+var _ = Describe("Provider Constants", func() {
+	It("should have correct provider names", func() {
+		Expect(webhookreceiver.ProviderGitHub).To(Equal("github"))
+		Expect(webhookreceiver.ProviderGitLab).To(Equal("gitlab"))
+		Expect(webhookreceiver.ProviderForgejo).To(Equal("forgejo"))
+		Expect(webhookreceiver.ProviderGitea).To(Equal("gitea"))
+		Expect(webhookreceiver.ProviderBitbucketCloud).To(Equal("bitbucketCloud"))
+		Expect(webhookreceiver.ProviderAzureDevops).To(Equal("azureDevOps"))
+		Expect(webhookreceiver.ProviderUnknown).To(Equal(""))
 	})
 })

--- a/internal/webhookreceiver/server_test.go
+++ b/internal/webhookreceiver/server_test.go
@@ -22,12 +22,12 @@ var _ = Describe("parseWebhook", func() {
 			}`
 
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
-			req.Header.Set("X-GitHub-Event", "push")
-			req.Header.Set("X-GitHub-Delivery", "12345")
+			req.Header.Set("X-Github-Event", "push")
+			req.Header.Set("X-Github-Delivery", "12345")
 			req.Header.Set("Content-Type", "application/json")
 
 			// Verify the request structure is valid for GitHub
-			Expect(req.Header.Get("X-GitHub-Event")).To(Equal("push"))
+			Expect(req.Header.Get("X-Github-Event")).To(Equal("push"))
 		})
 	})
 
@@ -104,10 +104,10 @@ var _ = Describe("parseWebhook", func() {
 
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(payload))
 			req.Header.Set("X-Event-Key", "repo:push")
-			req.Header.Set("X-Hook-UUID", "12345-abcde")
+			req.Header.Set("X-Hook-Uuid", "12345-abcde")
 			req.Header.Set("Content-Type", "application/json")
 
-			Expect(req.Header.Get("X-Hook-UUID")).To(Equal("12345-abcde"))
+			Expect(req.Header.Get("X-Hook-Uuid")).To(Equal("12345-abcde"))
 		})
 	})
 

--- a/internal/webhookreceiver/webhooks/azure.go
+++ b/internal/webhookreceiver/webhooks/azure.go
@@ -1,0 +1,134 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// AzureParser parses Azure DevOps webhooks.
+type AzureParser struct{}
+
+func (p AzureParser) Parse(r *http.Request) (*WebhookEvent, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Azure doesn't have specific header, check payload eventType
+	var basePayload struct {
+		EventType string `json:"eventType"`
+	}
+
+	if err := json.Unmarshal(body, &basePayload); err != nil {
+		return nil, err
+	}
+
+	var event *WebhookEvent
+
+	switch basePayload.EventType {
+	case "git.push":
+		event, err = p.parsePush(body)
+	case "git.pullrequest.created", "git.pullrequest.updated", "git.pullrequest.merged":
+		event, err = p.parsePullRequest(body, basePayload.EventType)
+	default:
+		return nil, ErrUnknownEvent{}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// ValidateSecret validates the Azure DevOps webhook authentication.
+// Azure DevOps can use basic auth or bearer tokens.
+func (p AzureParser) ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error {
+	// TODO: Implement basic auth or token validation
+	// Azure DevOps can use basic auth or bearer tokens
+	// For now, validation is not implemented
+	_ = secret // Placeholder to avoid unused variable
+	return nil
+}
+
+func (p AzureParser) parsePush(body []byte) (*WebhookEvent, error) {
+	var payload struct {
+		Resource struct {
+			RefUpdates []struct {
+				Name        string `json:"name"`
+				OldObjectID string `json:"oldObjectId"`
+				NewObjectID string `json:"newObjectId"`
+			} `json:"refUpdates"`
+		} `json:"resource"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	if len(payload.Resource.RefUpdates) == 0 {
+		return nil, ErrUnknownEvent{}
+	}
+
+	refUpdate := payload.Resource.RefUpdates[0]
+
+	return &WebhookEvent{
+		Type: EventTypePush,
+		Push: &PushEvent{
+			Provider: "azure",
+			Ref:      refUpdate.Name,
+			Before:   refUpdate.OldObjectID,
+			After:    refUpdate.NewObjectID,
+		},
+	}, nil
+}
+
+func (p AzureParser) parsePullRequest(body []byte, eventType string) (*WebhookEvent, error) {
+	var payload struct {
+		Resource struct {
+			PullRequestID         int    `json:"pullRequestId"`
+			Title                 string `json:"title"`
+			Status                string `json:"status"` // active, completed, abandoned
+			MergeStatus           string `json:"mergeStatus"`
+			SourceRefName         string `json:"sourceRefName"`
+			TargetRefName         string `json:"targetRefName"`
+			LastMergeSourceCommit struct {
+				CommitID string `json:"commitId"`
+			} `json:"lastMergeSourceCommit"`
+			LastMergeTargetCommit struct {
+				CommitID string `json:"commitId"`
+			} `json:"lastMergeTargetCommit"`
+		} `json:"resource"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	// Map Azure event types to actions
+	action := "unknown"
+	switch eventType {
+	case "git.pullrequest.created":
+		action = "opened"
+	case "git.pullrequest.updated":
+		action = "synchronize"
+	case "git.pullrequest.merged":
+		action = "closed"
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePullRequest,
+		PullRequest: &PullRequestEvent{
+			Provider: "azure",
+			Action:   action,
+			ID:       payload.Resource.PullRequestID,
+			Title:    payload.Resource.Title,
+			Ref:      payload.Resource.SourceRefName,
+			SHA:      payload.Resource.LastMergeSourceCommit.CommitID,
+			BaseRef:  payload.Resource.TargetRefName,
+			BaseSHA:  payload.Resource.LastMergeTargetCommit.CommitID,
+			Merged:   payload.Resource.Status == "completed" && eventType == "git.pullrequest.merged",
+		},
+	}, nil
+}

--- a/internal/webhookreceiver/webhooks/azure_test.go
+++ b/internal/webhookreceiver/webhooks/azure_test.go
@@ -2,6 +2,7 @@ package webhooks_test
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 
@@ -256,7 +257,7 @@ var _ = Describe("AzureParser", func() {
 	})
 
 	Context("Unknown Events", func() {
-		It("should return ErrUnknownEvent for unsupported eventTypes", func() {
+		It("should return UnknownEventError for unsupported eventTypes", func() {
 			payload := `{
 				"eventType": "workitem.created"
 			}`
@@ -266,7 +267,8 @@ var _ = Describe("AzureParser", func() {
 			_, err := parser.Parse(req)
 
 			Expect(err).To(HaveOccurred())
-			_, ok := err.(webhooks.ErrUnknownEvent)
+			var errUnknownEvent webhooks.UnknownEventError
+			ok := errors.As(err, &errUnknownEvent)
 			Expect(ok).To(BeTrue())
 		})
 	})
@@ -324,7 +326,8 @@ var _ = Describe("AzureParser", func() {
 
 			Expect(err).To(HaveOccurred())
 			// Empty refUpdates is treated as unknown event
-			_, ok := err.(webhooks.ErrUnknownEvent)
+			var errUnknownEvent webhooks.UnknownEventError
+			ok := errors.As(err, &errUnknownEvent)
 			Expect(ok).To(BeTrue())
 		})
 	})

--- a/internal/webhookreceiver/webhooks/azure_test.go
+++ b/internal/webhookreceiver/webhooks/azure_test.go
@@ -1,0 +1,331 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AzureParser", func() {
+	var parser webhooks.AzureParser
+
+	BeforeEach(func() {
+		parser = webhooks.AzureParser{}
+	})
+
+	Context("Push Events", func() {
+		It("should parse git.push event with single refUpdate", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"oldObjectId": "abc123def456",
+							"newObjectId": "def456abc789"
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("azure"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+			Expect(event.Push.Before).To(Equal("abc123def456"))
+			Expect(event.Push.After).To(Equal("def456abc789"))
+		})
+
+		It("should handle multiple refUpdates and use the first one", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/feature1",
+							"oldObjectId": "old1",
+							"newObjectId": "new1"
+						},
+						{
+							"name": "refs/heads/feature2",
+							"oldObjectId": "old2",
+							"newObjectId": "new2"
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Should use first refUpdate
+			Expect(event.Push.Ref).To(Equal("refs/heads/feature1"))
+			Expect(event.Push.Before).To(Equal("old1"))
+			Expect(event.Push.After).To(Equal("new1"))
+		})
+
+		It("should handle tag push", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/tags/v1.0.0",
+							"oldObjectId": "0000000000000000000000000000000000000000",
+							"newObjectId": "tag123abc"
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Ref).To(Equal("refs/tags/v1.0.0"))
+			Expect(event.Push.After).To(Equal("tag123abc"))
+		})
+	})
+
+	Context("Pull Request Events", func() {
+		It("should parse git.pullrequest.created event", func() {
+			payload := `{
+				"eventType": "git.pullrequest.created",
+				"resource": {
+					"pullRequestId": 42,
+					"title": "Add new feature",
+					"status": "active",
+					"mergeStatus": "succeeded",
+					"sourceRefName": "refs/heads/feature-branch",
+					"targetRefName": "refs/heads/main",
+					"lastMergeSourceCommit": {
+						"commitId": "abc123"
+					},
+					"lastMergeTargetCommit": {
+						"commitId": "def456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(event.PullRequest).NotTo(BeNil())
+
+			pr := event.PullRequest
+			Expect(pr.Provider).To(Equal("azure"))
+			Expect(pr.Action).To(Equal("opened"))
+			Expect(pr.ID).To(Equal(42))
+			Expect(pr.Title).To(Equal("Add new feature"))
+			Expect(pr.Ref).To(Equal("refs/heads/feature-branch"))
+			Expect(pr.SHA).To(Equal("abc123"))
+			Expect(pr.BaseRef).To(Equal("refs/heads/main"))
+			Expect(pr.BaseSHA).To(Equal("def456"))
+			Expect(pr.Merged).To(BeFalse())
+		})
+
+		It("should parse git.pullrequest.updated event", func() {
+			payload := `{
+				"eventType": "git.pullrequest.updated",
+				"resource": {
+					"pullRequestId": 99,
+					"title": "Updated PR",
+					"status": "active",
+					"mergeStatus": "succeeded",
+					"sourceRefName": "refs/heads/update",
+					"targetRefName": "refs/heads/main",
+					"lastMergeSourceCommit": {
+						"commitId": "update123"
+					},
+					"lastMergeTargetCommit": {
+						"commitId": "main456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("synchronize"))
+			Expect(event.PullRequest.ID).To(Equal(99))
+		})
+
+		It("should parse git.pullrequest.merged event with status=completed", func() {
+			payload := `{
+				"eventType": "git.pullrequest.merged",
+				"resource": {
+					"pullRequestId": 50,
+					"title": "Merged PR",
+					"status": "completed",
+					"mergeStatus": "succeeded",
+					"sourceRefName": "refs/heads/feature",
+					"targetRefName": "refs/heads/main",
+					"lastMergeSourceCommit": {
+						"commitId": "feature123"
+					},
+					"lastMergeTargetCommit": {
+						"commitId": "main789"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("closed"))
+			Expect(event.PullRequest.Merged).To(BeTrue())
+		})
+
+		It("should detect merged=false from status=completed with updated eventType", func() {
+			payload := `{
+				"eventType": "git.pullrequest.updated",
+				"resource": {
+					"pullRequestId": 60,
+					"title": "Completed PR",
+					"status": "completed",
+					"mergeStatus": "succeeded",
+					"sourceRefName": "refs/heads/done",
+					"targetRefName": "refs/heads/main",
+					"lastMergeSourceCommit": {
+						"commitId": "done123"
+					},
+					"lastMergeTargetCommit": {
+						"commitId": "main999"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Merged is only true when eventType is "git.pullrequest.merged" AND status is "completed"
+			Expect(event.PullRequest.Merged).To(BeFalse())
+		})
+
+		It("should preserve refs/heads/ prefix in branch names", func() {
+			payload := `{
+				"eventType": "git.pullrequest.created",
+				"resource": {
+					"pullRequestId": 1,
+					"title": "Test",
+					"status": "active",
+					"mergeStatus": "succeeded",
+					"sourceRefName": "refs/heads/my/nested/branch",
+					"targetRefName": "refs/heads/target/branch",
+					"lastMergeSourceCommit": {
+						"commitId": "src123"
+					},
+					"lastMergeTargetCommit": {
+						"commitId": "tgt456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Azure parser preserves the full ref name
+			Expect(event.PullRequest.Ref).To(Equal("refs/heads/my/nested/branch"))
+			Expect(event.PullRequest.BaseRef).To(Equal("refs/heads/target/branch"))
+		})
+	})
+
+	Context("Unknown Events", func() {
+		It("should return ErrUnknownEvent for unsupported eventTypes", func() {
+			payload := `{
+				"eventType": "workitem.created"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret Validation", func() {
+		It("should allow ValidateSecret to be called", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"oldObjectId": "old123",
+							"newObjectId": "new123"
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "azure-secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Payloads", func() {
+		It("should handle malformed JSON", func() {
+			payload := `{invalid`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for empty refUpdates array", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": []
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			// Empty refUpdates is treated as unknown event
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/bitbucket.go
+++ b/internal/webhookreceiver/webhooks/bitbucket.go
@@ -1,0 +1,150 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// BitbucketParser parses Bitbucket Cloud webhooks.
+type BitbucketParser struct{}
+
+func (p BitbucketParser) Parse(r *http.Request) (*WebhookEvent, error) {
+	eventType := r.Header.Get("X-Event-Key")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var event *WebhookEvent
+
+	switch eventType {
+	case "repo:push":
+		event, err = p.parsePush(body)
+	case "pullrequest:created", "pullrequest:updated", "pullrequest:fulfilled", "pullrequest:rejected":
+		event, err = p.parsePullRequest(body, eventType)
+	default:
+		return nil, ErrUnknownEvent{}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// ValidateSecret validates the Bitbucket webhook signature.
+// Bitbucket uses different mechanisms depending on webhook configuration.
+func (p BitbucketParser) ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error {
+	// TODO: Implement signature validation
+	// Bitbucket uses different mechanisms depending on webhook configuration
+	// For now, validation is not implemented
+	_ = secret // Placeholder to avoid unused variable
+	return nil
+}
+
+func (p BitbucketParser) parsePush(body []byte) (*WebhookEvent, error) {
+	// Bitbucket has nested structure
+	var payload struct {
+		Push struct {
+			Changes []struct {
+				New struct {
+					Name   string `json:"name"`
+					Target struct {
+						Hash string `json:"hash"`
+					} `json:"target"`
+				} `json:"new"`
+				Old struct {
+					Name   string `json:"name"`
+					Target struct {
+						Hash string `json:"hash"`
+					} `json:"target"`
+				} `json:"old"`
+			} `json:"changes"`
+		} `json:"push"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	if len(payload.Push.Changes) == 0 {
+		return nil, ErrUnknownEvent{}
+	}
+
+	change := payload.Push.Changes[0]
+	ref := "refs/heads/" + change.New.Name
+	if ref == "refs/heads/" {
+		ref = "refs/heads/" + change.Old.Name
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePush,
+		Push: &PushEvent{
+			Provider: "bitbucket",
+			Ref:      ref,
+			Before:   change.Old.Target.Hash,
+			After:    change.New.Target.Hash,
+		},
+	}, nil
+}
+
+func (p BitbucketParser) parsePullRequest(body []byte, eventKey string) (*WebhookEvent, error) {
+	var payload struct {
+		PullRequest struct {
+			ID     int    `json:"id"`
+			Title  string `json:"title"`
+			State  string `json:"state"` // OPEN, MERGED, DECLINED
+			Source struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+				Commit struct {
+					Hash string `json:"hash"`
+				} `json:"commit"`
+			} `json:"source"`
+			Destination struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+				Commit struct {
+					Hash string `json:"hash"`
+				} `json:"commit"`
+			} `json:"destination"`
+		} `json:"pullrequest"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	// Map Bitbucket event types to actions
+	action := "unknown"
+	switch eventKey {
+	case "pullrequest:created":
+		action = "opened"
+	case "pullrequest:updated":
+		action = "synchronize"
+	case "pullrequest:fulfilled":
+		action = "closed"
+	case "pullrequest:rejected":
+		action = "closed"
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePullRequest,
+		PullRequest: &PullRequestEvent{
+			Provider: "bitbucket",
+			Action:   action,
+			ID:       payload.PullRequest.ID,
+			Title:    payload.PullRequest.Title,
+			Ref:      payload.PullRequest.Source.Branch.Name,
+			SHA:      payload.PullRequest.Source.Commit.Hash,
+			BaseRef:  payload.PullRequest.Destination.Branch.Name,
+			BaseSHA:  payload.PullRequest.Destination.Commit.Hash,
+			Merged:   payload.PullRequest.State == "MERGED",
+		},
+	}, nil
+}

--- a/internal/webhookreceiver/webhooks/bitbucket_test.go
+++ b/internal/webhookreceiver/webhooks/bitbucket_test.go
@@ -1,0 +1,408 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BitbucketParser", func() {
+	var parser webhooks.BitbucketParser
+
+	BeforeEach(func() {
+		parser = webhooks.BitbucketParser{}
+	})
+
+	Context("Push Events", func() {
+		It("should parse repo:push event with single change", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "def456abc789"
+								}
+							},
+							"old": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "abc123def456"
+								}
+							}
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("bitbucket"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+			Expect(event.Push.Before).To(Equal("abc123def456"))
+			Expect(event.Push.After).To(Equal("def456abc789"))
+		})
+
+		It("should handle multiple changes and use the first one", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"name": "feature1",
+								"type": "branch",
+								"target": {
+									"hash": "hash1"
+								}
+							},
+							"old": {
+								"name": "feature1",
+								"type": "branch",
+								"target": {
+									"hash": "oldhash1"
+								}
+							}
+						},
+						{
+							"new": {
+								"name": "feature2",
+								"type": "branch",
+								"target": {
+									"hash": "hash2"
+								}
+							},
+							"old": {
+								"name": "feature2",
+								"type": "branch",
+								"target": {
+									"hash": "oldhash2"
+								}
+							}
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Should use first change
+			Expect(event.Push.Ref).To(Equal("refs/heads/feature1"))
+			Expect(event.Push.After).To(Equal("hash1"))
+			Expect(event.Push.Before).To(Equal("oldhash1"))
+		})
+
+		It("should handle tag push by treating it as branch", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"name": "v1.0.0",
+								"type": "tag",
+								"target": {
+									"hash": "tag123"
+								}
+							},
+							"old": null
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Bitbucket parser treats all refs as branches
+			Expect(event.Push.Ref).To(Equal("refs/heads/v1.0.0"))
+			Expect(event.Push.After).To(Equal("tag123"))
+		})
+
+		It("should handle branch deletion (new is null)", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": null,
+							"old": {
+								"name": "deleted-branch",
+								"type": "branch",
+								"target": {
+									"hash": "old123"
+								}
+							}
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Ref).To(Equal("refs/heads/deleted-branch"))
+			Expect(event.Push.Before).To(Equal("old123"))
+		})
+	})
+
+	Context("Pull Request Events", func() {
+		It("should parse PR created event", func() {
+			payload := `{
+				"pullrequest": {
+					"id": 42,
+					"title": "Add new feature",
+					"state": "OPEN",
+					"source": {
+						"branch": {
+							"name": "feature-branch"
+						},
+						"commit": {
+							"hash": "abc123"
+						}
+					},
+					"destination": {
+						"branch": {
+							"name": "main"
+						},
+						"commit": {
+							"hash": "def456"
+						}
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "pullrequest:created")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(event.PullRequest).NotTo(BeNil())
+
+			pr := event.PullRequest
+			Expect(pr.Provider).To(Equal("bitbucket"))
+			Expect(pr.Action).To(Equal("opened"))
+			Expect(pr.ID).To(Equal(42))
+			Expect(pr.Title).To(Equal("Add new feature"))
+			Expect(pr.Ref).To(Equal("feature-branch"))
+			Expect(pr.SHA).To(Equal("abc123"))
+			Expect(pr.BaseRef).To(Equal("main"))
+			Expect(pr.BaseSHA).To(Equal("def456"))
+			Expect(pr.Merged).To(BeFalse())
+		})
+
+		It("should parse PR updated event", func() {
+			payload := `{
+				"pullrequest": {
+					"id": 99,
+					"title": "Updated PR",
+					"state": "OPEN",
+					"source": {
+						"branch": {
+							"name": "update"
+						},
+						"commit": {
+							"hash": "update123"
+						}
+					},
+					"destination": {
+						"branch": {
+							"name": "main"
+						},
+						"commit": {
+							"hash": "main456"
+						}
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "pullrequest:updated")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("synchronize"))
+			Expect(event.PullRequest.ID).To(Equal(99))
+		})
+
+		It("should parse PR fulfilled (merged) event", func() {
+			payload := `{
+				"pullrequest": {
+					"id": 50,
+					"title": "Merged PR",
+					"state": "MERGED",
+					"source": {
+						"branch": {
+							"name": "feature"
+						},
+						"commit": {
+							"hash": "feature123"
+						}
+					},
+					"destination": {
+						"branch": {
+							"name": "main"
+						},
+						"commit": {
+							"hash": "main789"
+						}
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "pullrequest:fulfilled")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("closed"))
+			Expect(event.PullRequest.Merged).To(BeTrue())
+		})
+
+		It("should parse PR rejected event", func() {
+			payload := `{
+				"pullrequest": {
+					"id": 60,
+					"title": "Rejected PR",
+					"state": "DECLINED",
+					"source": {
+						"branch": {
+							"name": "bad-feature"
+						},
+						"commit": {
+							"hash": "bad123"
+						}
+					},
+					"destination": {
+						"branch": {
+							"name": "main"
+						},
+						"commit": {
+							"hash": "main999"
+						}
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "pullrequest:rejected")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("closed"))
+			Expect(event.PullRequest.Merged).To(BeFalse())
+		})
+	})
+
+	Context("Unknown Events", func() {
+		It("should return ErrUnknownEvent for unsupported events", func() {
+			payload := `{}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "issue:created") // Unsupported
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret Validation", func() {
+		It("should allow ValidateSecret to be called", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "new123"
+								}
+							},
+							"old": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "old123"
+								}
+							}
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "bitbucket-secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Payloads", func() {
+		It("should handle malformed JSON", func() {
+			payload := `{invalid`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for empty changes array", func() {
+			payload := `{
+				"push": {
+					"changes": []
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			// Empty changes is treated as unknown event
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/gitea.go
+++ b/internal/webhookreceiver/webhooks/gitea.go
@@ -1,0 +1,117 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// GiteaParser parses Gitea and Forgejo webhooks (compatible format).
+type GiteaParser struct{}
+
+func (p GiteaParser) Parse(r *http.Request) (*WebhookEvent, error) {
+	// Gitea uses X-Gitea-Event, Forgejo uses X-Forgejo-Event
+	eventType := r.Header.Get("X-Gitea-Event")
+	forgejoEvent := r.Header.Get("X-Forgejo-Event")
+
+	if eventType == "" {
+		eventType = forgejoEvent
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	provider := "gitea"
+	if forgejoEvent != "" {
+		provider = "forgejo"
+	}
+
+	var event *WebhookEvent
+
+	switch eventType {
+	case "push":
+		event, err = p.parsePush(body, provider)
+	case "pull_request":
+		event, err = p.parsePullRequest(body, provider)
+	default:
+		return nil, ErrUnknownEvent{}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// ValidateSecret validates the Gitea/Forgejo webhook signature using HMAC-SHA256.
+// Gitea sends signatures in X-Gitea-Signature, Forgejo in X-Forgejo-Signature.
+func (p GiteaParser) ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error {
+	// TODO: Implement HMAC-SHA256 signature validation
+	// Expected header: X-Gitea-Signature or X-Forgejo-Signature
+	// For now, validation is not implemented
+	_ = secret // Placeholder to avoid unused variable
+	return nil
+}
+
+func (p GiteaParser) parsePush(body []byte, provider string) (*WebhookEvent, error) {
+	var payload struct {
+		Ref    string `json:"ref"`
+		Before string `json:"before"`
+		After  string `json:"after"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePush,
+		Push: &PushEvent{
+			Provider: provider,
+			Ref:      payload.Ref,
+			Before:   payload.Before,
+			After:    payload.After,
+		},
+	}, nil
+}
+
+func (p GiteaParser) parsePullRequest(body []byte, provider string) (*WebhookEvent, error) {
+	var payload struct {
+		Action      string `json:"action"`
+		Number      int    `json:"number"`
+		PullRequest struct {
+			Title  string `json:"title"`
+			Merged bool   `json:"merged"`
+			Head   struct {
+				Ref string `json:"ref"`
+				SHA string `json:"sha"`
+			} `json:"head"`
+			Base struct {
+				Ref string `json:"ref"`
+				SHA string `json:"sha"`
+			} `json:"base"`
+		} `json:"pull_request"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePullRequest,
+		PullRequest: &PullRequestEvent{
+			Provider: provider,
+			Action:   payload.Action,
+			ID:       payload.Number,
+			Title:    payload.PullRequest.Title,
+			Ref:      payload.PullRequest.Head.Ref,
+			SHA:      payload.PullRequest.Head.SHA,
+			BaseRef:  payload.PullRequest.Base.Ref,
+			BaseSHA:  payload.PullRequest.Base.SHA,
+			Merged:   payload.PullRequest.Merged,
+		},
+	}, nil
+}

--- a/internal/webhookreceiver/webhooks/gitea_test.go
+++ b/internal/webhookreceiver/webhooks/gitea_test.go
@@ -1,0 +1,264 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GiteaParser", func() {
+	var parser webhooks.GiteaParser
+
+	BeforeEach(func() {
+		parser = webhooks.GiteaParser{}
+	})
+
+	Context("Gitea Push Events", func() {
+		It("should parse Gitea push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc789"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("gitea"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+			Expect(event.Push.Before).To(Equal("abc123def456"))
+			Expect(event.Push.After).To(Equal("def456abc789"))
+		})
+	})
+
+	Context("Forgejo Push Events", func() {
+		It("should parse Forgejo push event and detect as Forgejo", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc789"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("forgejo"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+		})
+
+		It("should prefer Forgejo header when both are present", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+			req.Header.Set("X-Forgejo-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Provider).To(Equal("forgejo"))
+		})
+	})
+
+	Context("Pull Request Events", func() {
+		It("should parse Gitea PR opened event", func() {
+			payload := `{
+				"action": "opened",
+				"number": 42,
+				"pull_request": {
+					"title": "Add feature",
+					"merged": false,
+					"head": {
+						"ref": "feature",
+						"sha": "abc123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "def456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(event.PullRequest).NotTo(BeNil())
+
+			pr := event.PullRequest
+			Expect(pr.Provider).To(Equal("gitea"))
+			Expect(pr.Action).To(Equal("opened"))
+			Expect(pr.ID).To(Equal(42))
+			Expect(pr.Title).To(Equal("Add feature"))
+			Expect(pr.Ref).To(Equal("feature"))
+			Expect(pr.SHA).To(Equal("abc123"))
+			Expect(pr.BaseRef).To(Equal("main"))
+			Expect(pr.BaseSHA).To(Equal("def456"))
+			Expect(pr.Merged).To(BeFalse())
+		})
+
+		It("should parse Forgejo PR event", func() {
+			payload := `{
+				"action": "opened",
+				"number": 99,
+				"pull_request": {
+					"title": "Fix bug",
+					"merged": false,
+					"head": {
+						"ref": "fix",
+						"sha": "fix123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "main456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Provider).To(Equal("forgejo"))
+			Expect(event.PullRequest.ID).To(Equal(99))
+		})
+
+		It("should parse PR merged event", func() {
+			payload := `{
+				"action": "closed",
+				"number": 50,
+				"pull_request": {
+					"title": "Merge this",
+					"merged": true,
+					"head": {
+						"ref": "branch",
+						"sha": "sha1"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "sha2"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Merged).To(BeTrue())
+		})
+	})
+
+	Context("Unknown Events", func() {
+		It("should return ErrUnknownEvent for unsupported Gitea events", func() {
+			payload := `{}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "release") // Unsupported
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return ErrUnknownEvent for unsupported Forgejo events", func() {
+			payload := `{}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "issues")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret Validation", func() {
+		It("should allow ValidateSecret for Gitea", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("gitea"))
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow ValidateSecret for Forgejo", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("forgejo"))
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Payloads", func() {
+		It("should handle malformed JSON", func() {
+			payload := `{invalid json`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/github.go
+++ b/internal/webhookreceiver/webhooks/github.go
@@ -1,0 +1,106 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// GitHubParser parses GitHub webhooks.
+type GitHubParser struct{}
+
+func (p GitHubParser) Parse(r *http.Request) (*WebhookEvent, error) {
+	eventType := r.Header.Get("X-Github-Event")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var event *WebhookEvent
+
+	switch eventType {
+	case "push":
+		event, err = p.parsePush(body)
+	case "pull_request":
+		event, err = p.parsePullRequest(body)
+	default:
+		return nil, ErrUnknownEvent{}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// ValidateSecret validates the GitHub webhook signature using HMAC-SHA256.
+// GitHub sends signatures in X-Hub-Signature-256 (SHA256) or X-Hub-Signature (SHA1) headers.
+func (p GitHubParser) ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error {
+	// TODO: Implement HMAC-SHA256 signature validation
+	// Expected header: X-Hub-Signature-256 or X-Hub-Signature
+	// For now, validation is not implemented
+	_ = secret // Placeholder to avoid unused variable
+	return nil
+}
+
+func (p GitHubParser) parsePush(body []byte) (*WebhookEvent, error) {
+	var payload struct {
+		Ref    string `json:"ref"`
+		Before string `json:"before"`
+		After  string `json:"after"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePush,
+		Push: &PushEvent{
+			Provider: "github",
+			Ref:      payload.Ref,
+			Before:   payload.Before,
+			After:    payload.After,
+		},
+	}, nil
+}
+
+func (p GitHubParser) parsePullRequest(body []byte) (*WebhookEvent, error) {
+	var payload struct {
+		Action      string `json:"action"`
+		Number      int    `json:"number"`
+		PullRequest struct {
+			Title  string `json:"title"`
+			Merged bool   `json:"merged"`
+			Head   struct {
+				Ref string `json:"ref"`
+				SHA string `json:"sha"`
+			} `json:"head"`
+			Base struct {
+				Ref string `json:"ref"`
+				SHA string `json:"sha"`
+			} `json:"base"`
+		} `json:"pull_request"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePullRequest,
+		PullRequest: &PullRequestEvent{
+			Provider: "github",
+			Action:   payload.Action,
+			ID:       payload.Number,
+			Title:    payload.PullRequest.Title,
+			Ref:      payload.PullRequest.Head.Ref,
+			SHA:      payload.PullRequest.Head.SHA,
+			BaseRef:  payload.PullRequest.Base.Ref,
+			BaseSHA:  payload.PullRequest.Base.SHA,
+			Merged:   payload.PullRequest.Merged,
+		},
+	}, nil
+}

--- a/internal/webhookreceiver/webhooks/github_test.go
+++ b/internal/webhookreceiver/webhooks/github_test.go
@@ -1,0 +1,295 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GitHubParser", func() {
+	var parser webhooks.GitHubParser
+
+	BeforeEach(func() {
+		parser = webhooks.GitHubParser{}
+	})
+
+	Context("Push Events", func() {
+		It("should parse valid push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123def456",
+				"after": "def456abc789"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("github"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+			Expect(event.Push.Before).To(Equal("abc123def456"))
+			Expect(event.Push.After).To(Equal("def456abc789"))
+		})
+
+		It("should handle branch push", func() {
+			payload := `{
+				"ref": "refs/heads/feature/new-feature",
+				"before": "111111",
+				"after": "222222"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Ref).To(Equal("refs/heads/feature/new-feature"))
+		})
+
+		It("should handle tag push", func() {
+			payload := `{
+				"ref": "refs/tags/v1.0.0",
+				"before": "000000",
+				"after": "aaa111"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Ref).To(Equal("refs/tags/v1.0.0"))
+		})
+	})
+
+	Context("Pull Request Events", func() {
+		It("should parse PR opened event", func() {
+			payload := `{
+				"action": "opened",
+				"number": 42,
+				"pull_request": {
+					"title": "Add new feature",
+					"merged": false,
+					"head": {
+						"ref": "feature-branch",
+						"sha": "abc123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "def456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(event.PullRequest).NotTo(BeNil())
+
+			pr := event.PullRequest
+			Expect(pr.Provider).To(Equal("github"))
+			Expect(pr.Action).To(Equal("opened"))
+			Expect(pr.ID).To(Equal(42))
+			Expect(pr.Title).To(Equal("Add new feature"))
+			Expect(pr.Ref).To(Equal("feature-branch"))
+			Expect(pr.SHA).To(Equal("abc123"))
+			Expect(pr.BaseRef).To(Equal("main"))
+			Expect(pr.BaseSHA).To(Equal("def456"))
+			Expect(pr.Merged).To(BeFalse())
+		})
+
+		It("should parse PR synchronize event", func() {
+			payload := `{
+				"action": "synchronize",
+				"number": 123,
+				"pull_request": {
+					"title": "Update docs",
+					"merged": false,
+					"head": {
+						"ref": "docs-update",
+						"sha": "new123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "base456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("synchronize"))
+			Expect(event.PullRequest.ID).To(Equal(123))
+		})
+
+		It("should parse PR closed event with merged=true", func() {
+			payload := `{
+				"action": "closed",
+				"number": 99,
+				"pull_request": {
+					"title": "Fix bug",
+					"merged": true,
+					"head": {
+						"ref": "fix-bug",
+						"sha": "fix123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "main456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("closed"))
+			Expect(event.PullRequest.Merged).To(BeTrue())
+		})
+
+		It("should parse PR closed event with merged=false", func() {
+			payload := `{
+				"action": "closed",
+				"number": 99,
+				"pull_request": {
+					"title": "Fix bug",
+					"merged": false,
+					"head": {
+						"ref": "fix-bug",
+						"sha": "fix123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "main456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "pull_request")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("closed"))
+			Expect(event.PullRequest.Merged).To(BeFalse())
+		})
+	})
+
+	Context("Unknown Events", func() {
+		It("should return ErrUnknownEvent for unsupported event types", func() {
+			payload := `{"action": "created"}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "release") // Unsupported
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return ErrUnknownEvent for issues event", func() {
+			payload := `{"action": "opened"}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "issues")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret Validation", func() {
+		It("should not require secret validation", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+		})
+
+		It("should allow ValidateSecret to be called", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "test-secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Payloads", func() {
+		It("should handle malformed JSON", func() {
+			payload := `{invalid json`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should handle empty payload", func() {
+			payload := `{}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			// Empty fields are allowed, just zero values
+			Expect(event.Push.Ref).To(Equal(""))
+			Expect(event.Push.Before).To(Equal(""))
+			Expect(event.Push.After).To(Equal(""))
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/gitlab.go
+++ b/internal/webhookreceiver/webhooks/gitlab.go
@@ -1,0 +1,103 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// GitLabParser parses GitLab webhooks.
+type GitLabParser struct{}
+
+func (p GitLabParser) Parse(r *http.Request) (*WebhookEvent, error) {
+	eventType := r.Header.Get("X-Gitlab-Event")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var event *WebhookEvent
+
+	switch eventType {
+	case "Push Hook":
+		event, err = p.parsePush(body)
+	case "Merge Request Hook":
+		event, err = p.parseMergeRequest(body)
+	default:
+		return nil, ErrUnknownEvent{}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// ValidateSecret validates the GitLab webhook token.
+// GitLab sends the secret token in the X-Gitlab-Token header.
+func (p GitLabParser) ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error {
+	// TODO: Implement token validation
+	// Expected header: X-Gitlab-Token
+	// For now, validation is not implemented
+	_ = secret // Placeholder to avoid unused variable
+	return nil
+}
+
+func (p GitLabParser) parsePush(body []byte) (*WebhookEvent, error) {
+	var payload struct {
+		Ref    string `json:"ref"`
+		Before string `json:"before"`
+		After  string `json:"after"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePush,
+		Push: &PushEvent{
+			Provider: "gitlab",
+			Ref:      payload.Ref,
+			Before:   payload.Before,
+			After:    payload.After,
+		},
+	}, nil
+}
+
+func (p GitLabParser) parseMergeRequest(body []byte) (*WebhookEvent, error) {
+	var payload struct {
+		ObjectAttributes struct {
+			Action      string `json:"action"`
+			IID         int    `json:"iid"` // GitLab uses iid for MR number
+			Title       string `json:"title"`
+			State       string `json:"state"` // opened, closed, merged
+			MergeStatus string `json:"merge_status"`
+			LastCommit  struct {
+				ID string `json:"id"`
+			} `json:"last_commit"`
+			SourceBranch string `json:"source_branch"`
+			TargetBranch string `json:"target_branch"`
+		} `json:"object_attributes"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	return &WebhookEvent{
+		Type: EventTypePullRequest,
+		PullRequest: &PullRequestEvent{
+			Provider: "gitlab",
+			Action:   payload.ObjectAttributes.Action,
+			ID:       payload.ObjectAttributes.IID,
+			Title:    payload.ObjectAttributes.Title,
+			Ref:      payload.ObjectAttributes.SourceBranch,
+			SHA:      payload.ObjectAttributes.LastCommit.ID,
+			BaseRef:  payload.ObjectAttributes.TargetBranch,
+			Merged:   payload.ObjectAttributes.State == "merged",
+		},
+	}, nil
+}

--- a/internal/webhookreceiver/webhooks/gitlab_test.go
+++ b/internal/webhookreceiver/webhooks/gitlab_test.go
@@ -1,0 +1,198 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GitLabParser", func() {
+	var parser webhooks.GitLabParser
+
+	BeforeEach(func() {
+		parser = webhooks.GitLabParser{}
+	})
+
+	Context("Push Events", func() {
+		It("should parse valid push hook", func() {
+			payload := `{
+				"object_kind": "push",
+				"before": "abc123def456",
+				"after": "def456abc789",
+				"ref": "refs/heads/main"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(event.Push).NotTo(BeNil())
+			Expect(event.Push.Provider).To(Equal("gitlab"))
+			Expect(event.Push.Ref).To(Equal("refs/heads/main"))
+			Expect(event.Push.Before).To(Equal("abc123def456"))
+			Expect(event.Push.After).To(Equal("def456abc789"))
+		})
+
+		It("should handle branch push", func() {
+			payload := `{
+				"ref": "refs/heads/feature/test",
+				"before": "111111",
+				"after": "222222"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.Push.Ref).To(Equal("refs/heads/feature/test"))
+		})
+	})
+
+	Context("Merge Request Events", func() {
+		It("should parse MR opened event", func() {
+			payload := `{
+				"object_attributes": {
+					"action": "open",
+					"iid": 42,
+					"title": "Add new feature",
+					"state": "opened",
+					"source_branch": "feature-branch",
+					"target_branch": "main",
+					"last_commit": {
+						"id": "abc123"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Merge Request Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+			Expect(event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(event.PullRequest).NotTo(BeNil())
+
+			mr := event.PullRequest
+			Expect(mr.Provider).To(Equal("gitlab"))
+			Expect(mr.Action).To(Equal("open"))
+			Expect(mr.ID).To(Equal(42))
+			Expect(mr.Title).To(Equal("Add new feature"))
+			Expect(mr.Ref).To(Equal("feature-branch"))
+			Expect(mr.SHA).To(Equal("abc123"))
+			Expect(mr.BaseRef).To(Equal("main"))
+			Expect(mr.Merged).To(BeFalse())
+		})
+
+		It("should parse MR merged event", func() {
+			payload := `{
+				"object_attributes": {
+					"action": "merge",
+					"iid": 99,
+					"title": "Fix bug",
+					"state": "merged",
+					"source_branch": "fix-bug",
+					"target_branch": "main",
+					"last_commit": {
+						"id": "fix123"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Merge Request Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("merge"))
+			Expect(event.PullRequest.Merged).To(BeTrue())
+		})
+
+		It("should parse MR update event", func() {
+			payload := `{
+				"object_attributes": {
+					"action": "update",
+					"iid": 123,
+					"title": "Update docs",
+					"state": "opened",
+					"source_branch": "docs",
+					"target_branch": "main",
+					"last_commit": {
+						"id": "doc123"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Merge Request Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.PullRequest.Action).To(Equal("update"))
+			Expect(event.PullRequest.ID).To(Equal(123))
+		})
+	})
+
+	Context("Unknown Events", func() {
+		It("should return ErrUnknownEvent for unsupported events", func() {
+			payload := `{"action": "created"}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Tag Push Hook") // Unsupported
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret Validation", func() {
+		It("should allow ValidateSecret to be called", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+
+			event, err := parser.Parse(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+
+			// Validate with a secret (not implemented yet, but shouldn't error)
+			err = parser.ValidateSecret(req, event, "gitlab-token")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid Payloads", func() {
+		It("should handle malformed JSON", func() {
+			payload := `{invalid`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+
+			_, err := parser.Parse(req)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/parseany_test.go
+++ b/internal/webhookreceiver/webhooks/parseany_test.go
@@ -1,0 +1,223 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver/webhooks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseAny", func() {
+	Context("When parsing webhooks from different providers", func() {
+		It("should parse GitHub push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("github"))
+		})
+
+		It("should parse GitLab push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitlab-Event", "Push Hook")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("gitlab"))
+		})
+
+		It("should parse Gitea push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Gitea-Event", "push")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("gitea"))
+		})
+
+		It("should parse Forgejo push event", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Forgejo-Event", "push")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("forgejo"))
+		})
+
+		It("should parse Bitbucket push event", func() {
+			payload := `{
+				"push": {
+					"changes": [
+						{
+							"new": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "def456"
+								}
+							},
+							"old": {
+								"name": "main",
+								"type": "branch",
+								"target": {
+									"hash": "abc123"
+								}
+							}
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Event-Key", "repo:push")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("bitbucket"))
+		})
+
+		It("should parse Azure DevOps push event", func() {
+			payload := `{
+				"eventType": "git.push",
+				"resource": {
+					"refUpdates": [
+						{
+							"name": "refs/heads/main",
+							"oldObjectId": "abc123",
+							"newObjectId": "def456"
+						}
+					]
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePush))
+			Expect(result.Event.Push.Provider).To(Equal("azure"))
+		})
+
+		It("should parse GitHub pull request event", func() {
+			payload := `{
+				"action": "opened",
+				"number": 42,
+				"pull_request": {
+					"title": "Test PR",
+					"merged": false,
+					"head": {
+						"ref": "feature",
+						"sha": "abc123"
+					},
+					"base": {
+						"ref": "main",
+						"sha": "def456"
+					}
+				}
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "pull_request")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).NotTo(BeNil())
+			Expect(result.Event.Type).To(Equal(webhooks.EventTypePullRequest))
+			Expect(result.Event.PullRequest.Provider).To(Equal("github"))
+		})
+	})
+
+	Context("When no parser can handle the request", func() {
+		It("should return ErrUnknownEvent", func() {
+			payload := `{"some": "data"}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Custom-Header", "unknown")
+
+			_, err := webhooks.ParseAny(req)
+
+			Expect(err).To(HaveOccurred())
+			_, ok := err.(webhooks.ErrUnknownEvent)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Context("Secret validation", func() {
+		It("should allow ValidateSecret to be called on result", func() {
+			payload := `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+
+			req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(payload))
+			req.Header.Set("X-Github-Event", "push")
+
+			result, err := webhooks.ParseAny(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			// Validate with empty secret (should not error)
+			err = result.ValidateSecret("")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Validate with a secret (not implemented yet, but shouldn't panic)
+			err = result.ValidateSecret("test-secret")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhookreceiver/webhooks/testdata_test.go
+++ b/internal/webhookreceiver/webhooks/testdata_test.go
@@ -1,0 +1,11 @@
+package webhooks_test
+
+// Common test constants used across multiple test files
+const (
+	invalidJSON       = `{invalid`
+	simplePushPayload = `{
+				"ref": "refs/heads/main",
+				"before": "abc123",
+				"after": "def456"
+			}`
+)

--- a/internal/webhookreceiver/webhooks/webhooks.go
+++ b/internal/webhookreceiver/webhooks/webhooks.go
@@ -1,0 +1,136 @@
+package webhooks
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+// EventType represents the type of webhook event.
+type EventType string
+
+const (
+	EventTypePush        EventType = "push"
+	EventTypePullRequest EventType = "pull_request"
+	EventTypeUnknown     EventType = "unknown"
+)
+
+// SecretFunc is a function that returns the webhook secret for validation.
+// If it returns an empty string, validation is skipped.
+// The function receives the parsed event to allow secret lookup based on repository/provider.
+type SecretFunc func(event *WebhookEvent) (string, error)
+
+// ValidationError is returned when webhook signature validation fails.
+type ValidationError struct {
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	return "webhook validation failed: " + e.Message
+}
+
+// PushEvent represents a push/commit event from any SCM provider.
+type PushEvent struct {
+	Provider string // github, gitlab, gitea, forgejo, bitbucket, azure
+	Ref      string // refs/heads/main
+	Before   string // SHA before push
+	After    string // SHA after push
+}
+
+// PullRequestEvent represents a pull/merge request event from any SCM provider.
+type PullRequestEvent struct {
+	Provider string // github, gitlab, gitea, forgejo, bitbucket, azure
+	Action   string // opened, closed, merged, synchronize, etc.
+	ID       int    // PR/MR ID or number
+	Title    string
+	Ref      string // Head branch ref
+	SHA      string // Head commit SHA
+	BaseRef  string // Base/target branch
+	BaseSHA  string // Base commit SHA
+	Merged   bool   // Whether PR was merged (for closed events)
+}
+
+// WebhookEvent is a union type for different webhook events.
+type WebhookEvent struct {
+	Type        EventType
+	Push        *PushEvent
+	PullRequest *PullRequestEvent
+}
+
+// Parser can parse webhook requests into WebhookEvents.
+type Parser interface {
+	// Parse parses an HTTP request and returns a WebhookEvent.
+	// Secret validation is NOT performed during parsing.
+	Parse(r *http.Request) (*WebhookEvent, error)
+
+	// ValidateSecret validates the webhook signature/secret.
+	// Returns nil if validation succeeds or is not applicable.
+	// Returns ValidationError if validation fails.
+	ValidateSecret(r *http.Request, event *WebhookEvent, secret string) error
+}
+
+// ParseResult contains a parsed webhook event and allows secret validation.
+type ParseResult struct {
+	Event   *WebhookEvent
+	parser  Parser
+	request *http.Request
+}
+
+// ValidateSecret validates the webhook secret/signature for this event.
+// If secret is empty, validation is skipped and nil is returned.
+// Returns ValidationError if validation fails.
+func (pr *ParseResult) ValidateSecret(secret string) error {
+	if secret == "" {
+		return nil // Skip validation if no secret provided
+	}
+	return pr.parser.ValidateSecret(pr.request, pr.Event, secret)
+}
+
+// ErrUnknownEvent is returned when the webhook event type is not recognized.
+type ErrUnknownEvent struct{}
+
+func (e ErrUnknownEvent) Error() string {
+	return "unknown event type"
+}
+
+// ParseAny attempts to parse a webhook request using all available parsers.
+// It tries each parser in sequence (GitHub, GitLab, Gitea/Forgejo, Bitbucket, Azure DevOps)
+// and returns the first successful parse result.
+// Secret validation is NOT performed - call ValidateSecret on the returned ParseResult.
+// If no parser succeeds, it returns an error.
+func ParseAny(r *http.Request) (*ParseResult, error) {
+	// Read the body once and buffer it so we can replay it for each parser
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	parsers := []Parser{
+		GitHubParser{},
+		GitLabParser{},
+		GiteaParser{},
+		BitbucketParser{},
+		AzureParser{},
+	}
+
+	for _, parser := range parsers {
+		// Create a new request with a fresh body reader for each parser
+		reqCopy := r.Clone(r.Context())
+		reqCopy.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+		if event, err := parser.Parse(reqCopy); err == nil {
+			// Store the original request (with buffered body) for later validation
+			originalReq := r.Clone(r.Context())
+			originalReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			return &ParseResult{
+				Event:   event,
+				parser:  parser,
+				request: originalReq,
+			}, nil
+		}
+	}
+
+	return nil, ErrUnknownEvent{}
+}

--- a/internal/webhookreceiver/webhooks/webhooks_suite_test.go
+++ b/internal/webhookreceiver/webhooks/webhooks_suite_test.go
@@ -1,0 +1,18 @@
+package webhooks_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebhooks(t *testing.T) {
+	t.Parallel()
+
+	RegisterFailHandler(Fail)
+
+	c, _ := GinkgoConfiguration()
+
+	RunSpecs(t, "Webhooks Suite", c)
+}


### PR DESCRIPTION
a step towards: https://cloud-native.slack.com/archives/C06NXPYQ06B/p1765536752779509

Also going to start trigginer on PullReqest events so make sense to start using this