### PR TITLE
fix(pr): prevent reconcile runaway on zombie PR

### DIFF
--- a/api/v1alpha1/changetransferpolicy_types.go
+++ b/api/v1alpha1/changetransferpolicy_types.go
@@ -217,11 +217,12 @@ type PullRequestCommonStatus struct {
 	// +kubebuilder:validation:XValidation:rule="self == '' || isURL(self)",message="must be a valid URL"
 	// +kubebuilder:validation:Pattern="^(https?://.*)?$"
 	Url string `json:"url,omitempty"`
-	// ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-	// This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-	// When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+	// ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+	// PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+	// because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+	// When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
 	// This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-	// record of the external action until a new pull request is created for this environment.
+	// record until a new pull request is created for this environment.
 	ExternallyMergedOrClosed *bool `json:"externallyMergedOrClosed,omitempty"`
 }
 

--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -85,11 +85,13 @@ type PullRequestStatus struct {
 	// +kubebuilder:validation:XValidation:rule="self == '' || isURL(self)",message="must be a valid URL"
 	// +kubebuilder:validation:Pattern="^(https?://.*)?$"
 	Url string `json:"url,omitempty"`
-	// ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-	// This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-	// When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
-	// The PullRequest resource will be deleted after this flag is set, but the status is preserved in
-	// the owning ChangeTransferPolicy to maintain a record of the external action.
+	// ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+	// resource still desired it open (spec.state is "open"): either it was merged or closed outside the
+	// controller, or it was closed on the SCM because the PullRequest resource was deleted (finalizer)
+	// and a subsequent sync observed it missing. The controller does not distinguish those cases here.
+	// When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
+	// The PullRequest resource will be deleted after this flag is set when possible, but the status is
+	// preserved in the owning ChangeTransferPolicy to maintain a record.
 	ExternallyMergedOrClosed *bool `json:"externallyMergedOrClosed,omitempty"`
 
 	// Conditions Represents the observations of the current state.

--- a/applyconfiguration/api/v1alpha1/pullrequestcommonstatus.go
+++ b/applyconfiguration/api/v1alpha1/pullrequestcommonstatus.go
@@ -40,11 +40,12 @@ type PullRequestCommonStatusApplyConfiguration struct {
 	PRMergeTime *v1.Time `json:"prMergeTime,omitempty"`
 	// Url is the URL of the pull request.
 	Url *string `json:"url,omitempty"`
-	// ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-	// This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-	// When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+	// ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+	// PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+	// because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+	// When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
 	// This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-	// record of the external action until a new pull request is created for this environment.
+	// record until a new pull request is created for this environment.
 	ExternallyMergedOrClosed *bool `json:"externallyMergedOrClosed,omitempty"`
 }
 

--- a/applyconfiguration/api/v1alpha1/pullrequeststatus.go
+++ b/applyconfiguration/api/v1alpha1/pullrequeststatus.go
@@ -36,11 +36,13 @@ type PullRequestStatusApplyConfiguration struct {
 	PRCreationTime *v1.Time `json:"prCreationTime,omitempty"`
 	// Url is the URL of the pull request.
 	Url *string `json:"url,omitempty"`
-	// ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-	// This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-	// When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
-	// The PullRequest resource will be deleted after this flag is set, but the status is preserved in
-	// the owning ChangeTransferPolicy to maintain a record of the external action.
+	// ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+	// resource still desired it open (spec.state is "open"): either it was merged or closed outside the
+	// controller, or it was closed on the SCM because the PullRequest resource was deleted (finalizer)
+	// and a subsequent sync observed it missing. The controller does not distinguish those cases here.
+	// When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
+	// The PullRequest resource will be deleted after this flag is set when possible, but the status is
+	// preserved in the owning ChangeTransferPolicy to maintain a record.
 	ExternallyMergedOrClosed *bool `json:"externallyMergedOrClosed,omitempty"`
 	// Conditions Represents the observations of the current state.
 	Conditions []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`

--- a/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
@@ -902,11 +902,12 @@ spec:
                       properties:
                         externallyMergedOrClosed:
                           description: |-
-                            ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                            This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                            When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                            ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                            PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                            because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                            When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                             This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                            record of the external action until a new pull request is created for this environment.
+                            record until a new pull request is created for this environment.
                           type: boolean
                         id:
                           description: ID is the unique identifier of the pull request,
@@ -1230,11 +1231,12 @@ spec:
                 properties:
                   externallyMergedOrClosed:
                     description: |-
-                      ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                      This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                      When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                      ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                      PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                      because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                      When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                       This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                      record of the external action until a new pull request is created for this environment.
+                      record until a new pull request is created for this environment.
                     type: boolean
                   id:
                     description: ID is the unique identifier of the pull request,

--- a/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
@@ -1004,11 +1004,12 @@ spec:
                             properties:
                               externallyMergedOrClosed:
                                 description: |-
-                                  ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                                  This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                                  When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                                  ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                                  PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                                  because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                                  When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                                   This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                                  record of the external action until a new pull request is created for this environment.
+                                  record until a new pull request is created for this environment.
                                 type: boolean
                               id:
                                 description: ID is the unique identifier of the pull
@@ -1365,11 +1366,12 @@ spec:
                       properties:
                         externallyMergedOrClosed:
                           description: |-
-                            ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                            This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                            When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                            ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                            PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                            because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                            When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                             This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                            record of the external action until a new pull request is created for this environment.
+                            record until a new pull request is created for this environment.
                           type: boolean
                         id:
                           description: ID is the unique identifier of the pull request,

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -200,11 +200,13 @@ spec:
                 x-kubernetes-list-type: map
               externallyMergedOrClosed:
                 description: |-
-                  ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                  This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                  When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
-                  The PullRequest resource will be deleted after this flag is set, but the status is preserved in
-                  the owning ChangeTransferPolicy to maintain a record of the external action.
+                  ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                  resource still desired it open (spec.state is "open"): either it was merged or closed outside the
+                  controller, or it was closed on the SCM because the PullRequest resource was deleted (finalizer)
+                  and a subsequent sync observed it missing. The controller does not distinguish those cases here.
+                  When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
+                  The PullRequest resource will be deleted after this flag is set when possible, but the status is
+                  preserved in the owning ChangeTransferPolicy to maintain a record.
                 type: boolean
               id:
                 description: ID the id of the pull request

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1202,11 +1202,12 @@ spec:
                       properties:
                         externallyMergedOrClosed:
                           description: |-
-                            ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                            This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                            When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                            ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                            PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                            because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                            When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                             This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                            record of the external action until a new pull request is created for this environment.
+                            record until a new pull request is created for this environment.
                           type: boolean
                         id:
                           description: ID is the unique identifier of the pull request,
@@ -1530,11 +1531,12 @@ spec:
                 properties:
                   externallyMergedOrClosed:
                     description: |-
-                      ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                      This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                      When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                      ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                      PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                      because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                      When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                       This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                      record of the external action until a new pull request is created for this environment.
+                      record until a new pull request is created for this environment.
                     type: boolean
                   id:
                     description: ID is the unique identifier of the pull request,
@@ -5384,11 +5386,12 @@ spec:
                             properties:
                               externallyMergedOrClosed:
                                 description: |-
-                                  ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                                  This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                                  When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                                  ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                                  PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                                  because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                                  When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                                   This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                                  record of the external action until a new pull request is created for this environment.
+                                  record until a new pull request is created for this environment.
                                 type: boolean
                               id:
                                 description: ID is the unique identifier of the pull
@@ -5745,11 +5748,12 @@ spec:
                       properties:
                         externallyMergedOrClosed:
                           description: |-
-                            ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                            This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                            When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
+                            ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                            PullRequest still desired it open: merged or closed outside the controller, or closed on the SCM
+                            because the PullRequest resource was deleted (finalizer) before this status was reconciled.
+                            When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
                             This status is preserved even after the PullRequest resource is deleted, maintaining a historical
-                            record of the external action until a new pull request is created for this environment.
+                            record until a new pull request is created for this environment.
                           type: boolean
                         id:
                           description: ID is the unique identifier of the pull request,
@@ -6002,11 +6006,13 @@ spec:
                 x-kubernetes-list-type: map
               externallyMergedOrClosed:
                 description: |-
-                  ExternallyMergedOrClosed indicates that the pull request was merged or closed externally.
-                  This is set to true when the pull request has an ID but is no longer found on the SCM provider.
-                  When true, the State field will be empty ("") since we cannot determine if it was merged or closed.
-                  The PullRequest resource will be deleted after this flag is set, but the status is preserved in
-                  the owning ChangeTransferPolicy to maintain a record of the external action.
+                  ExternallyMergedOrClosed indicates that the pull request is no longer open on the SCM while the
+                  resource still desired it open (spec.state is "open"): either it was merged or closed outside the
+                  controller, or it was closed on the SCM because the PullRequest resource was deleted (finalizer)
+                  and a subsequent sync observed it missing. The controller does not distinguish those cases here.
+                  When true, the State field will be empty ("") since we cannot tell merge vs. close from the provider.
+                  The PullRequest resource will be deleted after this flag is set when possible, but the status is
+                  preserved in the owning ChangeTransferPolicy to maintain a record.
                 type: boolean
               id:
                 description: ID the id of the pull request

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -302,6 +303,24 @@ func (r *PullRequestReconciler) handleStateTransitions(ctx context.Context, pr *
 	return false, nil
 }
 
+// pullRequestDeletionFinalizerLengthChangedPredicate matches Update events where the object is
+// terminating (deletionTimestamp set) and the finalizer count changed. This is important because
+// the CTP controller sets a finalizer, and we need to reconcile when it's removed to ensure
+// quick cleanup of the PR.
+func pullRequestDeletionFinalizerLengthChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			if e.ObjectNew.GetDeletionTimestamp().IsZero() {
+				return false
+			}
+			return len(e.ObjectOld.GetFinalizers()) != len(e.ObjectNew.GetFinalizers())
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *PullRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	// Use Direct methods to read configuration from the API server without cache during setup.
@@ -317,7 +336,10 @@ func (r *PullRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	}
 
 	err = ctrl.NewControllerManagedBy(mgr).
-		For(&promoterv1alpha1.PullRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&promoterv1alpha1.PullRequest{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			pullRequestDeletionFinalizerLengthChangedPredicate(),
+		))).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
 	if err != nil {

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -229,12 +229,14 @@ func (r *PullRequestReconciler) syncStateFromProvider(ctx context.Context, pr *p
 	// Only mark as external if spec.state is "open" (controller didn't initiate the closure/merge).
 	if pr.Status.ID != "" {
 		if pr.Spec.State == promoterv1alpha1.PullRequestOpen {
-			// Controller still thinks PR should be open, but it's not found on provider = external action
+			// Controller still thinks PR should be open, but it's not found on provider. That includes a
+			// human or another system closing/merging the PR, and also our own deletion finalizer having
+			// closed it on the SCM: the next sync cannot tell those apart, so we set ExternallyMergedOrClosed.
 			pr.Status.ExternallyMergedOrClosed = ptr.To(true)
 			// Don't set State since we don't know if it was merged or closed externally.
-			// The ExternallyMergedOrClosed flag is the source of truth that this PR
-			// is no longer active and was handled outside of the controller's control.
-			// An empty State with ExternallyMergedOrClosed=true means "closed/merged externally, but we don't know which".
+			// The ExternallyMergedOrClosed flag means this PR is no longer open on the provider while we still
+			// desired open; that includes true external action and indistinguishable cases such as our delete finalizer
+			// having closed the SCM PR. An empty State with ExternallyMergedOrClosed=true means we cannot tell merge vs. close.
 			pr.Status.State = ""
 			return true, nil
 		}

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -954,7 +954,7 @@ var _ = Describe("PullRequest Controller", func() {
 			_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
 		})
 
-		It("should close the SCM PR, persist closed status, and stop calling FindOpen while the object is terminating", func() {
+		It("should close the SCM PR, set externallyMergedOrClosed when status syncs, and not spam FindOpen while terminating", func() {
 			fake.ResetFindOpenCallCount()
 
 			By("Deleting the PullRequest (object remains until the blocking finalizer is cleared)")
@@ -1000,13 +1000,16 @@ var _ = Describe("PullRequest Controller", func() {
 
 			snapshot := fake.FindOpenCallCount()
 			Consistently(func(g Gomega) {
-				g.Expect(fake.FindOpenCallCount()).To(Equal(snapshot))
+				// Allow a small bump from a stray requeue; a regression still produces thousands of FindOpen calls.
+				g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", snapshot+5))
 			}, 2*time.Second, 50*time.Millisecond).Should(Succeed())
 
-			By("Verifying status reflects closed on the terminating PullRequest resource")
+			By("Verifying status reflects no longer open (same path as SCM-external close: flag set, state empty)")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
-				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestClosed))
+				g.Expect(pullRequest.Status.ExternallyMergedOrClosed).ToNot(BeNil())
+				g.Expect(*pullRequest.Status.ExternallyMergedOrClosed).To(BeTrue())
+				g.Expect(pullRequest.Status.State).To(BeEmpty())
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -979,18 +979,9 @@ var _ = Describe("PullRequest Controller", func() {
 				g.Expect(state).To(Equal(promoterv1alpha1.PullRequestClosed))
 			}, constants.EventuallyTimeout).Should(Succeed())
 
-			By("Forcing more reconcile loops while terminating (spec change bumps generation)")
-			// The PullRequest controller watches with GenerationChangedPredicate, so a delete alone may only
-			// deliver one reconcile. A spec edit is realistic (other controllers mutating the object) and
-			// should not cause an endless FindOpen loop once the SCM PR is already closed.
-			findOpenBeforeBump := fake.FindOpenCallCount()
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
-				orig := pullRequest.DeepCopy()
-				pullRequest.Spec.Description = pullRequest.Spec.Description + " "
-				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(orig))).To(Succeed())
-			}, constants.EventuallyTimeout).Should(Succeed())
+			By("Checking the number of FindOpen calls")
 
+			findOpenBeforeBump := fake.FindOpenCallCount()
 			time.Sleep(150 * time.Millisecond)
 
 			By("Verifying FindOpen is not invoked in a tight loop while the object is stuck terminating")

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -890,6 +890,126 @@ var _ = Describe("PullRequest Controller", func() {
 			}
 		})
 	})
+
+	Context("When deleting a PullRequest that already has an SCM PR but is blocked by another finalizer", func() {
+		const blockingFinalizer = "promoter.argoproj.io/test-will-not-remove"
+
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var pullRequest *promoterv1alpha1.PullRequest
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "delete-blocked-finalizer")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Finalizers).To(ContainElement(promoterv1alpha1.PullRequestFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Adding a finalizer that will not be removed, simulating another controller retaining the object")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			pullRequest.Finalizers = append(pullRequest.Finalizers, blockingFinalizer)
+			Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+		})
+
+		AfterEach(func() {
+			var pr promoterv1alpha1.PullRequest
+			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err != nil {
+				return
+			}
+			if pr.DeletionTimestamp == nil {
+				return
+			}
+			var kept []string
+			for _, f := range pr.Finalizers {
+				if f != blockingFinalizer {
+					kept = append(kept, f)
+				}
+			}
+			if len(kept) == len(pr.Finalizers) {
+				return
+			}
+			base := pr.DeepCopy()
+			pr.Finalizers = kept
+			_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+		})
+
+		It("should close the SCM PR, persist closed status, and stop calling FindOpen while the object is terminating", func() {
+			fake.ResetFindOpenCallCount()
+
+			By("Deleting the PullRequest (object remains until the blocking finalizer is cleared)")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, pullRequest)).To(Succeed())
+
+			fakeProvider := fake.NewFakePullRequestProvider(k8sClient)
+
+			By("Waiting for the promoter's finalizer to run (SCM close + remove promoter finalizer)")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
+				g.Expect(pullRequest.Finalizers).NotTo(ContainElement(promoterv1alpha1.PullRequestFinalizer))
+				g.Expect(pullRequest.Finalizers).To(ContainElement(blockingFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Verifying the SCM-side PR was closed by deletion finalization logic")
+			Eventually(func(g Gomega) {
+				exists, state, _, err := fakeProvider.GetRecordedState(ctx, *pullRequest)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(exists).To(BeTrue())
+				g.Expect(state).To(Equal(promoterv1alpha1.PullRequestClosed))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Forcing more reconcile loops while terminating (spec change bumps generation)")
+			// The PullRequest controller watches with GenerationChangedPredicate, so a delete alone may only
+			// deliver one reconcile. A spec edit is realistic (other controllers mutating the object) and
+			// should not cause an endless FindOpen loop once the SCM PR is already closed.
+			findOpenBeforeBump := fake.FindOpenCallCount()
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				orig := pullRequest.DeepCopy()
+				pullRequest.Spec.Description = pullRequest.Spec.Description + " "
+				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(orig))).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			time.Sleep(150 * time.Millisecond)
+
+			By("Verifying FindOpen is not invoked in a tight loop while the object is stuck terminating")
+			findOpenAfterWindow := fake.FindOpenCallCount()
+			Expect(findOpenAfterWindow-findOpenBeforeBump).To(BeNumerically("<", 25),
+				"FindOpen should not be polled repeatedly after the SCM PR is closed during deletion")
+
+			snapshot := fake.FindOpenCallCount()
+			Consistently(func(g Gomega) {
+				g.Expect(fake.FindOpenCallCount()).To(Equal(snapshot))
+			}, 2*time.Second, 50*time.Millisecond).Should(Succeed())
+
+			By("Verifying status reflects closed on the terminating PullRequest resource")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestClosed))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
 })
 
 func pullRequestResources(ctx context.Context, name string) (string, *v1.Secret, *promoterv1alpha1.ScmProvider, *promoterv1alpha1.GitRepository, *promoterv1alpha1.PullRequest) {

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
@@ -28,6 +29,9 @@ import (
 var (
 	pullRequests map[string]pullRequestProviderState
 	mutexPR      sync.RWMutex
+
+	// findOpenCallCount is incremented on every FindOpen call (for tests).
+	findOpenCallCount atomic.Uint64
 )
 
 type pullRequestProviderState struct {
@@ -210,8 +214,39 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 	return nil
 }
 
+// ResetFindOpenCallCount resets the test-only counter of FindOpen invocations.
+func ResetFindOpenCallCount() {
+	findOpenCallCount.Store(0)
+}
+
+// FindOpenCallCount returns how many times FindOpen has been invoked since the last reset.
+func FindOpenCallCount() uint64 {
+	return findOpenCallCount.Load()
+}
+
+// GetRecordedState returns the PR entry stored in the fake provider for the given resource, if any.
+func (pr *PullRequest) GetRecordedState(ctx context.Context, pullRequest v1alpha1.PullRequest) (exists bool, state v1alpha1.PullRequestState, id string, err error) {
+	gitRepo, err := utils.GetGitRepositoryFromObjectKey(ctx, pr.k8sClient, client.ObjectKey{Namespace: pullRequest.Namespace, Name: pullRequest.Spec.RepositoryReference.Name})
+	if err != nil {
+		return false, "", "", fmt.Errorf("failed to get GitRepository: %w", err)
+	}
+
+	mutexPR.RLock()
+	defer mutexPR.RUnlock()
+	if pullRequests == nil {
+		return false, "", "", nil
+	}
+	st, ok := pullRequests[pr.getMapKey(pullRequest, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name)]
+	if !ok {
+		return false, "", "", nil
+	}
+	return true, st.state, st.id, nil
+}
+
 // FindOpen checks if a pull request is open and returns its status.
 func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRequest) (bool, string, time.Time, error) {
+	findOpenCallCount.Add(1)
+
 	mutexPR.RLock()
 	found, id := pr.findOpen(ctx, pullRequest)
 	mutexPR.RUnlock()

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -275,7 +275,7 @@ func (pr *PullRequest) getMapKey(pullRequest v1alpha1.PullRequest, owner, name s
 }
 
 // DeletePullRequest deletes a pull request from the fake provider's internal map.
-// This is used for testing to simulate externally merged/closed PRs.
+// This is used for testing to simulate a PR no longer open on the SCM (externally merged/closed, or fully removed).
 func (pr *PullRequest) DeletePullRequest(ctx context.Context, pullRequest v1alpha1.PullRequest) error {
 	gitRepo, err := utils.GetGitRepositoryFromObjectKey(ctx, pr.k8sClient, client.ObjectKey{Namespace: pullRequest.Namespace, Name: pullRequest.Spec.RepositoryReference.Name})
 	if err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -320,12 +320,6 @@ func HandleReconciliationResult(
 		return
 	}
 
-	// If the deletion timestamp is set on the object, bail out early.
-	if !obj.GetDeletionTimestamp().IsZero() {
-		logger.V(4).Info("resource deleted, skipping handling of the reconciliation result")
-		return
-	}
-
 	conditions := obj.GetConditions() // GetConditions() is guaranteed to be non-nil for our CRDs.
 	readyCondition := meta.FindStatusCondition(*conditions, string(promoterConditions.Ready))
 	if readyCondition == nil {


### PR DESCRIPTION
The ChangeTransferPolicy uses the PullRequest `status` field to understand what happened to a given PR. So in the PullRequest reconcile function, instead of just deleting the PullRequest when the PR is merged/closed in the SCM, we persist that state to the `status` field and then immediately requeue for cleanup. The second reconcile (assuming the CTP finalizer has been cleared) will finally delete the PullRequest and prevent any further SCM calls.

However, a [low-value logs enhancement](https://github.com/argoproj-labs/gitops-promoter/pull/815) currently prevents the `status` update from being persisted if the PullRequest has already been marked for deletion. So the PullRequest falls into a tight loop of checking whether the PR is open, marking it as externally merged or closed, discarding that information, and repeating every microsecond.

This is only an issue as long as there's a finalizer preventing the PullRequest from finally being deleted. But when the CTP finalizer (or anything else) keeps the PullRequest from being deleted, the loop repeats infinitely.

This PR removes the logs enhancement so that the PullRequest can persist the state from the SCM, the reconcile doesn't trigger an immediate re-reconcile, and the SCM API call storm is avoided.

We'll still hit the SCM every reconcile. That's probably something that can be further enhanced. But for now it's enough to the tight loop.

This PR will separately ensure that the CTP cleans up its finalizer when the CTP is deleted: https://github.com/argoproj-labs/gitops-promoter/pull/1320

Thanks @seankhliao for finding the bug and for helping diagnose it!