### PR TITLE
chore(ci): upgrade to newer goreleaser format

### DIFF
--- a/.goreleaser-latest.yaml
+++ b/.goreleaser-latest.yaml
@@ -33,37 +33,22 @@ builds:
       - -X github.com/argoproj-labs/gitops-promoter/common.buildDate={{ .Date }}
       - -extldflags="-static"
 
-dockers:
-  - image_templates:
-      - quay.io/argoprojlabs/gitops-promoter:latest-amd64
+dockers_v2:
+  - images:
+      - quay.io/argoprojlabs/gitops-promoter
+    tags:
+      - latest
     dockerfile: release.Dockerfile
-    use: buildx
-    goarch: amd64
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - hack/git/promoter_askpass.sh
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version=latest"
-      - "--platform=linux/amd64"
-      - "--provenance=false"
-  - image_templates:
-      - quay.io/argoprojlabs/gitops-promoter:latest-arm64
-    dockerfile: release.Dockerfile
-    use: buildx
-    goarch: arm64
-    extra_files:
-      - hack/git/promoter_askpass.sh
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version=latest"
-      - "--platform=linux/arm64"
-      - "--provenance=false"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "latest"
 
 # No archives for latest builds
 archives: []

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,44 +36,23 @@ builds:
       - -X github.com/argoproj-labs/gitops-promoter/common.buildDate={{ .Date }}
       - -extldflags="-static"
 
-dockers:
-  - image_templates:
-      - quay.io/argoprojlabs/gitops-promoter:{{ .Tag }}-amd64
+dockers_v2:
+  - images:
+      - quay.io/argoprojlabs/gitops-promoter
+    tags:
+      - "{{ .Tag }}"
     dockerfile: release.Dockerfile
-    skip_push: "{{ .IsSnapshot }}"
-    use: buildx
-    goarch: amd64
+    disable: "{{ .IsSnapshot }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - hack/git/promoter_askpass.sh
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/amd64"
-      - "--provenance=false"
-  - image_templates:
-      - quay.io/argoprojlabs/gitops-promoter:{{ .Tag }}-arm64
-    dockerfile: release.Dockerfile
-    extra_files:
-      - hack/git/promoter_askpass.sh
-    skip_push: "{{ .IsSnapshot }}"
-    use: buildx
-    goarch: arm64
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/arm64"
-      - "--provenance=false"
-docker_manifests:
-  - name_template: "quay.io/argoprojlabs/gitops-promoter:{{ .Tag }}"
-    image_templates:
-      - "quay.io/argoprojlabs/gitops-promoter:{{ .Tag }}-amd64"
-      - "quay.io/argoprojlabs/gitops-promoter:{{ .Tag }}-arm64"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
 
 checksum:
   extra_files:
@@ -96,7 +75,6 @@ docker_signs:
       - sign
       - "${artifact}"
       - "--yes"
-    artifacts: all
     output: true
 
 archives:

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1
 
+ARG TARGETPLATFORM
+
 WORKDIR /
 
 # Install tini to handle process management and prevent process leaks
 RUN apt-get update && apt-get install -y tini && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# goreleaser runs docker build in a context that contains just the Dockerfile and the binary.
-
-COPY gitops-promoter .
+COPY ${TARGETPLATFORM}/gitops-promoter .
 RUN mkdir /git
 COPY hack/git/promoter_askpass.sh /git/promoter_askpass.sh
 ENV PATH="${PATH}:/git"


### PR DESCRIPTION
In response to this log line from goreleaser:

>     • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info