### PR TITLE
fix(wrcs): add list and watch for ns informer (#1251)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,8 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -7521,6 +7521,8 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -125,7 +125,7 @@ type httpValidationResult struct {
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=webrequestcommitstatuses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=webrequestcommitstatuses/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // Reconcile fetches the WebRequestCommitStatus and its PromotionStrategy, processes each applicable
 // environment (evaluating trigger and optionally making the HTTP request and validation), upserts


### PR DESCRIPTION
We're getting the ns to add metadata to the template engine. Alternatively, we could switch to a direct `get`, but I think the informer is preferable.

Fixes #1251