### PR TITLE
fix(test): wait for all envs before snapshotting WRCS HTTP request count

### DIFF
--- a/internal/controller/webrequestcommitstatus_controller_test.go
+++ b/internal/controller/webrequestcommitstatus_controller_test.go
@@ -3374,21 +3374,23 @@ var _ = Describe("WebRequestCommitStatus Controller - Success.when Every Reconci
 		})
 
 		It("should succeed via Response on first reconcile, then stay success via Phase fallback without extra HTTP", func() {
-			By("Waiting for first wave of HTTP requests and success (one request per applicable environment)")
+			By("Waiting for ALL environments to complete their first HTTP wave before snapshotting request count")
 			Eventually(func(g Gomega) {
-				requestCountMu.Lock()
-				c := requestCount
-				requestCountMu.Unlock()
-				g.Expect(c).To(BeNumerically(">=", 1))
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(len(fetched.Status.Environments)).To(Equal(3),
+					"all three environments must be processed before snapshotting the HTTP request count")
 				for _, env := range fetched.Status.Environments {
-					if env.Branch == testBranchDevelopment {
-						g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
-					}
+					g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess),
+						"environment %s should be success before snapshotting", env.Branch)
 				}
+
+				requestCountMu.Lock()
+				c := requestCount
+				requestCountMu.Unlock()
+				g.Expect(c).To(BeNumerically(">=", 3),
+					"each environment fires once on first SHA track")
 			}, constants.EventuallyTimeout).Should(Succeed())
 
 			requestCountMu.Lock()


### PR DESCRIPTION
## Summary

The Ginkgo spec [\"should succeed via Response on first reconcile, then stay success via Phase fallback without extra HTTP\"](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/webrequestcommitstatus_controller_test.go#L3376) (under `WebRequestCommitStatus Controller - Success.when Every Reconcile > Response guard pattern`) is flaky.

Its `Eventually` block only waits for **one** environment (`development`) to reach `success` and at least one HTTP request to have fired before snapshotting `requestCount` into `countAfterSuccess`. The PromotionStrategy used by this suite has three environments (development/staging/production), each of which fires one request on first SHA track. The other two environments can still complete their initial HTTP requests after the snapshot, and the immediately-following `Consistently` strict-equality assertion (`Expect(c).To(Equal(countAfterSuccess))`) fails as the count keeps growing.

Concrete example from the most recent failure: snapshot was `4`, count grew to `6` (the staging and production first-wave requests).

This PR waits for all three environments to be processed and at `success`, and for at least 3 requests to have fired, before snapshotting — mirroring the working pattern already used by the adjacent [`HTTP response expiry via ResponseOutput and now()`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/webrequestcommitstatus_controller_test.go#L3480) spec in the same file.

## Known occurrences

- 2026-04-28 — PR [#1375](https://github.com/argoproj-labs/gitops-promoter/pull/1375) (unrelated dependabot bump): [run 25035298104](https://github.com/argoproj-labs/gitops-promoter/actions/runs/25035298104)
- 2026-04-22 — push to `main` from PR [#1353](https://github.com/argoproj-labs/gitops-promoter/pull/1353) (unrelated): [run 24797398418](https://github.com/argoproj-labs/gitops-promoter/actions/runs/24797398418)

Both runs failed in the exact same spec at `webrequestcommitstatus_controller_test.go:3403` with `HTTP request count should not increase after trigger stops firing`.

## Prior art

The same kind of partial-completion → strict-equality flake was previously fixed in PR [#1163 \"fix: flakey tests by checking that all envs have been processed once\"](https://github.com/argoproj-labs/gitops-promoter/pull/1163) ([commit 8f50122b](https://github.com/argoproj-labs/gitops-promoter/commit/8f50122b4714f5ae491f17b84607c98ed8ff88a2)). This PR applies the same shape of fix to the spec that was added later under the `Response guard pattern` describe block.

## Audit of similar tests

I audited the rest of `internal/controller/webrequestcommitstatus_controller_test.go` for the same pattern (multi-env `Eventually` that gates on a single env, then snapshot, then strict-equality `Consistently`):

- `Enriched context: PromotionStrategy in promotionstrategy context without HTTP request` (line 3292) — `Eventually` already waits for all 3 envs; `Consistently` not used.
- `Skip optimization (context=promotionstrategy)` (line 2578) — `Eventually` already waits for all 3 envs; `Consistently` uses `<= initialCount+1` (loose).
- `SuccessOutput tracking` (line 3868) — `Consistently` uses `<= initialCount+3` with explicit \"small buffer for concurrent env processing\" (loose).
- `ResponseOutput - preserve response data when trigger returns false` (line 1238) — uses a single-env `PromotionStrategy` (overridden in `BeforeAll`), so `Equal(1)` is correct.

The fixed spec was the only one with the partial-env `Eventually` gate combined with a strict-equality `Consistently` snapshot.

## Test plan

- [x] Run the targeted spec locally — passes in ~36s.
- [x] Repeat-run (`--repeat=2`) the `Response guard pattern` and `HTTP response expiry` describes — both pass twice.
- [ ] CI runs the full suite.

Made with [Cursor](https://cursor.com)