### PR TITLE
fix: resource name validation

### DIFF
--- a/api/v1alpha1/argocdcommitstatus_types.go
+++ b/api/v1alpha1/argocdcommitstatus_types.go
@@ -118,7 +118,7 @@ type ApplicationsSelected struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`
 	Name string `json:"name"`
 	// Phase is the current phase of the commit status.
 	// +required

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -79,7 +79,7 @@ type ObjectReference struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`
 	Name string `json:"name"`
 }
 

--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -48,7 +48,7 @@ type ScmProviderObjectReference struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`
 	Name string `json:"name"`
 }
 

--- a/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
@@ -103,7 +103,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -185,7 +185,7 @@ spec:
                       description: Name is the name of the Argo CD application.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                       type: string
                     namespace:
                       description: Namespace is the namespace of the Argo CD application.

--- a/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
@@ -89,7 +89,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
@@ -72,7 +72,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_gitcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_gitcommitstatuses.yaml
@@ -132,7 +132,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
+++ b/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
@@ -191,7 +191,7 @@ spec:
                     description: Name is the name of the resource being referenced
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - kind

--- a/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
@@ -147,7 +147,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -84,7 +84,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_timedcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_timedcommitstatuses.yaml
@@ -74,7 +74,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
@@ -434,7 +434,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -115,7 +115,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -197,7 +197,7 @@ spec:
                       description: Name is the name of the Argo CD application.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                       type: string
                     namespace:
                       description: Namespace is the namespace of the Argo CD application.
@@ -389,7 +389,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -1887,7 +1887,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -3925,7 +3925,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -4294,7 +4294,7 @@ spec:
                     description: Name is the name of the resource being referenced
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - kind
@@ -4527,7 +4527,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -5886,7 +5886,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -6409,7 +6409,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name
@@ -6979,7 +6979,7 @@ spec:
                     description: Name is the name of the object to refer to.
                     maxLength: 253
                     minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - name


### PR DESCRIPTION
Resource names are allowed to contain dots: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names