### PR TITLE
docs: link directly to GH page to create new app

### DIFF
--- a/docs/tutorial-argocd-apps.md
+++ b/docs/tutorial-argocd-apps.md
@@ -88,7 +88,7 @@ Argo provides an example repository: [https://github.com/argoproj/argocd-example
 
 In your GitHub account, go to Settings > Developer settings > GitHub Apps.
 
-Click on `New GitHub App`, pass the MFA challenge.
+Click on [`New GitHub App`](https://github.com/settings/apps/new), pass the MFA challenge.
 
 Fill up the form with the following (leave non specified to defaults):
 


### PR DESCRIPTION
The link is the same no matter the account, so it's fine to link directly.