### PR TITLE
feat(ci): add job to check if the produced helm chart is valid

### DIFF
--- a/.github/workflows/kubebuilder_helm.yaml
+++ b/.github/workflows/kubebuilder_helm.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
 
+# this version will need to match the one in https://github.com/argoproj-labs/gitops-promoter-helm/
 env:
   KUBEBUILDER_VERSION: v4.11.1
 


### PR DESCRIPTION
## What

Add a new CI check, that will fail if the generated helm chart is not valid.

## Why

We have seen couple of time that the helm chart generated won't be valid and will fail, we want to shift left and get the signal early.
E.g https://github.com/kubernetes-sigs/kubebuilder/issues/5527

## Test

I tested on my own repo https://github.com/emirot/gitops-promoter/actions/runs/23023820776/job/66866665754
Tested on an older commit reproduced what we saw on gitops-promoter-helm

<img width="1262" height="245" alt="Screenshot 2026-03-12 at 11 40 13 AM" src="https://github.com/user-attachments/assets/10d04116-89bc-4d1a-80c5-536e4270f904" />

