### PR TITLE
fix(rbac): add events.k8s.io API group permission to manager role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,13 @@ rules:
   - create
   - patch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
## Summary
- Add RBAC permission for `events.k8s.io` API group to fix event creation failures

## Problem
The controller fails to create events with:
```
events.events.k8s.io is forbidden: User "system:serviceaccount:promoter-system:promoter-controller-manager" cannot create resource "events" in API group "events.k8s.io"
```

## Root Cause
The `promoter-manager-role` only has permissions for the legacy core API events (`apiGroups: [""]`), but controller-runtime uses `events.k8s.io/v1` API by default.

## Solution
Add a rule for `events.k8s.io` API group alongside the existing core API rule.

## Test plan
- [ ] Deploy the fix to a test cluster
- [ ] Verify events are created successfully in target namespaces

Fixes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)