### PR TITLE
chore: improve error message for missing app installation

### DIFF
--- a/internal/scms/github/git_operations.go
+++ b/internal/scms/github/git_operations.go
@@ -197,5 +197,5 @@ func GetClient(ctx context.Context, scmProvider v1alpha1.GenericScmProvider, sec
 		return getInstallationClient(scmProvider, secret, id)
 	}
 	appInstallationIdCacheMutex.Unlock()
-	return nil, nil, fmt.Errorf("installation not found for org: %s", org)
+	return nil, nil, fmt.Errorf("installation of app %d not found for org: %s", scmProvider.GetSpec().GitHub.AppID, org)
 }


### PR DESCRIPTION
Makes it just slightly easier to find the app to install. Getting the app name would have been a lot more work.