### PR TITLE
chore: add cli version information in project

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-cliVersion: 4.11.1
+cliVersion: 4.10.1
 domain: argoproj.io
 layout:
 - go.kubebuilder.io/v4


### PR DESCRIPTION
## What

Add `cliVersion` in PROJECT

## Why

This is needed when updating kubebuilder see https://book.kubebuilder.io/migrations.html?highlight=migrat#recommended-use-alpha-update-to-upgrade-without-losing-customisations-logic-behind-autoupdategithub-action

## Now 
```
ERROR CLI run failed error=error executing command: failed to prepare update: failed to determine the version to use for the upgrade from: no version specified in PROJECT file. Please use --from-version flag to specify the version to update from
```

## After the change

```
WARN No --from-branch specified, using 'main' as default 
INFO Your project already uses the latest version. No action taken. version=v4.11.1
```