### PR TITLE
fix(wrcs): resolve GitRepository name correctly in SCM host validation

### DIFF
--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -1041,7 +1041,8 @@ func (r *WebRequestCommitStatusReconciler) validateURLHostAgainstScmProvider(
 	var ps promoterv1alpha1.PromotionStrategy
 	if err := r.Get(ctx, client.ObjectKey{Namespace: wrcs.Namespace, Name: wrcs.Spec.PromotionStrategyRef.Name}, &ps); err != nil {
 		return fmt.Errorf("failed to get PromotionStrategy for SCM host validation: %w", err)
-    }
+	}
+
 	// Resolve the GitRepository for this PromotionStrategy.
 	gitRepo, err := utils.GetGitRepositoryFromObjectKey(ctx, r.Client, client.ObjectKey{
 		Namespace: wrcs.Namespace,


### PR DESCRIPTION
Fixes #1250
`wrcs.Spec.PromotionStrategyRef.Name` is used used directly as the GitRepository name instead of fetching the PromotionStrategy first and use `spec.repositoryReference.name`. This breaks when the PromotionStrategy and GitRepository have different names.                
                                                                                                                                                                                                                
The [existing tests](https://github.com/CHL-work/gitops-promoter/blob/a0dc88f9228ae41a22ce6b116756da20bc0c5234/internal/controller/promotionstrategy_controller_test.go#L2829) don't catch this because `promotionStrategyResource()` uses the same generated name for both the PromotionStrategy and GitRepository. 