### PR TITLE
fix: keep embedded dashboard assets present in fresh checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,12 @@ yarn-error.log*
 
 # Built UI static files
 ui/web/static/
+!ui/web/static/
+ui/web/static/*
+!ui/web/static/index.html
+!ui/web/static/assets/
+ui/web/static/assets/*
+!ui/web/static/assets/placeholder.txt
 
 # MkDocs build output
 mkdocs-lint.log
@@ -100,4 +106,3 @@ main
 # Claude Code
 .claude
 CLAUDE.md
-

--- a/ui/web/embed_test.go
+++ b/ui/web/embed_test.go
@@ -1,0 +1,12 @@
+package web
+
+import "testing"
+
+func TestDashboardFSContainsBootstrapAssets(t *testing.T) {
+	if _, err := DashboardFS.Open("static/index.html"); err != nil {
+		t.Fatalf("DashboardFS missing static/index.html: %v", err)
+	}
+	if _, err := DashboardFS.Open("static/assets/placeholder.txt"); err != nil {
+		t.Fatalf("DashboardFS missing static/assets/placeholder.txt: %v", err)
+	}
+}

--- a/ui/web/static/assets/placeholder.txt
+++ b/ui/web/static/assets/placeholder.txt
@@ -1,0 +1,1 @@
+This placeholder keeps the embedded dashboard assets directory present in fresh checkouts.

--- a/ui/web/static/index.html
+++ b/ui/web/static/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GitOps Promoter Dashboard</title>
+</head>
+<body>
+  <main>
+    <h1>GitOps Promoter dashboard assets are not built</h1>
+    <p>Run <code>make build-dashboard</code> to generate the embedded UI assets.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Fresh checkout is kinda busted for Go builds.

`ui/web/embed.go` embeds `ui/web/static`, but that dir is ignored and missing until `make build-dashboard` runs. So a plain fresh-clone `go build ./cmd/main.go` blows up.

This keeps a tiny bootstrap `index.html` and `assets/placeholder.txt` in git, and adds a small test. I also checked `npm run build:embed`, still fine.

Repro:
```bash
git clone git@github.com:argoproj-labs/gitops-promoter.git
cd gitops-promoter
go build ./cmd/main.go
```

Before:
```text
ui/web/embed.go:7:12: pattern static: no matching files found
```

After this branch, the same command works.
