### PR TITLE
chore: remove unnecessary wrapper funcs

### DIFF
--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -626,25 +626,14 @@ func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.
 	return commitStatus, nil
 }
 
-func (r *ArgoCDCommitStatusReconciler) getPromotionStrategy(ctx context.Context, namespace string, promotionStrategyRef promoterv1alpha1.ObjectReference) (*promoterv1alpha1.PromotionStrategy, error) {
-	promotionStrategy := promoterv1alpha1.PromotionStrategy{}
-	err := r.localClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: promotionStrategyRef.Name}, &promotionStrategy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get PromotionStrategy object: %w", err)
-	}
-	return &promotionStrategy, nil
-}
-
 func (r *ArgoCDCommitStatusReconciler) getGitAuthProvider(ctx context.Context, argoCDCommitStatus promoterv1alpha1.ArgoCDCommitStatus) (scms.GitOperationsProvider, promoterv1alpha1.ObjectReference, error) {
-	ps, err := r.getPromotionStrategy(ctx, argoCDCommitStatus.GetNamespace(), argoCDCommitStatus.Spec.PromotionStrategyRef)
-	if ps == nil {
-		return nil, promoterv1alpha1.ObjectReference{}, fmt.Errorf("PromotionStrategy is nil for ArgoCDCommitStatus %s", argoCDCommitStatus.Name)
-	}
+	ps := promoterv1alpha1.PromotionStrategy{}
+	err := r.localClient.Get(ctx, client.ObjectKey{Namespace: argoCDCommitStatus.GetNamespace(), Name: argoCDCommitStatus.Spec.PromotionStrategyRef.Name}, &ps)
 	if err != nil {
-		return nil, ps.Spec.RepositoryReference, fmt.Errorf("failed to get PromotionStrategy from ArgoCDCommitStatus %s: %w", argoCDCommitStatus.Name, err)
+		return nil, promoterv1alpha1.ObjectReference{}, fmt.Errorf("failed to get PromotionStrategy from ArgoCDCommitStatus %s: %w", argoCDCommitStatus.Name, err)
 	}
 
-	scmProvider, secret, err := utils.GetScmProviderAndSecretFromRepositoryReference(ctx, r.localClient, r.SettingsMgr.GetControllerNamespace(), ps.Spec.RepositoryReference, ps)
+	scmProvider, secret, err := utils.GetScmProviderAndSecretFromRepositoryReference(ctx, r.localClient, r.SettingsMgr.GetControllerNamespace(), ps.Spec.RepositoryReference, &ps)
 	if err != nil {
 		return nil, ps.Spec.RepositoryReference, fmt.Errorf("failed to get ScmProvider and secret for PromotionStrategy %q: %w", ps.Name, err)
 	}


### PR DESCRIPTION
I saw an error message that looked unnecessarily wrong, and realized we have a couple wrapper funcs that are unnecessary.

```diff
- failed to get git auth provider for ScmProvider "gitops-promoter-demo-scm": failed to create git operations provider: failed to create GitHub Auth Provider: failed to create GitHub client: installation of app 2762619 not found for org: crenshaw-dev
+ failed to get git auth provider for ScmProvider "gitops-promoter-demo-scm": failed to create GitHub Auth Provider: failed to create GitHub client: installation of app 2762619 not found for org: crenshaw-dev
```