### PR TITLE
Fix activePath issues: branch naming, CommitStatus scoping, FindOpen filter, PR titles

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -22,6 +22,10 @@ const TimedCommitStatusLabel = "promoter.argoproj.io/timed-commit-status"
 // WebRequestCommitStatusLabel the web request commit status which the commit status is associated with.
 const WebRequestCommitStatusLabel = "promoter.argoproj.io/web-request-commit-status"
 
+// ActivePathLabel scopes CommitStatus CRs to a specific activePath when multiple
+// PromotionStrategies share the same environment branches.
+const ActivePathLabel = "promoter.argoproj.io/active-path"
+
 // PreviousEnvironmentCommitStatusKey the commit status key name used to indicate the previous environment health
 const PreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 

--- a/config/config/controllerconfiguration.yaml
+++ b/config/config/controllerconfiguration.yaml
@@ -47,8 +47,8 @@ spec:
               slowDelay: "5m"
               maxFastAttempts: 3
     template:
-      title: "Promote {{ trunc 5 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }} to `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}`"
-      description: "This PR is promoting the environment branch `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}` which is currently on dry sha {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }} to dry sha {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}."
+      title: "Promote {{ with .ChangeTransferPolicy.Spec.ActivePath }}`{{ . }}` {{ end }}({{ trunc 5 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}) to `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}`"
+      description: "This PR is promoting {{ with .ChangeTransferPolicy.Spec.ActivePath }}`{{ . }}` on {{ end }}the environment branch `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}` from dry sha {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }} to {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}."
   commitStatus:
     workQueue:
       maxConcurrentReconciles: 10

--- a/config/samples/promoter_v1alpha1_controllerconfiguration.yaml
+++ b/config/samples/promoter_v1alpha1_controllerconfiguration.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   pullRequest:
     template:
-      title: "Promote {{ trunc 5 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }} to `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}`"
-      description: "This PR is promoting the environment branch `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}` which is currently on dry sha {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }} to dry sha {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}."
+      title: "Promote {{ with .ChangeTransferPolicy.Spec.ActivePath }}`{{ . }}` {{ end }}({{ trunc 5 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}) to `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}`"
+      description: "This PR is promoting {{ with .ChangeTransferPolicy.Spec.ActivePath }}`{{ . }}` on {{ end }}the environment branch `{{ .ChangeTransferPolicy.Spec.ActiveBranch }}` from dry sha {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }} to {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}."
 

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -550,7 +550,7 @@ func (r *ChangeTransferPolicyReconciler) calculateStatus(ctx context.Context, ct
 		return fmt.Errorf("failed to set commit metadata: %w", err)
 	}
 
