### PR TITLE
fix(demo): cli remove replicaCount

### DIFF
--- a/cmd/demo/helm-guestbook/staging-values.yaml
+++ b/cmd/demo/helm-guestbook/staging-values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: gcr.io/google-samples/gb-frontend
   tag: v5

--- a/cmd/demo/helm-guestbook/values-production-east.yaml
+++ b/cmd/demo/helm-guestbook/values-production-east.yaml
@@ -2,5 +2,3 @@ service:
   type: NodePort
 
 region: us-east-1
-
-replicaCount: 2


### PR DESCRIPTION
## What

Removing replicacount in overrides 


## Why

It is better to have it inherit from values.yaml so when changing this value it can go through the environments and it creates PR.