### PR TITLE
fix(ui): use SCM-specific commit URL paths

### DIFF
--- a/ui/shared/src/utils/util.ts
+++ b/ui/shared/src/utils/util.ts
@@ -25,7 +25,14 @@ export const timeAgo = (dateString: string): string => {
 export function getCommitUrl(repoUrl: string, sha: string): string {
   if (!repoUrl || !sha) return '';
   const cleanRepoUrl = repoUrl.replace(/\/$/, '');
-  return `${cleanRepoUrl}/commit/${sha}`;
+  // SCM-specific commit URL path patterns, keyed by domain.
+  // Fallback is '/commit/' which works for GitHub, Gitea, Forgejo, and Azure DevOps.
+  const scmCommitPaths: { domain: string; path: string }[] = [
+    { domain: 'bitbucket.org', path: '/commits/' },
+    { domain: 'gitlab.com', path: '/-/commit/' },
+  ];
+  const match = scmCommitPaths.find(scm => cleanRepoUrl.includes(scm.domain));
+  return `${cleanRepoUrl}${match ? match.path : '/commit/'}${sha}`;
 }
   
 //Extract name from 'Name <email>'


### PR DESCRIPTION
## Summary

The `getCommitUrl()` function in the ArgoCD extension UI was hardcoded to use `/commit/{sha}` for all SCM providers. This works for GitHub, Gitea, Forgejo, and Azure DevOps, but produces broken links for:

- **Bitbucket Cloud** — expects `/commits/{sha}` (plural)
- **GitLab** — expects `/-/commit/{sha}`

## Fix

Added a domain-based lookup table inside `getCommitUrl()` that maps SCM domains to their correct commit URL path pattern, with `/commit/` as the default fallback. Adding support for a new SCM is a single line addition.

## Images

Hyperlink

<img width="580" height="389" alt="before_1" src="https://github.com/user-attachments/assets/75cbc825-583d-460d-9ae9-68213819f2c4" />

Wrong URL for Bitbucket Cloud

<img width="1363" height="483" alt="before_2" src="https://github.com/user-attachments/assets/2bde3804-dd9a-42b4-a4aa-0cf2a9a44c39" />
