### PR TITLE
fix(pipeline): security issue for dev packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,11 @@ run-dashboard: build-dashboard
 
 .PHONY: lint-dashboard
 lint-dashboard: ## Run dashboard type-check, lint and audit checks
-	cd ui/dashboard && npm run type-check && npm run lint && npm audit
+	cd ui/dashboard && npm run type-check && npm run lint && npm audit --omit=dev
 
 .PHONY: lint-extension
 lint-extension: ## Run extension type-check, lint and audit checks
-	cd ui/extension && npm run type-check && npm run lint && npm audit
+	cd ui/extension && npm run type-check && npm run lint && npm audit --omit=dev
 
 .PHONY: lint-ui
 lint-ui: lint-dashboard lint-extension ## Run all UI checks


### PR DESCRIPTION
## What

There is a new vulnerability on Ajv npm lib.
This is not an ideal fix, but this in unblocking development for now. 

Adding override with `ajv` newer version is not enough


## Why

See https://github.com/argoproj-labs/gitops-promoter/actions/runs/22108514421/job/63898060511?pr=1051

```
> dashboard@0.0.0 lint
> eslint "src/**/*.{ts,tsx}"

# npm audit report

ajv  <8.18.0
Severity: moderate
ajv has ReDoS when using $data option - https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
No fix available
node_modules/ajv
  @eslint/eslintrc  *
  Depends on vulnerable versions of ajv
```

## Previous attempts

-https://github.com/argoproj-labs/gitops-promoter/pull/1063 
-https://github.com/argoproj-labs/gitops-promoter/pull/1062