### PR TITLE
fix: recover from lost status update after successful provider merge/close

### DIFF
--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -701,6 +701,90 @@ var _ = Describe("PullRequest Controller", func() {
 		})
 	})
 
+	Context("When a controller-initiated merge already completed on provider but status update was lost", func() {
+		var ctx context.Context
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var pullRequest *promoterv1alpha1.PullRequest
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			By("Creating test resources")
+			name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "merge-already-completed")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			By("Waiting for PullRequest to be open")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		It("should recover when PR is no longer open on provider and spec.state is merged", func() {
+			By("Simulating: merge succeeded on provider but status update was lost")
+			// Delete the PR from the fake provider to simulate that it was already merged
+			// on the provider side (FindOpen will return false)
+			fakeProvider := fake.NewFakePullRequestProvider(k8sClient)
+			Expect(fakeProvider.DeletePullRequest(ctx, *pullRequest)).To(Succeed())
+
+			By("Setting spec.state to merged (simulating CTP controller's merge request)")
+			// This simulates the CTP controller having patched spec.state to "merged",
+			// but the PR controller's status update failing after a successful provider merge.
+			// On the next reconcile, the controller should detect that the PR is no longer
+			// open and set status.state to "merged" instead of retrying the merge.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestMerged
+				g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Verifying the PullRequest is cleaned up (not stuck in error loop)")
+			// Before the fix, the controller would try to merge again on the provider,
+			// get "already closed" error, and loop forever with Ready=False.
+			// After the fix, syncStateFromProvider detects the PR is gone, sets
+			// status.state="merged", and requeues for cleanup.
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		It("should recover when PR is no longer open on provider and spec.state is closed", func() {
+			By("Simulating: close succeeded on provider but status update was lost")
+			fakeProvider := fake.NewFakePullRequestProvider(k8sClient)
+			Expect(fakeProvider.DeletePullRequest(ctx, *pullRequest)).To(Succeed())
+
+			By("Setting spec.state to closed")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestClosed
+				g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Verifying the PullRequest is cleaned up")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
+
 	Context("When a PullRequest is externally merged or closed", func() {
 		var ctx context.Context
 		var name string


### PR DESCRIPTION
## Problem

When the PullRequest controller successfully merges (or closes) a PR on the SCM provider, but the subsequent Kubernetes status update fails due to a resource version conflict, the controller enters an infinite error loop:

1. CTP controller SSA-patches `spec.state="merged"` on the PullRequest resource (bumps `resourceVersion`)
2. PR controller (already mid-reconcile with the old `resourceVersion`) calls `provider.Merge()` — **succeeds on the SCM**
3. Sets `status.state="merged"` in memory
4. Deferred `HandleReconciliationResult` tries to persist the status — **fails** (conflict, `resourceVersion` changed in step 1)
5. Next reconcile: fetches PR from k8s with stale `status.state="open"`
6. `FindOpen` returns `false` (PR is merged on the provider, not open)
7. `syncStateFromProvider` sees `spec.state="merged"` + not found → **falls through** with just a log message
8. `handleStateTransitions` tries to merge **again** → provider rejects (e.g., Bitbucket: `400 "This pull request is already closed"`)
9. PR gets `Ready=False` permanently, CTP inherits it, PromotionStrategy is blocked

This is especially likely when SCM webhooks are configured, as the push event from the merge creates additional concurrent reconciles that increase the chance of a resource version conflict.

### Evidence from a live cluster (Bitbucket Cloud)

```
# Both dev and tst stuck with Ready=False, Active Dry SHA == Proposed Dry SHA
$ kubectl get changetransferpolicies -n argocd
NAME                                               PR STATE   READY
gitops-emoji-kube-live-environments-dev-3d96e91c   open       False
gitops-emoji-kube-live-environments-tst-b5721ac    open       False

# PullRequest resources show the root cause: spec.state=merged but status.state=open
spec:
  state: merged
status:
  state: open
  conditions:
  - message: Reconciliation failed: failed to merge pull request: failed to merge
      request: unexpected status 400 Bad Request, body: {"type": "error", "error":
      {"message": "newstatus: This pull request is already closed."}}
    reason: ReconciliationError
    status: "False"
    type: Ready
```

## Fix

In `syncStateFromProvider`, when `spec.state` is `"merged"` or `"closed"` and the PR is not found as open on the provider, set `status.state` to match `spec.state` and requeue for cleanup. This follows the same requeue-then-cleanup pattern already used for externally merged/closed PRs.


## Tests

Added two test cases covering:
- Recovery when `spec.state="merged"` and PR is no longer on the provider
- Recovery when `spec.state="closed"` and PR is no longer on the provider

## Verified

Deployed to a live cluster with Bitbucket Cloud + webhooks. Both stuck PRs recovered immediately after deploying the fix.

## Images

<img width="1382" height="826" alt="image" src="https://github.com/user-attachments/assets/94647cea-7588-4872-bcb9-5d1ffd76c1cb" />

<img width="1507" height="498" alt="image" src="https://github.com/user-attachments/assets/45d36a66-27a4-4aa5-90ee-8bc544952455" />
