### PR TITLE
feat: Allow CS label to prevent SCM reconciliation

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -4,6 +4,9 @@ package v1alpha1
 // PromotionStrategy CR
 const CommitStatusLabel = "promoter.argoproj.io/commit-status"
 
+// ReconcileLabel is the label used to identify whether a resource should be reconciled by its controller
+const ReconcileLabel = "promoter.argoproj.io/reconcile"
+
 // PreviousEnvProposedCommitPrefixNameLabel is the prefix name for copied proposed commits
 const PreviousEnvProposedCommitPrefixNameLabel = "promoter-previous-env-"
 

--- a/internal/controller/commitstatus_controller.go
+++ b/internal/controller/commitstatus_controller.go
@@ -92,6 +92,11 @@ func (r *CommitStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to get CommitStatus %q: %w", req.Name, err)
 	}
 
+	// If resource has opted out from reconciliation, skip it
+	if cs.Labels != nil && cs.Labels[promoterv1alpha1.ReconcileLabel] == "false" {
+		return ctrl.Result{}, nil
+	}
+
 	// Remove any existing Ready condition. We want to start fresh.
 	meta.RemoveStatusCondition(cs.GetConditions(), string(promoterConditions.Ready))
 

--- a/internal/controller/commitstatus_controller_test.go
+++ b/internal/controller/commitstatus_controller_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	_ "embed"
+	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -26,8 +28,10 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
@@ -220,8 +224,54 @@ var _ = Describe("CommitStatus Controller", func() {
 			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
 			Expect(k8sClient.Create(ctx, commitStatus)).To(Succeed())
 
+			By("Verifying CommitStatusSet events were recorded")
+			Eventually(func(g Gomega) {
+				events, err := eventsForCommitStatus(ctx, commitStatus)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(events).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("When reconciling a CommitStatus with the reconcile label set to false", func() {
+		ctx := context.Background()
+
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var commitStatus *promoterv1alpha1.CommitStatus
+
+		BeforeEach(func() {
+			scmSecret, scmProvider, gitRepo, commitStatus = commitStatusResources(ctx, "test-reconcile-false")
+			// Set the reconcile label to false
+			commitStatus.Labels = map[string]string{
+				promoterv1alpha1.ReconcileLabel: "false",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, commitStatus)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Cleaning up resources")
+			Expect(k8sClient.Delete(ctx, commitStatus)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, scmSecret)).To(Succeed())
+		})
+
+		It("should skip pushing the status to SCM", func() {
+			By("Verifying no CommitStatusSet events were recorded")
+			Consistently(func(g Gomega) {
+				events, err := eventsForCommitStatus(ctx, commitStatus)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(events).To(BeEmpty())
+			}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 		})
 	})
 
@@ -428,4 +478,21 @@ func commitStatusResources(ctx context.Context, name string) (*v1.Secret, *promo
 	}
 
 	return scmSecret, scmProvider, gitRepo, commitStatus
+}
+
+func eventsForCommitStatus(ctx context.Context, commitStatus *promoterv1alpha1.CommitStatus) ([]v1.Event, error) {
+	events := &v1.EventList{}
+	err := k8sClient.List(ctx, events, client.InNamespace(commitStatus.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events: %w", err)
+	}
+
+	var filteredEvents []v1.Event
+	for _, e := range events.Items {
+		if e.InvolvedObject.Name == commitStatus.Name && e.Reason == constants.CommitStatusSetReason {
+			filteredEvents = append(filteredEvents, e)
+		}
+	}
+
+	return filteredEvents, nil
 }


### PR DESCRIPTION
Support a label that prevents CommitStatus to be pushed back into SCM

First step for https://github.com/argoproj-labs/gitops-promoter/issues/1165 proposal