### PR TITLE
fix: set default log level to info

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -425,6 +425,7 @@ func newCommand() *cobra.Command {
 
 	opts := zap.Options{
 		Development: true,
+		Level:       zapcore.InfoLevel, // default to info; use --zap-log-level=debug or =5 for verbose
 		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
 	}
 


### PR DESCRIPTION
we have zap configured as development mode to remove the sampling, however in development mode we default to debug this sets the proper default to info.

helps: https://github.com/argoproj-labs/gitops-promoter/issues/1212