### PR TITLE
feat(ui): persist strategy dropdown selection

### DIFF
--- a/ui/extension/AppViewExtension.test.tsx
+++ b/ui/extension/AppViewExtension.test.tsx
@@ -189,7 +189,7 @@ describe('AppViewExtension', () => {
         .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       await wait();
 
-      const options = Array.from(container.querySelectorAll('.strategy-dropdown__option'));
+      const options = Array.from(document.querySelectorAll('.strategy-dropdown__option'));
       const optionTexts = options.map((o) => o.textContent);
       expect(optionTexts).toContain('strategy-1');
       expect(optionTexts).toContain('strategy-2');
@@ -204,7 +204,7 @@ describe('AppViewExtension', () => {
         .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       await wait();
 
-      const options = Array.from(container.querySelectorAll('.strategy-dropdown__option'));
+      const options = Array.from(document.querySelectorAll('.strategy-dropdown__option'));
       options
         .find((o) => o.textContent === 'strategy-2')!
         .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -242,7 +242,7 @@ describe('AppViewExtension', () => {
         .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       await wait();
 
-      const options = Array.from(container.querySelectorAll('.strategy-dropdown__option'));
+      const options = Array.from(document.querySelectorAll('.strategy-dropdown__option'));
       const optionTexts = options.map((o) => o.textContent);
       expect(optionTexts).toContain('my-strategy (ns-a)');
       expect(optionTexts).toContain('my-strategy (ns-b)');
@@ -271,7 +271,7 @@ describe('AppViewExtension', () => {
         .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       await wait();
 
-      const options = Array.from(container.querySelectorAll('.strategy-dropdown__option'));
+      const options = Array.from(document.querySelectorAll('.strategy-dropdown__option'));
       options
         .find((o) => o.textContent === 'my-strategy (ns-b)')!
         .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));

--- a/ui/extension/AppViewExtension.tsx
+++ b/ui/extension/AppViewExtension.tsx
@@ -8,6 +8,7 @@ import './StrategyDropdown.scss';
 const GROUP = 'promoter.argoproj.io';
 const KIND = 'PromotionStrategy';
 const PARAM = 'promotionstrategy';
+const STORAGE_PREFIX = 'gitops-promoter:lastStrategy:';
 
 interface SelectOption {
   value: string;
@@ -29,11 +30,37 @@ const setParam = (name: string) => {
   window.history.replaceState(null, '', url.toString());
 };
 
+const storageKey = (appNamespace: string, appName: string) =>
+  `${STORAGE_PREFIX}${appNamespace}/${appName}`;
+
+const getStored = (appNamespace: string, appName: string): string => {
+  try {
+    return window.localStorage.getItem(storageKey(appNamespace, appName)) || '';
+  } catch {
+    return '';
+  }
+};
+
+const setStored = (appNamespace: string, appName: string, name: string) => {
+  try {
+    const key = storageKey(appNamespace, appName);
+    if (name) {
+      window.localStorage.setItem(key, name);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // localStorage may be unavailable (privacy mode); fall through silently.
+  }
+};
+
 const strategyKey = (s: PromotionStrategy) => `${s.metadata.namespace}/${s.metadata.name}`;
 
 const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
   const [strategies, setStrategies] = useState<PromotionStrategy[]>([]);
-  const [selectedKey, setSelectedKey] = useState<string>(getParam);
+  const [selectedKey, setSelectedKey] = useState<string>(
+    () => getParam() || getStored(application.metadata.namespace, application.metadata.name),
+  );
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -49,6 +76,7 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
       setStrategies([]);
       setSelectedKey('');
       setParam('');
+      setStored(appNamespace, appName, '');
       return;
     }
 
@@ -83,11 +111,16 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
     )
       .then((parsed) => {
         setStrategies(parsed);
+        const keys = parsed.map(strategyKey);
         const fromUrl = getParam();
-        const match = parsed.find((s) => strategyKey(s) === fromUrl);
-        const initial = match ? fromUrl : strategyKey(parsed[0]);
+        const fromStored = getStored(appNamespace, appName);
+        const initial =
+          (keys.includes(fromUrl) && fromUrl) ||
+          (keys.includes(fromStored) && fromStored) ||
+          keys[0];
         setSelectedKey(initial);
         setParam(initial);
+        setStored(appNamespace, appName, initial);
       })
       .catch((err) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -95,6 +128,7 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
         setStrategies([]);
         setSelectedKey('');
         setParam('');
+        setStored(appNamespace, appName, '');
       });
   }, [application.metadata.name, application.metadata.namespace, tree]);
 
@@ -128,6 +162,7 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
               const key = option ? option.value : '';
               setSelectedKey(key);
               setParam(key);
+              setStored(application.metadata.namespace, application.metadata.name, key);
             }}
           />
         </div>

--- a/ui/extension/AppViewExtension.tsx
+++ b/ui/extension/AppViewExtension.tsx
@@ -158,6 +158,8 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
             options={options}
             placeholder="Select a PromotionStrategy"
             value={options.find((opt) => opt.value === selectedKey) || null}
+            menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
+            styles={{ menuPortal: (base) => ({ ...base, zIndex: 2000 }) }}
             onChange={(option: SingleValue<SelectOption>) => {
               const key = option ? option.value : '';
               setSelectedKey(key);


### PR DESCRIPTION
Enable deep-linking from a GitHub PR check's "Details" button to a specific
`PromotionStrategy` in the ArgoCD UI extension when an Application owns more
than one strategy.

- **Controller:** add `.PromotionStrategy` to `URLTemplateData` so the
  `ArgoCDCommitStatus` `url.template` can encode which strategy owns a status
  (e.g. `?promotionstrategy={{ .PromotionStrategy.Namespace }}/{{ .PromotionStrategy.Name }}`).
  Docs and a render test updated.
- **UI extension:** persist the selected strategy in `localStorage` (scoped
  per-app) as a fallback under the URL query param, since ArgoCD strips the
  query string when navigating between application views. Resolution order
  is URL → localStorage → first strategy; the URL remains the authoritative
  deep-link target.