### PR TITLE
chore: don't set hourly limit on Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,7 @@
     'dependencies',
   ],
   prConcurrentLimit: 10,
+  prHourlyLimit: 0,
   // Run `go mod tidy` natively as part of every gomod artifact update. This is the
   // reliable equivalent of the CI codegen `go mod tidy` check -- unlike a shell
   // postUpgradeTask it needs no allowedCommands entry and uses the go.mod toolchain,


### PR DESCRIPTION
It defaults to 2 per hour. We run 3 times a week, so PRs come in a trickle.