-	err = r.setCommitStatusState(ctx, &ctp.Status.Active, ctp.Spec.ActiveCommitStatuses)
+	err = r.setCommitStatusState(ctx, &ctp.Status.Active, ctp.Spec.ActiveCommitStatuses, ctp.Spec.ActivePath)
 	if err != nil {
 		var tooManyMatchingShaError *TooManyMatchingShaError
 		if errors.As(err, &tooManyMatchingShaError) {
@@ -559,7 +559,7 @@ func (r *ChangeTransferPolicyReconciler) calculateStatus(ctx context.Context, ct
 		return fmt.Errorf("failed to set active commit status state: %w", err)
 	}
 
-	err = r.setCommitStatusState(ctx, &ctp.Status.Proposed, ctp.Spec.ProposedCommitStatuses)
+	err = r.setCommitStatusState(ctx, &ctp.Status.Proposed, ctp.Spec.ProposedCommitStatuses, ctp.Spec.ActivePath)
 	if err != nil {
 		var tooManyMatchingShaError *TooManyMatchingShaError
 		if errors.As(err, &tooManyMatchingShaError) {
@@ -656,18 +656,21 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 
 // setCommitStatusState sets the hydrated and dry SHAs and commit times for the target commit branch state and sets the
 // commit statuses.
-func (r *ChangeTransferPolicyReconciler) setCommitStatusState(ctx context.Context, targetCommitBranchState *promoterv1alpha1.CommitBranchState, commitStatuses []promoterv1alpha1.CommitStatusSelector) error {
+func (r *ChangeTransferPolicyReconciler) setCommitStatusState(ctx context.Context, targetCommitBranchState *promoterv1alpha1.CommitBranchState, commitStatuses []promoterv1alpha1.CommitStatusSelector, activePath string) error {
 	logger := log.FromContext(ctx)
 
 	commitStatusesState := []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{}
 	var tooManyMatchingShaError error
 	for _, status := range commitStatuses {
 		var csList promoterv1alpha1.CommitStatusList
-		// Find all the replicasets that match the commit status configured name and the sha of the hydrated commit
+		commitStatusLabels := map[string]string{
+			promoterv1alpha1.CommitStatusLabel: utils.KubeSafeLabel(status.Key),
+		}
+		if activePath != "" {
+			commitStatusLabels[promoterv1alpha1.ActivePathLabel] = utils.KubeSafeLabel(activePath)
+		}
 		err := r.List(ctx, &csList, &client.ListOptions{
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				promoterv1alpha1.CommitStatusLabel: utils.KubeSafeLabel(status.Key),
-			}),
+			LabelSelector: labels.SelectorFromSet(commitStatusLabels),
 			FieldSelector: fields.SelectorFromSet(map[string]string{
 				".spec.sha": targetCommitBranchState.Hydrated.Sha,
 			}),

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -591,10 +591,14 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 	}
 
 	// Build the apply configuration
+	csLabels := map[string]string{
+		promoterv1alpha1.CommitStatusLabel: promoterv1alpha1.PreviousEnvironmentCommitStatusKey,
+	}
+	if ctp.Spec.ActivePath != "" {
+		csLabels[promoterv1alpha1.ActivePathLabel] = utils.KubeSafeLabel(ctp.Spec.ActivePath)
+	}
 	commitStatusApply := acv1alpha1.CommitStatus(csName, ctp.Namespace).
-		WithLabels(map[string]string{
-			promoterv1alpha1.CommitStatusLabel: promoterv1alpha1.PreviousEnvironmentCommitStatusKey,
-		}).
+		WithLabels(csLabels).
 		WithAnnotations(map[string]string{
 			promoterv1alpha1.CommitStatusPreviousEnvironmentStatusesAnnotation: string(yamlStatusMap),
 		}).

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -234,7 +234,7 @@ func (r *PromotionStrategyReconciler) upsertChangeTransferPolicy(ctx context.Con
 
 	proposedBranch := fmt.Sprintf("%s-%s", environment.Branch, "next")
 	if ps.Spec.ActivePath != "" {
-		proposedBranch = path.Join(environment.Branch, ps.Spec.ActivePath+"-next")
+		proposedBranch = path.Join(proposedBranch, ps.Spec.ActivePath)
 	}
 
 	// Build the spec

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -348,12 +348,16 @@ func (r *TimedCommitStatusReconciler) upsertCommitStatus(ctx context.Context, tc
 	gvk := promoterv1alpha1.GroupVersion.WithKind(kind)
 
 	// Build the apply configuration
+	commitStatusLabels := map[string]string{
+		promoterv1alpha1.TimedCommitStatusLabel: utils.KubeSafeLabel(tcs.Name),
+		promoterv1alpha1.EnvironmentLabel:       utils.KubeSafeLabel(branch),
+		promoterv1alpha1.CommitStatusLabel:      "timer",
+	}
+	if ps.Spec.ActivePath != "" {
+		commitStatusLabels[promoterv1alpha1.ActivePathLabel] = utils.KubeSafeLabel(ps.Spec.ActivePath)
+	}
 	commitStatusApply := acv1alpha1.CommitStatus(commitStatusName, tcs.Namespace).
-		WithLabels(map[string]string{
-			promoterv1alpha1.TimedCommitStatusLabel: utils.KubeSafeLabel(tcs.Name),
-			promoterv1alpha1.EnvironmentLabel:       utils.KubeSafeLabel(branch),
-			promoterv1alpha1.CommitStatusLabel:      "timer",
-		}).
+		WithLabels(commitStatusLabels).
 		WithOwnerReferences(acmetav1.OwnerReference().
 			WithAPIVersion(gvk.GroupVersion().String()).
 			WithKind(gvk.Kind).

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -319,7 +319,7 @@ func (r *WebRequestCommitStatusReconciler) processEnvironments(ctx context.Conte
 			if lastReconciledEnvStatus != nil && lastState.Phase == string(promoterv1alpha1.CommitPhaseSuccess) && lastSuccessfulSha == reportedSha {
 				logger.V(4).Info("Skipping already successful SHA in polling mode", "branch", branch, "sha", reportedSha)
 				wrcs.Status.Environments = append(wrcs.Status.Environments, *lastReconciledEnvStatus)
-				cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, reportedSha, promoterv1alpha1.CommitPhaseSuccess, td)
+				cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, reportedSha, promoterv1alpha1.CommitPhaseSuccess, td, ps.Spec.ActivePath)
 				if err != nil {
 					return nil, nil, 0, fmt.Errorf("failed to upsert CommitStatus for skipped environment %q: %w", branch, err)
 				}
@@ -365,7 +365,7 @@ func (r *WebRequestCommitStatusReconciler) processEnvironments(ctx context.Conte
 
 		commitTd := td.withLatestOutputs(result.ResponseDataJSON, decision.NewTriggerData, result.SuccessDataJSON)
 		commitTd.Phase = string(result.Phase)
-		cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, reportedSha, result.Phase, commitTd)
+		cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, reportedSha, result.Phase, commitTd, ps.Spec.ActivePath)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("failed to upsert CommitStatus for environment %q: %w", branch, err)
 		}
@@ -414,7 +414,7 @@ func (r *WebRequestCommitStatusReconciler) processContextPromotionStrategy(ctx c
 			for _, env := range applicableEnvs {
 				perEnvTd := baseTd
 				perEnvTd.Branch = env.Branch
-				cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, env.Branch, currentShaPerBranch[env.Branch], promoterv1alpha1.CommitPhaseSuccess, perEnvTd)
+				cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, env.Branch, currentShaPerBranch[env.Branch], promoterv1alpha1.CommitPhaseSuccess, perEnvTd, ps.Spec.ActivePath)
 				if err != nil {
 					return nil, nil, 0, fmt.Errorf("failed to upsert CommitStatus for skipped environment %q (context=promotionstrategy): %w", env.Branch, err)
 				}
@@ -480,7 +480,7 @@ func (r *WebRequestCommitStatusReconciler) processContextPromotionStrategy(ctx c
 		perEnvTd := commitTd
 		perEnvTd.Branch = branch
 		perEnvTd.Phase = string(envPhase)
-		cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, currentShaPerBranch[branch], envPhase, perEnvTd)
+		cs, err := r.upsertCommitStatus(ctx, wrcs, ps.Spec.RepositoryReference.Name, branch, currentShaPerBranch[branch], envPhase, perEnvTd, ps.Spec.ActivePath)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("failed to upsert CommitStatus for environment %q (context=promotionstrategy): %w", branch, err)
 		}
@@ -1184,7 +1184,7 @@ func (r *WebRequestCommitStatusReconciler) applySCMAuthentication(ctx context.Co
 // upsertCommitStatus creates or updates the CommitStatus resource that reports this WebRequestCommitStatus's result to the SCM.
 // The phase (Success or Pending) and sha are set from the validation outcome; description and URL are rendered from templateData.
 // The created resource is owned by the WebRequestCommitStatus so it is cleaned up when the WebRequestCommitStatus is deleted.
-func (r *WebRequestCommitStatusReconciler) upsertCommitStatus(ctx context.Context, wrcs *promoterv1alpha1.WebRequestCommitStatus, repositoryRefName string, branch, sha string, phase promoterv1alpha1.CommitStatusPhase, templateData templateData) (*promoterv1alpha1.CommitStatus, error) {
+func (r *WebRequestCommitStatusReconciler) upsertCommitStatus(ctx context.Context, wrcs *promoterv1alpha1.WebRequestCommitStatus, repositoryRefName string, branch, sha string, phase promoterv1alpha1.CommitStatusPhase, templateData templateData, activePath string) (*promoterv1alpha1.CommitStatus, error) {
 	// Generate a consistent name for the CommitStatus
 	commitStatusName := utils.KubeSafeUniqueName(ctx, fmt.Sprintf("%s-%s-webrequest", wrcs.Name, branch))
 
@@ -1220,12 +1220,16 @@ func (r *WebRequestCommitStatusReconciler) upsertCommitStatus(ctx context.Contex
 	}
 
 	// Build the apply configuration
+	commitStatusLabels := map[string]string{
+		promoterv1alpha1.WebRequestCommitStatusLabel: utils.KubeSafeLabel(wrcs.Name),
+		promoterv1alpha1.EnvironmentLabel:            utils.KubeSafeLabel(branch),
+		promoterv1alpha1.CommitStatusLabel:           wrcs.Spec.Key,
+	}
+	if activePath != "" {
+		commitStatusLabels[promoterv1alpha1.ActivePathLabel] = utils.KubeSafeLabel(activePath)
+	}
 	commitStatusApply := acv1alpha1.CommitStatus(commitStatusName, wrcs.Namespace).
-		WithLabels(map[string]string{
-			promoterv1alpha1.WebRequestCommitStatusLabel: utils.KubeSafeLabel(wrcs.Name),
-			promoterv1alpha1.EnvironmentLabel:            utils.KubeSafeLabel(branch),
-			promoterv1alpha1.CommitStatusLabel:           wrcs.Spec.Key,
-		}).
+		WithLabels(commitStatusLabels).
 		WithOwnerReferences(acmetav1.OwnerReference().
 			WithAPIVersion(gvk.GroupVersion().String()).
 			WithKind(gvk.Kind).

--- a/internal/scms/github/pullrequest.go
+++ b/internal/scms/github/pullrequest.go
@@ -203,7 +203,7 @@ func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRe
 	pullRequests, response, err := pr.client.PullRequests.List(
 		ctx, gitRepo.Spec.GitHub.Owner,
 		gitRepo.Spec.GitHub.Name,
-		&github.PullRequestListOptions{Base: pullRequest.Spec.TargetBranch, Head: pullRequest.Spec.SourceBranch, State: "open"})
+		&github.PullRequestListOptions{Base: pullRequest.Spec.TargetBranch, Head: fmt.Sprintf("%s:%s", gitRepo.Spec.GitHub.Owner, pullRequest.Spec.SourceBranch), State: "open"})
 	if response != nil {
 		metrics.RecordSCMCall(ctx, gitRepo, metrics.SCMAPIPullRequest, metrics.SCMOperationList, response.StatusCode, time.Since(start), getRateLimitMetrics(response.Rate))
 	}


### PR DESCRIPTION
## Summary

Fixes found while testing the `activePath` monorepo mode from #1337 with a [5-component × 6-environment example repo](https://github.com/patjlm/gitops-promoter-example). Details in [discussion #1385](https://github.com/argoproj-labs/gitops-promoter/discussions/1385).

### 1. Git ref conflict: proposed branch names conflict with active branch names (Blocker)

The current naming generates proposed branches as `<active-branch>/<activePath>-next`, e.g. `environment/development/apps/app-a-next`. Git cannot create this ref because `environment/development` already exists as a branch ref.

**Fix** (`766d3e0`): Append activePath to the existing `-next` convention — `environment/development-next/apps/app-a`.

### 2. Shared commit status keys collide in activePath mode (Blocker)

When multiple PromotionStrategies share the same active branch, they share the same commit SHA. If they use the same commit status keys (e.g. `ci-check`), the CTP controller finds multiple CommitStatus CRs with the same `(sha, key)` and errors with "too many matching SHAs". This blocks promotion for all components.

**Fix** (`59014dc`, `404a8ff`): Add an `ActivePathLabel` to CommitStatus CRs and filter on it in `setCommitStatusState`. The label must be set everywhere CommitStatus CRs are created: WebRequestCommitStatus controller, TimedCommitStatus controller, and `createOrUpdatePreviousEnvironmentCommitStatus` in the PromotionStrategy controller. Without the label on `promoter-previous-environment` CRs, promotion beyond the first environment is blocked.

### 3. PR title and description should include activePath (Enhancement)

With shared active branches, all PRs are titled `Promote <sha> to environment/development` — indistinguishable.

**Fix** (`5e13fa3`): Update the default PR title template to conditionally include activePath.

### 4. FindOpen returns wrong PR when multiple PRs target the same base branch (Medium)

Not activePath-specific, but exposed by it. `FindOpen` in the GitHub SCM provider passes `pullRequest.Spec.SourceBranch` directly as the `Head` filter to GitHub's List Pull Requests API. GitHub requires `owner:branch` format — without the `owner:` prefix, GitHub silently ignores the filter and returns all open PRs for the base branch. `FindOpen` then picks `pullRequests[0]` and the subsequent `Update` overwrites the wrong PR's title.

**Fix** (`23a6558`): Prefix `Head` with `gitRepo.Spec.GitHub.Owner`.

## Test plan

- [x] Tested with [gitops-promoter-example](https://github.com/patjlm/gitops-promoter-example): 5 components × 6 environments, shared active branches, same commit status keys
- [x] Full promotion pipeline verified: development → integration → stage (with 2min soak timer) → prod (manual merge)
- [x] Single-component change (app-b only) promotes independently without affecting other components
- [x] PRs created with correct titles and source branches (no cross-contamination)
- [x] CommitStatus CRs don't collide across components sharing the same active branch
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)