### PR TITLE
fix(ctp): avoid SSA empty-object null

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -644,12 +644,16 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("failed to get hydrator note for proposed hydrated SHA %q: %w", proposedHydratedSha, err)
 	}
-	ctp.Status.Proposed.Note = &promoterv1alpha1.HydratorMetadata{
-		DrySha: proposedNote.DrySha,
+	var drySha string
+	if proposedNote != nil {
+		drySha = proposedNote.DrySha
+		ctp.Status.Proposed.Note = &promoterv1alpha1.HydratorMetadata{
+			DrySha: drySha,
+		}
 	}
 	logger.V(4).Info("Set proposed Note.DrySha from git note",
 		"proposedHydratedSha", proposedHydratedSha,
-		"noteDrySha", proposedNote.DrySha)
+		"noteDrySha", drySha)
 
 	return nil
 }

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -758,7 +758,7 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				_ = os.RemoveAll(gitPath)
 			})
 
-			FIt("should not surface a status.proposed.note SSA validation error", func() {
+			It("should not surface a status.proposed.note SSA validation error", func() {
 				By("Hydrating the proposed branch with a git note so proposed.note.drySha is populated")
 				firstDrySha, err := makeDryCommit(ctx, gitPath, "first dry commit")
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -24,12 +24,14 @@ import (
 	"strings"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -701,6 +703,106 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					}, &createdPR)
 					// PR should be deleted (not found)
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
+			})
+		})
+
+		// Regression guard for kubernetes/kubernetes#135841: when SSA re-applies a
+		// previously-populated nested object as the empty object {}, structured-merge
+		// converts the empty object to JSON null during typed merge, and OpenAPI
+		// rejects null against a non-nullable type=object field. The promoter
+		// triggered this whenever setCommitMetadata wrote
+		//
+		//	ctp.Status.Proposed.Note = &HydratorMetadata{DrySha: ""}
+		//
+		// after a previous reconcile populated the same field. Every HydratorMetadata
+		// field is JSON omitempty, so the SSA body serialized proposed.note as {}.
+		// https://github.com/kubernetes/kubernetes/issues/134902
+		Context("When proposed.note transitions populated → empty across reconciles", func() {
+			var (
+				name                 string
+				scmSecret            *v1.Secret
+				scmProvider          *promoterv1alpha1.ScmProvider
+				gitRepo              *promoterv1alpha1.GitRepository
+				changeTransferPolicy *promoterv1alpha1.ChangeTransferPolicy
+				ctpKey               types.NamespacedName
+				gitPath              string
+				err                  error
+			)
+
+			BeforeEach(func() {
+				name, scmSecret, scmProvider, gitRepo, _, changeTransferPolicy = changeTransferPolicyResources(ctx, "ctp-note-empty-regression", "default")
+
+				ctpKey = types.NamespacedName{Name: name, Namespace: "default"}
+				changeTransferPolicy.Spec.ProposedBranch = testBranchDevelopmentNext
+				changeTransferPolicy.Spec.ActiveBranch = testBranchDevelopment
+				// Avoid auto-merging so the proposed branch keeps advancing across the two
+				// hydrations the test drives.
+				changeTransferPolicy.Spec.AutoMerge = ptr.To(false)
+
+				Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+				Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Create(ctx, changeTransferPolicy)).To(Succeed())
+
+				gitPath, err = cloneTestRepo(ctx, gitRepo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				By("Cleaning up resources")
+				Expect(k8sClient.Delete(ctx, changeTransferPolicy)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, scmSecret)).To(Succeed())
+				_ = os.RemoveAll(gitPath)
+			})
+
+			FIt("should not surface a status.proposed.note SSA validation error", func() {
+				By("Hydrating the proposed branch with a git note so proposed.note.drySha is populated")
+				firstDrySha, err := makeDryCommit(ctx, gitPath, "first dry commit")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hydrateEnvironment(ctx, gitPath, testBranchDevelopmentNext, firstDrySha, "hydrate dev for first dry sha")).To(Succeed())
+
+				By("Waiting for the controller to record the populated proposed.note.drySha")
+				Eventually(func(g Gomega) {
+					var ctp promoterv1alpha1.ChangeTransferPolicy
+					g.Expect(k8sClient.Get(ctx, ctpKey, &ctp)).To(Succeed())
+					g.Expect(ctp.Status.Proposed.Note).NotTo(BeNil())
+					g.Expect(ctp.Status.Proposed.Note.DrySha).To(Equal(firstDrySha))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Hydrating again, advancing the proposed branch to a new hydrated commit with NO git note")
+				// makeChangeAndHydrateRepo creates a new dry commit and hydrates each
+				// environment branch with a fresh hydrated commit, but does not add a
+				// git note to those commits. GetHydratorNote therefore returns
+				// HydratorMetadata{} on the next reconcile, and setCommitMetadata
+				// serializes the SSA body with "note":{} — the populated → empty
+				// transition that triggers #135841 without the schema fix.
+				secondDrySha, _ := makeChangeAndHydrateRepo(gitPath, gitRepo, "second dry commit", "")
+				Expect(secondDrySha).NotTo(Equal(firstDrySha))
+
+				By("Waiting for the controller to advance the CTP and report Ready=True without an SSA validation error")
+				// Without the fix the full status SSA is rejected with 422 and the
+				// fallback writes only Ready=False with reason=ReconciliationError and
+				// the apiserver error in the message. With the fix the controller
+				// successfully applies status and Ready=True. We assert both the
+				// positive end state and the absence of the bug-specific error text in
+				// the Ready condition message.
+				Eventually(func(g Gomega) {
+					var ctp promoterv1alpha1.ChangeTransferPolicy
+					g.Expect(k8sClient.Get(ctx, ctpKey, &ctp)).To(Succeed())
+
+					ready := meta.FindStatusCondition(ctp.Status.Conditions, string(promoterConditions.Ready))
+					g.Expect(ready).NotTo(BeNil(), "Ready condition should be present")
+					g.Expect(ready.Message).NotTo(ContainSubstring("status.proposed.note"),
+						"Ready message should not surface the kubernetes/kubernetes#135841 SSA validation error: %s", ready.Message)
+					g.Expect(ready.Message).NotTo(ContainSubstring("must be of type object"),
+						"Ready message should not surface the kubernetes/kubernetes#135841 SSA validation error: %s", ready.Message)
+					g.Expect(ready.Status).To(Equal(metav1.ConditionTrue),
+						"Ready should be True after the populated → empty proposed.note transition, got reason=%q message=%q", ready.Reason, ready.Message)
+					g.Expect(ready.Reason).To(Equal(string(promoterConditions.ReconciliationSuccess)))
+					g.Expect(ctp.Status.Proposed.Dry.Sha).To(Equal(secondDrySha))
 				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})

--- a/internal/controller/promotionstrategy_controller_test.go
+++ b/internal/controller/promotionstrategy_controller_test.go
@@ -3860,6 +3860,7 @@ var _ = Describe("PromotionStrategy Bug Tests", func() {
 					Namespace: ctpDev.Namespace,
 				}, &ctpDev)
 				g.Expect(err).To(Succeed())
+				g.Expect(ctpDev.Status.Proposed.Note).NotTo(BeNil())
 				// Dev's Note.DrySha should be the second dry SHA (from git note)
 				g.Expect(ctpDev.Status.Proposed.Note.DrySha).To(Equal(secondDrySha))
 				// Dev's Proposed.Dry.Sha should still be the first dry SHA (no new commit was made)
@@ -4007,6 +4008,7 @@ var _ = Describe("PromotionStrategy Bug Tests", func() {
 					Namespace: ctpDev.Namespace,
 				}, &ctpDev)
 				g.Expect(err).To(Succeed())
+				g.Expect(ctpDev.Status.Proposed.Note).NotTo(BeNil())
 				// Dev's Note.DrySha should be the second dry SHA (from git note)
 				g.Expect(ctpDev.Status.Proposed.Note.DrySha).To(Equal(secondDrySha))
 				// Dev's Proposed.Dry.Sha should still be the first dry SHA (no new commit was made)
@@ -4048,6 +4050,7 @@ var _ = Describe("PromotionStrategy Bug Tests", func() {
 					Namespace: ctpProd.Namespace,
 				}, &ctpProd)
 				g.Expect(err).To(Succeed())
+				g.Expect(ctpProd.Status.Proposed.Note).NotTo(BeNil())
 				// Production's Note.DrySha should be the second dry SHA (from git note)
 				g.Expect(ctpProd.Status.Proposed.Note.DrySha).To(Equal(secondDrySha))
 				// Production's Proposed.Dry.Sha should still be the first dry SHA (no new commit was made)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -562,11 +562,11 @@ func (g *EnvironmentOperations) FetchNotes(ctx context.Context) error {
 
 // GetHydratorNote reads the hydrator git note for a given commit SHA.
 // Returns an empty HydratorMetadata if no note exists for the commit.
-func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string) (HydratorMetadata, error) {
+func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string) (*HydratorMetadata, error) {
 	logger := log.FromContext(ctx)
 	gitPath := gitpaths.Get(g.gap.GetGitHttpsRepoUrl(*g.gitRepo) + g.activeBranch)
 	if gitPath == "" {
-		return HydratorMetadata{}, fmt.Errorf("no repo path found for repo %q", g.gitRepo.Name)
+		return nil, fmt.Errorf("no repo path found for repo %q", g.gitRepo.Name)
 	}
 
 	stdout, stderr, err := g.runCmd(ctx, gitPath, "notes", "--ref="+HydratorNotesRef, "show", sha)
@@ -574,20 +574,20 @@ func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string)
 		// No note for this commit is not an error - git outputs "error: no note found for object <sha>"
 		if strings.Contains(strings.ToLower(stderr), "no note found") {
 			logger.V(4).Info("No git note found for commit", "sha", sha)
-			return HydratorMetadata{}, nil
+			return nil, nil
 		}
 		logger.Error(err, "Failed to read git note", "sha", sha, "stderr", stderr)
-		return HydratorMetadata{}, fmt.Errorf("failed to read git note for sha %q: %w", sha, err)
+		return nil, fmt.Errorf("failed to read git note for sha %q: %w", sha, err)
 	}
 
 	var note HydratorMetadata
 	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &note); err != nil {
 		logger.V(4).Info("Failed to parse git note as JSON, ignoring", "sha", sha, "content", stdout, "error", err)
-		return HydratorMetadata{}, nil
+		return nil, nil
 	}
 
 	logger.V(4).Info("Got hydrator note", "sha", sha, "note", note)
-	return note, nil
+	return &note, nil
 }
 
 // ParseTrailersFromMessage parses git trailers from a commit message using git interpret-trailers.


