### PR TITLE
feat(ui): show PR merge time on live card active badge

### DIFF
--- a/ui/components-lib/src/components/Card.tsx
+++ b/ui/components-lib/src/components/Card.tsx
@@ -79,6 +79,10 @@ const Card: React.FC<CardProps> = ({ environments }) => {
             date: env.proposedDryCommitDate,
           };
 
+          const mergeTimeAgo = inHistoryMode
+            ? (env.historyMergeTimeAgo ?? undefined)
+            : (env.activeMergeTimeAgo ?? undefined);
+
           const hasPendingProposal =
             !inHistoryMode &&
             proposedStatus !== undefined &&
@@ -156,9 +160,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
                         ? 'State of active checks when this promotion was superseded'
                         : undefined
                     }
-                    mergeTimeAgo={
-                      inHistoryMode ? (env.historyMergeTimeAgo ?? undefined) : undefined
-                    }
+                    mergeTimeAgo={mergeTimeAgo}
                   />
 
                   {/* Proposed Commits Section (normal mode only) */}

--- a/ui/shared/src/types/promotion.ts
+++ b/ui/shared/src/types/promotion.ts
@@ -31,6 +31,8 @@ export interface PullRequest {
   id: string;
   url?: string;
   prMergeTime?: string;
+  state?: string;
+  externallyMergedOrClosed?: boolean;
 }
 
 export interface History {
@@ -138,6 +140,7 @@ export interface EnrichedEnvDetails {
 
   // History
   historyMergeTimeAgo: string | null;
+  activeMergeTimeAgo: string | null;
 }
 
 export type PromotionPhase = 'promoted' | 'failure' | 'pending' | 'unknown';

--- a/ui/shared/src/utils/PSData.ts
+++ b/ui/shared/src/utils/PSData.ts
@@ -81,6 +81,14 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
   const entryPr = selectedHistoryEntry?.pullRequest;
   const historyWithPr = entryPr?.id ? entryPr : null;
 
+  // For the live active badge, fall back to environment.pullRequest when state is merged
+  // and history[0] has no PR data (e.g. externally merged PRs)
+  const mergedEnvPr =
+    pullRequest?.id && (pullRequest?.state === 'merged' || pullRequest?.externallyMergedOrClosed)
+      ? pullRequest
+      : null;
+  const activePr = historyWithPr ?? mergedEnvPr;
+
   // Resolve merge time: prefer prMergeTime, fall back to hydrated commitTime
   let historyMergeTimeAgo: string | null = null;
   if (index > 0) {
@@ -89,6 +97,10 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
       entry?.pullRequest?.prMergeTime || entry?.active?.hydrated?.commitTime || null;
     historyMergeTimeAgo = mergeTimeStr ? timeAgo(mergeTimeStr) : null;
   }
+
+  // Merge time for the live (index 0) active PR
+  const liveMergeTimeStr = activePr?.prMergeTime || history[0]?.pullRequest?.prMergeTime || null;
+  const activeMergeTimeAgo = liveMergeTimeStr ? timeAgo(liveMergeTimeStr) : null;
 
   // In historical view, proposed cards should only show status info, not commit details
   const isHistoric = index > 0;
@@ -100,8 +112,8 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
 
     // ACTIVE
     activeStatus: getHealthStatus(activeChecks),
-    activePrUrl: historyWithPr?.url || null,
-    activePrNumber: historyWithPr?.id ? parseInt(historyWithPr.id, 10) : null,
+    activePrUrl: activePr?.url || null,
+    activePrNumber: activePr?.id ? parseInt(activePr.id, 10) : null,
     activeCommitSubject: activeCommitInfo.subject || '-',
     activeCommitMessage: extractBodyPreTrailer(activeCommitInfo.body || '-'),
     activeCommitAuthor: extractNameOnly(activeCommitInfo.author || '-'),
@@ -134,6 +146,7 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
 
     // History
     historyMergeTimeAgo,
+    activeMergeTimeAgo,
   };
 }
 


### PR DESCRIPTION
Display the PR merge time on the Active section's PR badge in the live (non-history) card view, consistent with the existing history view.

Falls back to environment.pullRequest when history[0].pullRequest has no id (e.g. externally or manually merged PRs), treating both state=merged and externallyMergedOrClosed=true as displayable.

<img width="911" height="331" alt="image" src="https://github.com/user-attachments/assets/6fae3547-8ad8-4611-b32f-bda1368f533e" />

_note: for PR's that are manually merged, merge time is not recorded, so it will not show_