### PR TITLE
fix: remove git@ from GitHub HTTPS repo URLs

### DIFF
--- a/internal/scms/github/git_operations.go
+++ b/internal/scms/github/git_operations.go
@@ -53,9 +53,9 @@ func NewGithubGitAuthenticationProvider(ctx context.Context, k8sClient client.Cl
 // GetGitHttpsRepoUrl constructs the HTTPS URL for a GitHub repository based on the provided GitRepository object.
 func (gh GitAuthenticationProvider) GetGitHttpsRepoUrl(gitRepository v1alpha1.GitRepository) string {
 	if gh.scmProvider.GetSpec().GitHub != nil && gh.scmProvider.GetSpec().GitHub.Domain != "" {
-		return fmt.Sprintf("https://git@%s/%s/%s.git", gh.scmProvider.GetSpec().GitHub.Domain, gitRepository.Spec.GitHub.Owner, gitRepository.Spec.GitHub.Name)
+		return fmt.Sprintf("https://%s/%s/%s.git", gh.scmProvider.GetSpec().GitHub.Domain, gitRepository.Spec.GitHub.Owner, gitRepository.Spec.GitHub.Name)
 	}
-	return fmt.Sprintf("https://git@github.com/%s/%s.git", gitRepository.Spec.GitHub.Owner, gitRepository.Spec.GitHub.Name)
+	return fmt.Sprintf("https://github.com/%s/%s.git", gitRepository.Spec.GitHub.Owner, gitRepository.Spec.GitHub.Name)
 }
 
 // GetToken retrieves the authentication token for GitHub.


### PR DESCRIPTION
`GetGitHttpsRepoUrl` was constructing URLs of the form
`https://git@github.com/...` which broke GitHub sub-pages like the
branches view. The `git@` prefix is unnecessary since authentication
is handled via `GIT_ASKPASS` env vars, not the URL.