### PR DESCRIPTION
## Summary

Fixes the production failure on Kubernetes 1.33.x where `ChangeTransferPolicy` status updates are rejected with:

```
ChangeTransferPolicy.promoter.argoproj.io "<name>" is invalid:
  [status.proposed.note: Invalid value: "null":
   proposed.note in body must be of type object: "null", ...]
```

### Root cause

`CommitBranchState.Note` is a `*HydratorMetadata` whose every field is JSON `omitempty`. When `setCommitMetadata` runs after `GetHydratorNote` returned the zero value (no/unparseable git note for the proposed hydrated commit), the controller still assigns `&HydratorMetadata{DrySha: ""}`, so the SSA status body serializes `proposed.note` as `{}`.

After a previous reconcile populated `proposed.note.drySha`, the next SSA call carries the populated → `{}` transition. Server-Side Apply's structured-merge collapses the empty object to JSON `null` during typed merge ([kubernetes/kubernetes#135841](https://github.com/kubernetes/kubernetes/issues/135841)), and OpenAPI structural validation rejects `null` against the non-nullable `type=object` schema.

### Fix

When we don't have a note from git, don't set the note field at all. So instead of the field being transformed `{}` -> `null`, it's omitted entirely.

### Regression test

New Ginkgo context inside `Describe("ChangeTransferPolicy Controller") / Context("When reconciling a resource")` drives the populated → empty transition through real reconciles:

1. `makeDryCommit` + `hydrateEnvironment` (which adds a git note) populates `proposed.note.drySha`.
2. `makeChangeAndHydrateRepo` advances the proposed branch to a new hydrated commit with no git note. `setCommitMetadata` writes Note as `&HydratorMetadata{}`, serializing the SSA body with `"note":{}`.
3. The test asserts the Ready condition is True (reason `ReconciliationSuccess`), and the Ready message does NOT contain the `status.proposed.note: Invalid value: "null": proposed.note in body must be of type object` fragments.

Verified that reverting the schema fix makes the test fail with the literal production error captured in the CTP's Ready condition.

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `go test ./internal/controller/ -run TestControllers -ginkgo.focus="proposed.note transitions populated"` passes with the fix (~27s).
- [x] Same test fails with the fix reverted; failure shows the production error string in the Ready condition message.
- [ ] CI


Made with [Cursor](https://cursor.com)