### PR TITLE
fix(github): prefix owner in FindOpen head filter

### DIFF
--- a/internal/scms/github/pullrequest.go
+++ b/internal/scms/github/pullrequest.go
@@ -203,7 +203,7 @@ func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRe
 	pullRequests, response, err := pr.client.PullRequests.List(
 		ctx, gitRepo.Spec.GitHub.Owner,
 		gitRepo.Spec.GitHub.Name,
-		&github.PullRequestListOptions{Base: pullRequest.Spec.TargetBranch, Head: pullRequest.Spec.SourceBranch, State: "open"})
+		&github.PullRequestListOptions{Base: pullRequest.Spec.TargetBranch, Head: fmt.Sprintf("%s:%s", gitRepo.Spec.GitHub.Owner, pullRequest.Spec.SourceBranch), State: "open"})
 	if response != nil {
 		metrics.RecordSCMCall(ctx, gitRepo, metrics.SCMAPIPullRequest, metrics.SCMOperationList, response.StatusCode, time.Since(start), getRateLimitMetrics(response.Rate))
 	}


### PR DESCRIPTION
## Summary

The GitHub REST API's [List pull requests](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests) endpoint requires the `head` parameter to use the format `owner:branch-name`. When a bare branch name is passed, the filter is **silently ignored** and the API returns all open PRs for the base branch instead of only the one matching the source branch.

This bug means `FindOpen` could match the wrong PR (or multiple PRs) when several PRs target the same base branch.

The fix prefixes `Head` with `gitRepo.Spec.GitHub.Owner` so the filter works as intended.

## References

- [GitHub REST API — List pull requests](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests): *"Filter pulls by head user or head organization and branch name in the format of `user:ref-name` or `organization:ref-name`."*
- [GitHub Community Discussion #24354](https://github.com/orgs/community/discussions/24354): confirms the silent-ignore behavior when the owner prefix is omitted.

Extracted from #1408 per [review comment](https://github.com/argoproj-labs/gitops-promoter/pull/1408#discussion_r3204571623).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>