### PR TITLE
feat(acdcs): resolve root-relative URL templates via argocd-cm

### DIFF
--- a/api/v1alpha1/argocdcommitstatus_types.go
+++ b/api/v1alpha1/argocdcommitstatus_types.go
@@ -34,8 +34,25 @@ type ArgoCDCommitStatusSpec struct {
 	ApplicationSelector *metav1.LabelSelector `json:"applicationSelector,omitempty"`
 
 	// URL generates the URL to use in the CommitStatus, for example a link to the Argo CD UI.
+	// The template may render either an absolute http(s) URL or a root-relative path
+	// beginning with "/" (but not "//"). Root-relative output is resolved against
+	// ArgoCDBaseURL (if set) or argocd-cm.url on the local cluster, producing the
+	// absolute URL stored on CommitStatus.spec.url.
 	// +kubebuilder:validation:Optional
 	URL URLConfig `json:"url,omitempty"`
+
+	// ArgoCDBaseURL is the external base URL of the Argo CD instance whose Applications
+	// this commit status aggregates. It is used to resolve root-relative URLs produced
+	// by URL.Template into absolute URLs (required, since SCM providers forward
+	// CommitStatus.spec.url as details_url / target_url and reject non-http(s) values).
+	//
+	// Precedence: this field takes priority over the argocd-cm.url ConfigMap on the
+	// local cluster. Setting it is only necessary when URL.Template renders root-relative
+	// AND the local argocd-cm is unavailable, has no `url` key, or reports an URL that
+	// differs from the externally-reachable Argo CD origin (e.g. behind a proxy).
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^(|https?://[^\s]+)$`
+	ArgoCDBaseURL string `json:"argocdBaseURL,omitempty"`
 }
 
 // URLConfig is a template that can be rendered using the Go template engine.

--- a/applyconfiguration/api/v1alpha1/argocdcommitstatusspec.go
+++ b/applyconfiguration/api/v1alpha1/argocdcommitstatusspec.go
@@ -33,7 +33,21 @@ type ArgoCDCommitStatusSpecApplyConfiguration struct {
 	// ApplicationSelector is a label selector that selects the Argo CD applications to which this commit status applies.
 	ApplicationSelector *v1.LabelSelectorApplyConfiguration `json:"applicationSelector,omitempty"`
 	// URL generates the URL to use in the CommitStatus, for example a link to the Argo CD UI.
+	// The template may render either an absolute http(s) URL or a root-relative path
+	// beginning with "/" (but not "//"). Root-relative output is resolved against
+	// ArgoCDBaseURL (if set) or argocd-cm.url on the local cluster, producing the
+	// absolute URL stored on CommitStatus.spec.url.
 	URL *URLConfigApplyConfiguration `json:"url,omitempty"`
+	// ArgoCDBaseURL is the external base URL of the Argo CD instance whose Applications
+	// this commit status aggregates. It is used to resolve root-relative URLs produced
+	// by URL.Template into absolute URLs (required, since SCM providers forward
+	// CommitStatus.spec.url as details_url / target_url and reject non-http(s) values).
+	//
+	// Precedence: this field takes priority over the argocd-cm.url ConfigMap on the
+	// local cluster. Setting it is only necessary when URL.Template renders root-relative
+	// AND the local argocd-cm is unavailable, has no `url` key, or reports an URL that
+	// differs from the externally-reachable Argo CD origin (e.g. behind a proxy).
+	ArgoCDBaseURL *string `json:"argocdBaseURL,omitempty"`
 }
 
 // ArgoCDCommitStatusSpecApplyConfiguration constructs a declarative configuration of the ArgoCDCommitStatusSpec type for use with
@@ -63,5 +77,13 @@ func (b *ArgoCDCommitStatusSpecApplyConfiguration) WithApplicationSelector(value
 // If called multiple times, the URL field is set to the value of the last call.
 func (b *ArgoCDCommitStatusSpecApplyConfiguration) WithURL(value *URLConfigApplyConfiguration) *ArgoCDCommitStatusSpecApplyConfiguration {
 	b.URL = value
+	return b
+}
+
+// WithArgoCDBaseURL sets the ArgoCDBaseURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ArgoCDBaseURL field is set to the value of the last call.
+func (b *ArgoCDCommitStatusSpecApplyConfiguration) WithArgoCDBaseURL(value string) *ArgoCDCommitStatusSpecApplyConfiguration {
+	b.ArgoCDBaseURL = &value
 	return b
 }

--- a/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
@@ -95,6 +95,19 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              argocdBaseURL:
+                description: |-
+                  ArgoCDBaseURL is the external base URL of the Argo CD instance whose Applications
+                  this commit status aggregates. It is used to resolve root-relative URLs produced
+                  by URL.Template into absolute URLs (required, since SCM providers forward
+                  CommitStatus.spec.url as details_url / target_url and reject non-http(s) values).
+
+                  Precedence: this field takes priority over the argocd-cm.url ConfigMap on the
+                  local cluster. Setting it is only necessary when URL.Template renders root-relative
+                  AND the local argocd-cm is unavailable, has no `url` key, or reports an URL that
+                  differs from the externally-reachable Argo CD origin (e.g. behind a proxy).
+                pattern: ^(|https?://[^\s]+)$
+                type: string
               promotionStrategyRef:
                 description: PromotionStrategyRef is a reference to the promotion
                   strategy that this commit status applies to.
@@ -109,8 +122,12 @@ spec:
                 - name
                 type: object
               url:
-                description: URL generates the URL to use in the CommitStatus, for
-                  example a link to the Argo CD UI.
+                description: |-
+                  URL generates the URL to use in the CommitStatus, for example a link to the Argo CD UI.
+                  The template may render either an absolute http(s) URL or a root-relative path
+                  beginning with "/" (but not "//"). Root-relative output is resolved against
+                  ArgoCDBaseURL (if set) or argocd-cm.url on the local cluster, producing the
+                  absolute URL stored on CommitStatus.spec.url.
                 properties:
                   options:
                     description: "Options sets options for the template. Options are

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - argocd-cm
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - namespaces
   verbs:

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -56,6 +56,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 	"sigs.k8s.io/multicluster-runtime/providers/kubeconfig"
 
+	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +73,16 @@ import (
 // lastTransitionTimeThreshold is the threshold for the last transition time to consider an application healthy.
 // This helps avoid premature acceptance of a transitive healthy state.
 const lastTransitionTimeThreshold = 5 * time.Second
+
+// argoCDConfigMapName is the conventional name of the Argo CD config map.
+const argoCDConfigMapName = "argocd-cm"
+
+// argoCDConfigMapNamespace is the conventional namespace of the Argo CD config map.
+const argoCDConfigMapNamespace = "argocd"
+
+// argoCDConfigMapURLKey is the key in argocd-cm whose value is the externally
+// reachable base URL of the Argo CD instance.
+const argoCDConfigMapURLKey = "url"
 
 // ArgoCDCommitStatusReconciler reconciles a ArgoCDCommitStatus object
 type ArgoCDCommitStatusReconciler struct {
@@ -100,6 +111,7 @@ type ApplicationsInEnvironment struct {
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=argocdcommitstatuses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=promotionstrategies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get,resourceNames=argocd-cm
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -198,6 +210,11 @@ func (r *ArgoCDCommitStatusReconciler) Reconcile(ctx context.Context, req mcreco
 		return ctrl.Result{}, fmt.Errorf("failed to get head shas for target branches: %w", err)
 	}
 
+	argoCDBaseURL, err := r.resolveArgoCDBaseURL(ctx, &argoCDCommitStatus)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	maxTimeUntilThreshold := time.Duration(0)
 	commitStatuses := make([]*promoterv1alpha1.CommitStatus, len(groupedArgoCDApps))
 	var i int
@@ -209,7 +226,7 @@ func (r *ArgoCDCommitStatusReconciler) Reconcile(ctx context.Context, req mcreco
 		resolvedPhase, desc := r.calculateAggregatedPhaseAndDescription(appsInEnvironment, resolvedSha)
 		resolvedPhase, maxTimeUntilThreshold = getRequeueTimeAndPhase(appsInEnvironment, resolvedPhase, maxTimeUntilThreshold)
 
-		cs, err := r.updateAggregatedCommitStatus(ctx, &promotionStrategy, argoCDCommitStatus, targetBranch, resolvedSha, resolvedPhase, desc)
+		cs, err := r.updateAggregatedCommitStatus(ctx, &promotionStrategy, &argoCDCommitStatus, argoCDBaseURL, targetBranch, resolvedSha, resolvedPhase, desc)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -610,9 +627,64 @@ var applicationPredicate predicate.Predicate = predicate.Funcs{
 	},
 }
 
+// resolveArgoCDBaseURL returns the external base URL of Argo CD to use when
+// resolving root-relative URLs produced by an ArgoCDCommitStatus URL template.
+//
+// Precedence:
+//  1. argoCDCommitStatus.Spec.ArgoCDBaseURL (per-resource override) wins if set.
+//  2. Otherwise, read argocd-cm.url from the argocd namespace on the local cluster.
+//  3. If neither is available, return "" with no error. The caller decides what
+//     to do (skip writing CommitStatus.spec.url and surface a Ready condition).
+//
+// A genuine API error (other than "ConfigMap not found") is propagated.
+func (r *ArgoCDCommitStatusReconciler) resolveArgoCDBaseURL(ctx context.Context, argoCDCommitStatus *promoterv1alpha1.ArgoCDCommitStatus) (string, error) {
+	if argoCDCommitStatus.Spec.ArgoCDBaseURL != "" {
+		return strings.TrimRight(argoCDCommitStatus.Spec.ArgoCDBaseURL, "/"), nil
+	}
+
+	var cm corev1.ConfigMap
+	err := r.localClient.Get(ctx, client.ObjectKey{Namespace: argoCDConfigMapNamespace, Name: argoCDConfigMapName}, &cm)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", argoCDConfigMapNamespace, argoCDConfigMapName, err)
+	}
+	return strings.TrimRight(cm.Data[argoCDConfigMapURLKey], "/"), nil
+}
+
+// renderAndResolveCommitStatusURL renders the URL template and, if the rendered
+// value is root-relative ("/..." but not "//..."), prepends argoCDBaseURL to
+// produce an absolute http(s) URL. Returns (absoluteURL, ok, err): ok is false
+// when the URL field should be omitted from the CommitStatus (root-relative
+// template + no base URL available).
+func renderAndResolveCommitStatusURL(template string, options []string, data URLTemplateData, argoCDBaseURL string) (string, bool, error) {
+	rendered, err := utils.RenderStringTemplate(template, data, options...)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to render URL template: %w", err)
+	}
+	rendered = strings.TrimSpace(rendered)
+
+	if strings.HasPrefix(rendered, "/") && !strings.HasPrefix(rendered, "//") {
+		if argoCDBaseURL == "" {
+			return "", false, nil
+		}
+		return argoCDBaseURL + rendered, true, nil
+	}
+
+	parsedURL, err := url.Parse(rendered)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return "", false, fmt.Errorf("URL scheme is not http or https: %s", parsedURL.Scheme)
+	}
+	return rendered, true, nil
+}
+
 // updateAggregatedCommitStatus creates or updates a CommitStatus object for the given target branch and sha.
 // If err is nil, the returned CommitStatus is guaranteed to be non-nil.
-func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.Context, promotionStrategy *promoterv1alpha1.PromotionStrategy, argoCDCommitStatus promoterv1alpha1.ArgoCDCommitStatus, targetBranch string, sha string, phase promoterv1alpha1.CommitStatusPhase, desc string) (*promoterv1alpha1.CommitStatus, error) {
+func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.Context, promotionStrategy *promoterv1alpha1.PromotionStrategy, argoCDCommitStatus *promoterv1alpha1.ArgoCDCommitStatus, argoCDBaseURL string, targetBranch string, sha string, phase promoterv1alpha1.CommitStatusPhase, desc string) (*promoterv1alpha1.CommitStatus, error) {
 	logger := log.FromContext(ctx)
 
 	commitStatusName := targetBranch + "/health"
@@ -629,32 +701,31 @@ func (r *ArgoCDCommitStatusReconciler) updateAggregatedCommitStatus(ctx context.
 		WithDescription(desc).
 		WithPhase(phase)
 
-	// Render URL from template if it exists
+	// Render URL from template if it exists. Root-relative templates are resolved
+	// against argoCDBaseURL; absolute http(s) templates pass through.
 	if argoCDCommitStatus.Spec.URL.Template != "" {
 		data := URLTemplateData{
 			Environment:        targetBranch,
-			ArgoCDCommitStatus: argoCDCommitStatus,
+			ArgoCDCommitStatus: *argoCDCommitStatus,
 		}
 
-		renderedURL, err := utils.RenderStringTemplate(argoCDCommitStatus.Spec.URL.Template, data, argoCDCommitStatus.Spec.URL.Options...)
+		resolvedURL, ok, err := renderAndResolveCommitStatusURL(argoCDCommitStatus.Spec.URL.Template, argoCDCommitStatus.Spec.URL.Options, data, argoCDBaseURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render URL template: %w", err)
+			return nil, err
 		}
-
-		// Parse the URL to check that it's valid
-		parsedURL, err := url.Parse(renderedURL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse URL: %w", err)
+		if ok {
+			logger.V(4).Info("Rendered URL template", "url", resolvedURL, "environment", targetBranch, "commitStatus", resourceName, "namespace", argoCDCommitStatus.Namespace)
+			commitStatusSpec = commitStatusSpec.WithUrl(resolvedURL)
+		} else {
+			logger.Info("Omitting CommitStatus.spec.url: URL template rendered root-relative but no Argo CD base URL is configured", "environment", targetBranch, "commitStatus", resourceName, "namespace", argoCDCommitStatus.Namespace)
+			meta.SetStatusCondition(argoCDCommitStatus.GetConditions(), metav1.Condition{
+				Type:               string(promoterConditions.Ready),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(promoterConditions.ArgoCDBaseURLUnset),
+				Message:            fmt.Sprintf("URL template rendered a root-relative path for environment %q but no Argo CD base URL is available; set spec.argocdBaseURL or configure %s/%s with a %q key", targetBranch, argoCDConfigMapNamespace, argoCDConfigMapName, argoCDConfigMapURLKey),
+				ObservedGeneration: argoCDCommitStatus.GetGeneration(),
+			})
 		}
-
-		// Check that the URL scheme is http or https
-		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			return nil, fmt.Errorf("URL scheme is not http or https: %s", parsedURL.Scheme)
-		}
-
-		// Set the URL in the CommitStatus
-		logger.V(4).Info("Rendered URL template", "url", renderedURL, "environment", targetBranch, "commitStatus", resourceName, "namespace", argoCDCommitStatus.Namespace)
-		commitStatusSpec = commitStatusSpec.WithUrl(renderedURL)
 	}
 
 	// Build the apply configuration

--- a/internal/controller/argocdcommitstatus_url_test.go
+++ b/internal/controller/argocdcommitstatus_url_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRenderAndResolveCommitStatusURL(t *testing.T) {
+	t.Parallel()
+
+	data := URLTemplateData{
+		Environment: "environment/staging",
+		ArgoCDCommitStatus: promoterv1alpha1.ArgoCDCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		template      string
+		argoCDBaseURL string
+		wantURL       string
+		wantOK        bool
+		wantErr       bool
+	}{
+		{
+			name:          "absolute https template passes through unchanged",
+			template:      "https://argocd.example.com/applications?env={{.Environment}}",
+			argoCDBaseURL: "https://ignored.example.com",
+			wantURL:       "https://argocd.example.com/applications?env=environment/staging",
+			wantOK:        true,
+		},
+		{
+			name:          "absolute http template passes through",
+			template:      "http://argocd.local/x",
+			argoCDBaseURL: "",
+			wantURL:       "http://argocd.local/x",
+			wantOK:        true,
+		},
+		{
+			name:          "root-relative template with base URL is prepended",
+			template:      "/applications?env={{.Environment}}",
+			argoCDBaseURL: "https://argocd.example.com",
+			wantURL:       "https://argocd.example.com/applications?env=environment/staging",
+			wantOK:        true,
+		},
+		{
+			name:          "root-relative template with no base URL returns ok=false",
+			template:      "/applications",
+			argoCDBaseURL: "",
+			wantURL:       "",
+			wantOK:        false,
+		},
+		{
+			name:          "leading/trailing whitespace is trimmed before prepend",
+			template:      "  /applications  ",
+			argoCDBaseURL: "https://argocd.example.com",
+			wantURL:       "https://argocd.example.com/applications",
+			wantOK:        true,
+		},
+		{
+			name:          "protocol-relative URL is rejected",
+			template:      "//evil.example.com/x",
+			argoCDBaseURL: "https://argocd.example.com",
+			wantErr:       true,
+		},
+		{
+			name:          "ftp scheme is rejected",
+			template:      "ftp://example.com/x",
+			argoCDBaseURL: "",
+			wantErr:       true,
+		},
+		{
+			name:          "rendered value with no scheme and no leading slash is rejected",
+			template:      "applications",
+			argoCDBaseURL: "https://argocd.example.com",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotURL, gotOK, err := renderAndResolveCommitStatusURL(tt.template, nil, data, tt.argoCDBaseURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotURL != tt.wantURL {
+				t.Errorf("url = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestResolveArgoCDBaseURL(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := promoterv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add promoter scheme: %v", err)
+	}
+
+	makeCM := func(url string) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      argoCDConfigMapName,
+				Namespace: argoCDConfigMapNamespace,
+			},
+		}
+		if url != "" {
+			cm.Data = map[string]string{argoCDConfigMapURLKey: url}
+		}
+		return cm
+	}
+
+	tests := []struct {
+		name         string
+		override     string
+		configMapURL string
+		wantBaseURL  string
+		hasConfigMap bool
+		wantErr      bool
+	}{
+		{
+			name:         "override wins over configmap",
+			override:     "https://override.example.com",
+			configMapURL: "https://argocd-cm.example.com",
+			wantBaseURL:  "https://override.example.com",
+			hasConfigMap: true,
+		},
+		{
+			name:        "trailing slash on override is trimmed",
+			override:    "https://override.example.com/",
+			wantBaseURL: "https://override.example.com",
+		},
+		{
+			name:         "configmap url used when no override",
+			configMapURL: "https://argocd-cm.example.com",
+			wantBaseURL:  "https://argocd-cm.example.com",
+			hasConfigMap: true,
+		},
+		{
+			name:         "trailing slash on configmap value is trimmed",
+			configMapURL: "https://argocd-cm.example.com/",
+			wantBaseURL:  "https://argocd-cm.example.com",
+			hasConfigMap: true,
+		},
+		{
+			name:         "configmap present but url key empty falls through to empty",
+			configMapURL: "",
+			wantBaseURL:  "",
+			hasConfigMap: true,
+		},
+		{
+			name:        "no override and no configmap returns empty without error",
+			wantBaseURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			objs := []client.Object{}
+			if tt.hasConfigMap {
+				objs = append(objs, makeCM(tt.configMapURL))
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+			r := &ArgoCDCommitStatusReconciler{localClient: c}
+			acs := &promoterv1alpha1.ArgoCDCommitStatus{
+				Spec: promoterv1alpha1.ArgoCDCommitStatusSpec{
+					ArgoCDBaseURL: tt.override,
+				},
+			}
+
+			got, err := r.resolveArgoCDBaseURL(context.Background(), acs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if got != tt.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", got, tt.wantBaseURL)
+			}
+		})
+	}
+}

--- a/internal/types/conditions/conditions.go
+++ b/internal/types/conditions/conditions.go
@@ -27,6 +27,12 @@ const (
 const (
 	// CommitStatusesNotReady is the condition type for commit statuses not being ready.
 	CommitStatusesNotReady CommonReason = "CommitStatusesNotReady"
+	// ArgoCDBaseURLUnset indicates that the rendered URL template produced a
+	// root-relative value, but no Argo CD base URL is available to resolve it
+	// (neither spec.argocdBaseURL nor argocd-cm.url is set). The CommitStatus is
+	// written without spec.url, so the SCM check posts no details link and the
+	// UI extension renders no "View Details" anchor.
+	ArgoCDBaseURLUnset CommonReason = "ArgoCDBaseURLUnset"
 )
 
 // Reasons that apply to ChangeTransferPolicy.


### PR DESCRIPTION
ArgoCDCommitStatus.URL.Template now accepts root-relative paths ("/applications?labels=...") in addition to absolute http(s) URLs. Root-relative output is resolved at render time to an absolute URL, so CommitStatus.spec.url stays SCM-safe (GitHub/GitLab/etc. require http(s) for details_url / target_url).

Base URL resolution precedence:
  1. ArgoCDCommitStatus.spec.argocdBaseURL (new, per-resource override)
  2. argocd-cm.url ConfigMap on the local cluster
  3. None — CommitStatus.spec.url is omitted and a Ready condition is set with Reason=ArgoCDBaseURLUnset so the degraded state is visible via kubectl describe.

Absolute http(s) templates continue to pass through unchanged.

Adds a narrow ConfigMap get permission scoped to resourceNames=argocd-cm.