### PR TITLE
chore: fix renovate author

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,8 @@
   extends: [
     'config:recommended',
   ],
-  gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
+  // GitHub App commits via the Contents API; avoids gitAuthor mismatch with the App bot.
+  platformCommit: true,
   timezone: 'UTC',
   // PR cadence is enforced by .github/workflows/renovate.yaml (Sun/Wed/Sat). A
   // weekend-only schedule here prevented those mid-week runs from opening updates.

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,7 @@
     'config:recommended',
   ],
   // GitHub App commits via the Contents API; avoids gitAuthor mismatch with the App bot.
-  platformCommit: true,
+  platformCommit: 'enabled',
   timezone: 'UTC',
   // PR cadence is enforced by .github/workflows/renovate.yaml (Sun/Wed/Sat). A
   // weekend-only schedule here prevented those mid-week runs from opening updates.


### PR DESCRIPTION
Renovate is not recognizing itself as the owner of opened PRs due to an author mismatch.

platformCommit is the recommended fix for github app-based setups.