### PR TITLE
feat: provide namespaced mode (#310)

### DIFF
--- a/api/v1alpha1/controllerconfiguration_types.go
+++ b/api/v1alpha1/controllerconfiguration_types.go
@@ -69,6 +69,13 @@ type ControllerConfigurationSpec struct {
 	// including WorkQueue settings that control reconciliation behavior.
 	// +required
 	WebRequestCommitStatus WebRequestCommitStatusConfiguration `json:"webRequestCommitStatus"`
+
+	// Namespaced, when true, configures the controller-runtime cache to list/watch only in the
+	// controller install namespace (the kubeconfig default namespace / ManagerConfig.controllerNamespace).
+	// This matches namespace-scoped Role RBAC. When false or unset, the controller uses the default
+	// cluster-wide list/watch (ClusterRole). Changing this value requires a controller restart to take effect.
+	// +optional
+	Namespaced bool `json:"namespaced,omitempty"`
 }
 
 // PromotionStrategyConfiguration defines the configuration for the PromotionStrategy controller.

--- a/applyconfiguration/api/v1alpha1/controllerconfigurationspec.go
+++ b/applyconfiguration/api/v1alpha1/controllerconfigurationspec.go
@@ -53,6 +53,11 @@ type ControllerConfigurationSpecApplyConfiguration struct {
 	// WebRequestCommitStatus contains the configuration for the WebRequestCommitStatus controller,
 	// including WorkQueue settings that control reconciliation behavior.
 	WebRequestCommitStatus *WebRequestCommitStatusConfigurationApplyConfiguration `json:"webRequestCommitStatus,omitempty"`
+	// Namespaced, when true, configures the controller-runtime cache to list/watch only in the
+	// controller install namespace (the kubeconfig default namespace / ManagerConfig.controllerNamespace).
+	// This matches namespace-scoped Role RBAC. When false or unset, the controller uses the default
+	// cluster-wide list/watch (ClusterRole). Changing this value requires a controller restart to take effect.
+	Namespaced *bool `json:"namespaced,omitempty"`
 }
 
 // ControllerConfigurationSpecApplyConfiguration constructs a declarative configuration of the ControllerConfigurationSpec type for use with
@@ -122,5 +127,13 @@ func (b *ControllerConfigurationSpecApplyConfiguration) WithGitCommitStatus(valu
 // If called multiple times, the WebRequestCommitStatus field is set to the value of the last call.
 func (b *ControllerConfigurationSpecApplyConfiguration) WithWebRequestCommitStatus(value *WebRequestCommitStatusConfigurationApplyConfiguration) *ControllerConfigurationSpecApplyConfiguration {
 	b.WebRequestCommitStatus = value
+	return b
+}
+
+// WithNamespaced sets the Namespaced field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Namespaced field is set to the value of the last call.
+func (b *ControllerConfigurationSpecApplyConfiguration) WithNamespaced(value bool) *ControllerConfigurationSpecApplyConfiguration {
+	b.Namespaced = &value
 	return b
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/rest"
 
 	"github.com/argoproj-labs/gitops-promoter/cmd/demo"
 	"github.com/argoproj-labs/gitops-promoter/internal/controller"
@@ -105,6 +106,7 @@ func newControllerCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	return cmd
 }
 
+//nolint:gocyclo // A long function in this case is clearer than a bunch of small functions.
 func runController(
 	metricsAddr string,
 	probeAddr string,
@@ -120,7 +122,7 @@ func runController(
 		os.Exit(1)
 	}
 	if controllerNamespace == "" {
-		setupLog.Error(err, "kubeconfig must set a default namespace (install namespace) to load ControllerConfiguration before the manager starts")
+		setupLog.Error(err, "kubeconfig must set a default (install) namespace")
 	}
 
 	restCfg, err := clientConfig.ClientConfig()
@@ -129,19 +131,10 @@ func runController(
 		os.Exit(1)
 	}
 
-	bootstrapClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	namespaced, err := getNamespaced(restCfg, controllerNamespace)
 	if err != nil {
-		return fmt.Errorf("create kubernetes client for bootstrap: %w", err)
-	}
-	bootstrapSettings := settings.NewManager(bootstrapClient, bootstrapClient, settings.ManagerConfig{
-		ControllerNamespace: controllerNamespace,
-	})
-
-	readCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	useRestrictedCache, err := bootstrapSettings.GetNamespacedDirect(readCtx)
-	if err != nil {
-		return fmt.Errorf("bootstrap read of ControllerConfiguration: %w", err)
+		setupLog.Error(err, "failed to get namespaced mode config")
+		os.Exit(1)
 	}
 
 	// Recover any panic and log using the configured logger. This ensures that panics get logged in JSON format if
@@ -173,7 +166,7 @@ func runController(
 		TLSOpts: tlsOpts,
 	})
 
-	if useRestrictedCache {
+	if namespaced {
 		setupLog.Info("restricting controller-runtime cache to controller install namespace; "+
 			"list/watch requests will be namespace-scoped (compatible with a namespaced Role)",
 			"namespace", controllerNamespace)
@@ -219,7 +212,8 @@ func runController(
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 	}
-	if useRestrictedCache {
+
+	if namespaced {
 		managerOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 			controllerNamespace: {},
 		}
@@ -411,6 +405,24 @@ func runController(
 		setupLog.Info("cleaning directory", "directory", path)
 	}
 	return nil
+}
+
+func getNamespaced(restCfg *rest.Config, controllerNamespace string) (bool, error) {
+	bootstrapClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return false, fmt.Errorf("create kubernetes client for bootstrap: %w", err)
+	}
+	bootstrapSettings := settings.NewManager(bootstrapClient, bootstrapClient, settings.ManagerConfig{
+		ControllerNamespace: controllerNamespace,
+	})
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	useRestrictedCache, err := bootstrapSettings.GetNamespacedDirect(readCtx)
+	if err != nil {
+		return false, fmt.Errorf("bootstrap read of ControllerConfiguration: %w", err)
+	}
+	return useRestrictedCache, nil
 }
 
 func newDashboardCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,26 +25,23 @@ import (
 	"os"
 	"runtime/debug"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/argoproj-labs/gitops-promoter/cmd/demo"
 	"github.com/argoproj-labs/gitops-promoter/internal/controller"
 	"github.com/argoproj-labs/gitops-promoter/internal/metrics"
+	"github.com/argoproj-labs/gitops-promoter/internal/settings"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils/gitpaths"
+	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver"
 	"github.com/argoproj-labs/gitops-promoter/internal/webserver"
-
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/argoproj-labs/gitops-promoter/internal/settings"
-	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
-	"github.com/argoproj-labs/gitops-promoter/internal/utils/gitpaths"
-	"github.com/argoproj-labs/gitops-promoter/internal/webhookreceiver"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -53,7 +50,11 @@ import (
 	"k8s.io/klog/v2"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -118,6 +119,30 @@ func runController(
 		setupLog.Error(err, "failed to get namespace")
 		os.Exit(1)
 	}
+	if controllerNamespace == "" {
+		setupLog.Error(err, "kubeconfig must set a default namespace (install namespace) to load ControllerConfiguration before the manager starts")
+	}
+
+	restCfg, err := clientConfig.ClientConfig()
+	if err != nil {
+		setupLog.Error(err, "failed to get rest config")
+		os.Exit(1)
+	}
+
+	bootstrapClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("create kubernetes client for bootstrap: %w", err)
+	}
+	bootstrapSettings := settings.NewManager(bootstrapClient, bootstrapClient, settings.ManagerConfig{
+		ControllerNamespace: controllerNamespace,
+	})
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	useRestrictedCache, err := bootstrapSettings.GetNamespacedDirect(readCtx)
+	if err != nil {
+		return fmt.Errorf("bootstrap read of ControllerConfiguration: %w", err)
+	}
 
 	// Recover any panic and log using the configured logger. This ensures that panics get logged in JSON format if
 	// JSON logging is enabled.
@@ -148,6 +173,12 @@ func runController(
 		TLSOpts: tlsOpts,
 	})
 
+	if useRestrictedCache {
+		setupLog.Info("restricting controller-runtime cache to controller install namespace; "+
+			"list/watch requests will be namespace-scoped (compatible with a namespaced Role)",
+			"namespace", controllerNamespace)
+	}
+
 	// Create the kubeconfig provider with options
 	providerOpts := kubeconfigprovider.Options{
 		Namespace:             controllerNamespace,
@@ -163,7 +194,7 @@ func runController(
 	// Create the provider first, then the manager with the provider
 	provider := kubeconfigprovider.New(providerOpts)
 
-	mcMgr, err := mcmanager.New(ctrl.GetConfigOrDie(), provider, ctrl.Options{
+	managerOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress:    metricsAddr,
@@ -187,7 +218,14 @@ func runController(
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+	if useRestrictedCache {
+		managerOpts.Cache.DefaultNamespaces = map[string]cache.Config{
+			controllerNamespace: {},
+		}
+	}
+
+	mcMgr, err := mcmanager.New(restCfg, provider, managerOpts)
 	if err != nil {
 		panic(fmt.Errorf("unable to start manager: %w", err))
 	}

--- a/config/config/controllerconfiguration.yaml
+++ b/config/config/controllerconfiguration.yaml
@@ -115,3 +115,4 @@ spec:
               fastDelay: "1s"
               slowDelay: "5m"
               maxFastAttempts: 3
+  namespaced: false

--- a/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
+++ b/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
@@ -891,6 +891,13 @@ spec:
                 required:
                 - workQueue
                 type: object
+              namespaced:
+                description: |-
+                  Namespaced, when true, configures the controller-runtime cache to list/watch only in the
+                  controller install namespace (the kubeconfig default namespace / ManagerConfig.controllerNamespace).
+                  This matches namespace-scoped Role RBAC. When false or unset, the controller uses the default
+                  cluster-wide list/watch (ClusterRole). Changing this value requires a controller restart to take effect.
+                type: boolean
               promotionStrategy:
                 description: |-
                   PromotionStrategy contains the configuration for the PromotionStrategy controller,

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2946,6 +2946,13 @@ spec:
                 required:
                 - workQueue
                 type: object
+              namespaced:
+                description: |-
+                  Namespaced, when true, configures the controller-runtime cache to list/watch only in the
+                  controller install namespace (the kubeconfig default namespace / ManagerConfig.controllerNamespace).
+                  This matches namespace-scoped Role RBAC. When false or unset, the controller uses the default
+                  cluster-wide list/watch (ClusterRole). Changing this value requires a controller restart to take effect.
+                type: boolean
               promotionStrategy:
                 description: |-
                   PromotionStrategy contains the configuration for the PromotionStrategy controller,
@@ -8342,6 +8349,7 @@ spec:
             maxFastAttempts: 3
             slowDelay: 5m
       requeueDuration: 5m
+  namespaced: false
   promotionStrategy:
     workQueue:
       maxConcurrentReconciles: 10

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -32,6 +32,17 @@ that one tenant's resources do not reference another tenant's resources within t
 If there are no trust boundaries to be enforced among PromotionStrategy users, a GitOps Promoter admin may choose to 
 host all resources in a single namespace, keeping in mind the need to avoid resource name collisions.
 
+## Namespace-scoped RBAC (Role instead of ClusterRole)
+
+By default the controller-runtime cache lists **all namespaces** for namespaced custom resources (for example `ScmProvider`, `CommitStatus`, `PromotionStrategy`). That list operation is evaluated at **cluster** scope, so it requires a `ClusterRole` with `list`/`watch` on those resources.
+
+If you bind only a namespace-scoped `Role`, enable a **namespace-scoped cache** so list/watch calls are limited to the **controller install namespace** (the same namespace as `ControllerConfiguration` and `ManagerConfig.controllerNamespace` from the kubeconfig default context—typically the pod namespace when in-cluster). Set **`ControllerConfiguration.spec.namespaced`** to `true`. The controller reads that resource once at startup (before the cache starts), so the `ControllerConfiguration` object **must already exist** in that namespace. **Restart the controller** after changing this field.
+
+When namespaced cache is active:
+
+* **`ClusterScmProvider`** is cluster-scoped: with only a namespace-scoped `Role`, the informer may repeatedly log **forbidden** list/watch errors for `clusterscmproviders`. That is noisy but does not crash the pod. Either extend RBAC so the service account can list/watch `clusterscmproviders` at cluster scope, or ignore those logs if you only use namespaced **`ScmProvider`**.
+* The controller only sees **CommitStatus** objects in the controller install namespace. PromotionStrategy behavior that depends on CommitStatuses in *other* namespaces (see [CommitStatus Tenancy](#commitstatus-tenancy)) will not see those remote CommitStatuses unless they are moved into that namespace.
+
 ## CommitStatus Tenancy
 
 As with PromotionStrategies, all references from CommitStatuses (to GitRepositories, then ScmProviders, and finally to

--- a/internal/settings/manager.go
+++ b/internal/settings/manager.go
@@ -8,6 +8,7 @@ import (
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	"golang.org/x/time/rate"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -61,6 +62,8 @@ type ControllerResultTypes interface {
 type ManagerConfig struct {
 	// ControllerNamespace is the namespace where the promoter controller is running.
 	// This namespace is used when fetching the ControllerConfiguration resource from the cluster.
+	// When ControllerConfiguration.spec.namespaced is true, the
+	// controller-runtime cache is also limited to this namespace.
 	ControllerNamespace string
 }
 
@@ -237,6 +240,20 @@ func GetRateLimiterDirect[T ControllerConfigurationTypes, R ControllerResultType
 	}
 
 	return limiter, nil
+}
+
+// GetNamespacedDirect returns spec.namespaced using a non-cached read.
+// It is safe to call before the manager cache has started.
+func (m *Manager) GetNamespacedDirect(ctx context.Context) (bool, error) {
+	cc, err := m.getControllerConfigurationDirect(ctx)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, fmt.Errorf("ControllerConfiguration %q not found in namespace %q (required before controller start): %w",
+				ControllerConfigurationName, m.config.ControllerNamespace, err)
+		}
+		return false, err
+	}
+	return cc.Spec.Namespaced, nil
 }
 
 // getWorkQueueForController retrieves the WorkQueue configuration for a specific controller type.


### PR DESCRIPTION
Partially fixed #310 

This implementation only allows monitoring resources in the same namespace as GitOps Promoter, but controller-runtime supports a list of namespaces. I think we should leave that as a future enhancement.

@zachaller mentioned potentially using the multicluster-runtime namespace provider. I think the only possible advantage to that option is the ability to hot-reload the list of configured namespaces. But I don't think the overhead of using multicluster-runtime would be worth it.