### PR TITLE
fix(ui): gracefully handle missing PromotionStrategy in AppView extension

### DIFF
--- a/ui/extension/AppViewExtension.tsx
+++ b/ui/extension/AppViewExtension.tsx
@@ -8,17 +8,12 @@ const AppViewExtension = ({ tree, application }: AppViewComponentProps) => {
     () => tree.nodes.filter((node) => node.kind === "PromotionStrategy"),
     [tree.nodes]
   );
-  if (promotionStrategyNodes.length !== 1) {
-    throw new Error(
-      `Expected exactly one PromotionStrategy resource in Gitops Promoter Extension, found ${promotionStrategyNodes.length}`
-    );
-  }
-
   const [promotionStrategy, setPromotionStrategy] =
     useState<PromotionStrategy>();
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    if (promotionStrategyNodes.length !== 1) return;
     const promotionStrategyNode = promotionStrategyNodes[0];
     const group = "promoter.argoproj.io";
     const url = `/api/v1/applications/${application.metadata.name}/resource?name=${promotionStrategyNode.name}&appNamespace=${application.metadata.namespace}&namespace=${promotionStrategyNode.namespace}&resourceName=${promotionStrategyNode.name}&version=${promotionStrategyNode?.version}&kind=${promotionStrategyNode.kind}&group=${group}`;
@@ -39,6 +34,13 @@ const AppViewExtension = ({ tree, application }: AppViewComponentProps) => {
         throw new Error("Error fetching promotion strategy data: " + err);
       });
   }, [promotionStrategyNodes, application.metadata.name, application.metadata.namespace]);
+
+  if (promotionStrategyNodes.length === 0) {
+    return <div>No PromotionStrategy resource found for this application.</div>;
+  }
+  if (promotionStrategyNodes.length > 1) {
+    return <div>Expected exactly one PromotionStrategy resource, found {promotionStrategyNodes.length}.</div>;
+  }
   if (isLoading && !promotionStrategy) {
     return <div>Loading...</div>;
   }


### PR DESCRIPTION
## Summary

The AppView extension crashes with an unhandled error when opened on ArgoCD Applications that don't have a PromotionStrategy resource in their resource tree.

**Error:** `Expected exactly one PromotionStrategy resource in Gitops Promoter Extension, found 0`

This happens because the component throws before React hooks (`useState`, `useEffect`) are called.

## Fix

- Move `useState` and `useEffect` hooks above the conditional checks
- Add an early return guard inside `useEffect` when the count is not exactly 1
- Replace the `throw` with graceful `return` messages after hooks, so the extension renders a message instead of crashing ArgoCD

## Before

Clicking the PromotionStrategy tab on any app without promotion CRDs crashes with `Something went wrong!` and a stacktrace.

<img width="604" height="348" alt="image" src="https://github.com/user-attachments/assets/6e7add0d-cde3-43dd-8c72-c203c9c6aeab" />


## After

Shows a simple message: "No PromotionStrategy resource found for this application."

<img width="2304" height="629" alt="image" src="https://github.com/user-attachments/assets/feb29f84-e292-4949-8707-d814e41d9660" />


