### PR TITLE
fix(gitlab): use project-scoped ListProjectMergeRequests in FindOpen

### DIFF
--- a/internal/scms/gitlab/pullrequest.go
+++ b/internal/scms/gitlab/pullrequest.go
@@ -240,14 +240,14 @@ func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRe
 		return false, "", time.Time{}, fmt.Errorf("failed to get repo: %w", err)
 	}
 
-	options := &gitlab.ListMergeRequestsOptions{
+	options := &gitlab.ListProjectMergeRequestsOptions{
 		SourceBranch: gitlab.Ptr(pullRequest.Spec.SourceBranch),
 		TargetBranch: gitlab.Ptr(pullRequest.Spec.TargetBranch),
 		State:        gitlab.Ptr("opened"),
 	}
 
 	start := time.Now()
-	mrs, resp, err := pr.client.MergeRequests.ListMergeRequests(options)
+	mrs, resp, err := pr.client.MergeRequests.ListProjectMergeRequests(repo.Spec.GitLab.ProjectID, options)
 	if resp == nil {
 		statusCode := -1
 		metrics.RecordSCMCall(ctx, repo, metrics.SCMAPIPullRequest, metrics.SCMOperationList, statusCode, time.Since(start), nil)


### PR DESCRIPTION
## Summary

`FindOpen` in `internal/scms/gitlab/pullrequest.go` uses the global `ListMergeRequests` API endpoint (`GET /api/v4/merge_requests`) instead of the project-scoped `ListProjectMergeRequests` (`GET /api/v4/projects/:id/merge_requests`). This causes the function to return merge requests from **any project** on the GitLab instance that matches the source/target branch names.

## Impact

When multiple repositories use the same branch naming convention (e.g. `environment/validation-next` → `environment/validation`), the first MR returned by the global API pollutes all other repositories' PullRequest objects with the wrong MR IID. This causes:

- `ChangeTransferPolicy` resources to enter a degraded state (Ready=False)
- The controller to attempt updating MRs in the wrong projects (404 errors or silently updating the wrong MR)
- Promotion to be completely blocked for all affected repositories

In our deployment, 10 out of 11 addon repositories were broken because they all picked up MR #9 from an unrelated project (reloader). Only reloader itself worked because its own MR happened to be #9.

## Fix

Replace `ListMergeRequestsOptions` / `ListMergeRequests(options)` with `ListProjectMergeRequestsOptions` / `ListProjectMergeRequests(repo.Spec.GitLab.ProjectID, options)`.

Both option structs share the same fields (`SourceBranch`, `TargetBranch`, `State`), and `ListProjectMergeRequests` returns `[]*BasicMergeRequest` with the same `IID`/`CreatedAt` fields used downstream — so this is a drop-in replacement.

## Versions Affected

- v0.26.2 (confirmed)
- v0.30.0 (confirmed — code is identical at this location)