### PR TITLE
chore: pin docker image in release CI

### DIFF
--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@206b75dbd282c4008313f59196a28caf84eb4198
+        version: type=image,tag=29.2.1
+    
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@206b75dbd282c4008313f59196a28caf84eb4198
+        version: type=image,tag=29.2.1
+
       - name: Extract version from commit message
         id: extract_version
         env:


### PR DESCRIPTION
## What

Pin docker version


## Why

The one pre installed by the runner is one year old see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

## Extra
Trying to better understand https://github.com/argoproj-labs/gitops-promoter/issues/1056 
