### PR TITLE
docs: use tabs for SCMs in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,7 @@ GitHub, GitHub Enterprise, GitLab, Forgejo (including Codeberg), Gitea, Bitbucke
 
 * kubectl CLI
 * kubernetes cluster
-* GitHub or GitHub Enterprise Application
-  * Will take PRs to add support for other SCM providers
+* Credential or app on your SCM (see [SCM provider configuration](#scm-provider-configuration) below)
 
 ## Installation
 
@@ -20,7 +19,11 @@ kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/downl
 
 Alternatively, you can install GitOps Promoter using Helm. See the [ArtifactHub page](https://artifacthub.io/packages/helm/gitops-promoter/gitops-promoter) for instructions.
 
-## GitHub App Configuration
+## SCM provider configuration
+
+Choose your provider:
+
+/// tab | GitHub
 
 You will need to [create a GitHub App](https://docs.github.com/en/developers/apps/creating-a-github-app) and configure
 it to allow the GitOps Promoter to interact with your GitHub repository.
@@ -127,7 +130,9 @@ spec:
 > The GitRepository and ScmProvider also need to be installed to the same namespace that you plan on creating PromotionStrategy
 > resources in, and it also needs to be in the same namespace of the secret it references.
 
-## GitLab Configuration
+///
+
+/// tab | GitLab
 
 To configure the GitOps Promoter with GitLab, you will need to create a GitLab Access Token under the "Developer" role with `api` and `write_repository` scopes and configure the necessary resources to allow the promoter to interact with your repository. This Access Token should be used in a secret as follows:
 
@@ -171,7 +176,9 @@ spec:
 > GitLab does not support updating existing commit statuses without transitioning the state. So a pending CommitStatus's
 > description or URL may go stale if updated after creation.
 
-## Gitea Configuration
+///
+
+/// tab | Gitea
 
 To configure GitOps Promoter with Gitea, you will need to create an access token. See the [official Gitea documentation](https://docs.gitea.com/development/api-usage#generating-and-listing-api-tokens) for creating access tokens. The token needs `read and write` repository permissions.
 
@@ -228,7 +235,9 @@ spec:
     name: <your-scmprovider-name>
 ```
 
-## Forgejo Configuration
+///
+
+/// tab | Forgejo
 
 To configure Gitops Promoter with Forgejo, you will need to configure an App. The process is very similar to Codeberg. Here is the [official Codeberg documentation](https://docs.codeberg.org/advanced/access-token/) (note: Codeberg is powered by Forgejo under the hood). Give the `read and write` Token the permissions on the repository.
 
@@ -279,10 +288,12 @@ spec:
     owner: <organization-or-user-name>
     name: <repo-name>
   scmProviderRef:
-    name: <your-scmprovider-name> # The secret that contains the GitLab Access Token
+    name: <your-scmprovider-name> # The secret that contains the Forgejo access token
 ```
 
-## Bitbucket Cloud Configuration
+///
+
+/// tab | Bitbucket Cloud
 
 To configure the GitOps Promoter with Bitbucket Cloud, you will need to create a repository access token with the appropriate permissions and configure the necessary resources to allow the promoter to interact with your repository.
 
@@ -296,50 +307,6 @@ To configure the GitOps Promoter with Bitbucket Cloud, you will need to create a
 6. Select the following permissions:
    * **Repositories**: Read and Write
    * **Pull requests**: Read and Write
-
-## Azure DevOps Configuration
-
-To configure Gitops Promoter with Azure Devops, you will need to create a Personal Access Token (PAT).
-### ScmProvider
-#### PAT
-Create an PAT in Azure Devops, that has 'Read & Write' on scope 'Code'.
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: <your-secret-name>
-type: Opaque
-stringData:
-  token: <your-access-token>
----
-apiVersion: promoter.argoproj.io/v1alpha1
-kind: ScmProvider
-metadata:
-  name: <your-scmprovider-name>
-spec:
-  secretRef:
-    name: <your-secret-name>
-  azureDevOps:
-    organization: <your-azdo-organization>
-```
-
-### GitRepository
-
-We also need a GitRepository referencing the ScmProvider
-
-```yaml
-apiVersion: promoter.argoproj.io/v1alpha1
-kind: GitRepository
-metadata:
-  name: <git-repository-ref-name>
-spec:
-  azureDevOps:
-    project: <project-name>
-    name: <repo-name>
-  scmProviderRef:
-    name: <your-scmprovider-name>
-```
 
 ### Webhooks (Optional - but highly recommended)
 
@@ -428,6 +395,57 @@ spec:
 
 > [!NOTE]
 > The GitRepository and ScmProvider also need to be installed to the same namespace that you plan on creating PromotionStrategy resources in, and it also needs to be in the same namespace of the secret it references.
+
+///
+
+/// tab | Azure DevOps
+
+To configure Gitops Promoter with Azure Devops, you will need to create a Personal Access Token (PAT).
+
+### ScmProvider
+
+#### PAT
+
+Create an PAT in Azure Devops, that has 'Read & Write' on scope 'Code'.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <your-secret-name>
+type: Opaque
+stringData:
+  token: <your-access-token>
+---
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ScmProvider
+metadata:
+  name: <your-scmprovider-name>
+spec:
+  secretRef:
+    name: <your-secret-name>
+  azureDevOps:
+    organization: <your-azdo-organization>
+```
+
+### GitRepository
+
+We also need a GitRepository referencing the ScmProvider:
+
+```yaml
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: GitRepository
+metadata:
+  name: <git-repository-ref-name>
+spec:
+  azureDevOps:
+    project: <project-name>
+    name: <repo-name>
+  scmProviderRef:
+    name: <your-scmprovider-name>
+```
+
+///
 
 ## Promotion Strategy
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,6 +23,10 @@ Alternatively, you can install GitOps Promoter using Helm. See the [ArtifactHub 
 
 Choose your provider:
 
+<!-- Intentionally no ### headings inside the tab bodies below: the tab strip is the only
+     navigation for each SCM—nested headings would flood the page TOC, clash with pymdownx
+     tab anchor IDs, and deep links would target content inside inactive/hidden panels. -->
+
 /// tab | GitHub
 
 You will need to [create a GitHub App](https://docs.github.com/en/developers/apps/creating-a-github-app) and configure
@@ -30,7 +34,7 @@ it to allow the GitOps Promoter to interact with your GitHub repository.
 
 During the creation the GitHub App, you will need to configure the following settings:
 
-### Permissions
+**Permissions**
 
 | Action         | Permission     |
 | -------------- | -------------- |
@@ -38,7 +42,7 @@ During the creation the GitHub App, you will need to configure the following set
 | `Contents`     | Read and write |
 | `Pull requests`| Read and write |
 
-### Webhooks (Optional - but highly recommended)
+**Webhooks (Optional - but highly recommended)**
 
 > [!NOTE]
 > We do support configuration of a GitHub App webhook that triggers PR creation upon Push. However, we do not configure
@@ -75,7 +79,7 @@ spec:
               number: 3333
 ```
 
-### Usage
+**Usage**
 
 The GitHub App will generate a private key that you will need to save. You will also need to get the App ID and the
 installation ID in a secret as follows:
@@ -297,7 +301,7 @@ spec:
 
 To configure the GitOps Promoter with Bitbucket Cloud, you will need to create a repository access token with the appropriate permissions and configure the necessary resources to allow the promoter to interact with your repository.
 
-### Creating a Bitbucket Cloud Repository Access Token
+**Creating a Bitbucket Cloud Repository Access Token**
 
 1. Navigate to your repository URL
 2. Click on "Repository settings" in the sidebar
@@ -308,7 +312,7 @@ To configure the GitOps Promoter with Bitbucket Cloud, you will need to create a
    * **Repositories**: Read and Write
    * **Pull requests**: Read and Write
 
-### Webhooks (Optional - but highly recommended)
+**Webhooks (Optional - but highly recommended)**
 
 > [!NOTE]
 > We do support configuration of a Bitbucket Cloud webhook that triggers PR creation upon Push. However, we do not configure
@@ -354,7 +358,7 @@ spec:
               number: 3333
 ```
 
-### Configuration
+**Configuration**
 
 This access token should be used in a secret as follows:
 
@@ -402,9 +406,9 @@ spec:
 
 To configure Gitops Promoter with Azure Devops, you will need to create a Personal Access Token (PAT).
 
-### ScmProvider
+**ScmProvider**
 
-#### PAT
+**PAT**
 
 Create an PAT in Azure Devops, that has 'Read & Write' on scope 'Code'.
 
@@ -428,7 +432,7 @@ spec:
     organization: <your-azdo-organization>
 ```
 
-### GitRepository
+**GitRepository**
 
 We also need a GitRepository referencing the ScmProvider:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ markdown_extensions:
       css_class: highlight
   - admonition
   - pymdownx.superfences
+  # Fenced tab blocks (/// tab | … ///) avoid indented-tab syntax that GitHub renders as code blocks.
+  - pymdownx.blocks.tab:
+      alternate_style: true
 nav:
   - Overview: index.md
   - Getting Started: getting-started.md
@@ -72,4 +75,3 @@ plugins:
   - redirects:
       redirect_maps:
         'metrics.md': 'monitoring/metrics.md' # Page was moved to a subdirectory.
-        'contributing.md': 'contributing/index.md' # Page was moved to a subdirectory.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,11 @@ markdown_extensions:
   # Fenced tab blocks (/// tab | … ///) avoid indented-tab syntax that GitHub renders as code blocks.
   - pymdownx.blocks.tab:
       alternate_style: true
+      # Tab label slugs for anchors (e.g. #github); tab bodies intentionally omit headings (see getting-started.md).
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        args: []
+        kwds:
+          case: lower
 nav:
   - Overview: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
The Getting Started page is way too long and contains mostly content the user will need to skip (irrelevant SCMs).

Each SCM now gets its own tab.

Went with `///` syntax for tabs to be minimally disruptive to non-mkdocs markdown renderers.

Also removed an unnecessary redirect that was causing an infinite redirect loop.