### PR TITLE
fix: run test-e2e locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
+	kind get clusters | grep -q '^kind$$' || kind create cluster --name kind
 	go test ./test/e2e/ -v
 
 .PHONY: test-deps


### PR DESCRIPTION
## What

In CI it will create a kind cluster, but locally it will fails if a cluster is not created with that particular name