### PR TITLE
chore: use renovate built in go support

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -33,16 +33,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Go
-        uses: actions/setup-go@4aaadf42668403795cdfdb15b1c4250e9fed12b9 # pin@v5
-        with:
-          go-version: "1.26.3"
-
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: Iv23liDYTI2rxpKqBDiv
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app
           # These MUST be a subset of the permissions granted to the App installation
@@ -61,20 +56,9 @@ jobs:
         with:
           configurationFile: renovate.json5
           token: ${{ steps.get_token.outputs.token }}
-          # Post-upgrade tasks (make mockery-gen, etc.) run inside the Renovate
-          # container; mount the runner Go toolchain and pass PATH through.
-          docker-volumes: |
-            /tmp:/tmp ;
-            /opt/hostedtoolcache:/opt/hostedtoolcache
-          env-regex: '^(?:RENOVATE_\w+|LOG_LEVEL|PATH|GOROOT|GOPATH|GOBIN|HOME)$'
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make lint-fix","^make mockery-gen$","^make build-installer","^make manifests","^make generate","^pip install pip-tools$","^pip-compile"]'
-          PATH: ${{ env.PATH }}
-          GOROOT: ${{ env.GOROOT }}
-          GOPATH: ${{ env.GOPATH }}
-          GOBIN: ${{ env.GOBIN }}
-          HOME: ${{ env.HOME }}
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make lint-fix","^make mockery-gen$","^make build-installer","^make manifests","^make generate","^pip-compile"]'

--- a/renovate.json5
+++ b/renovate.json5
@@ -133,6 +133,9 @@
         commands: [
           'make lint-fix || true',
         ],
+        installTools: {
+          golang: {},
+        },
         fileFilters: [
           '**/*.go',
           'go.mod',
@@ -172,6 +175,9 @@
         commands: [
           'make mockery-gen',
         ],
+        installTools: {
+          golang: {},
+        },
         fileFilters: [
           '**/mocks/**',
           '**/*.go',
@@ -192,6 +198,9 @@
         commands: [
           'make build-installer || true',
         ],
+        installTools: {
+          golang: {},
+        },
         fileFilters: [
           'dist/**',
         ],
@@ -212,6 +221,9 @@
           'go mod tidy',
           'make manifests generate || true',
         ],
+        installTools: {
+          golang: {},
+        },
         fileFilters: [
           'config/**',
           'test/**',
@@ -236,6 +248,9 @@
           'make manifests || true',
           'make build-installer || true',
         ],
+        installTools: {
+          golang: {},
+        },
         fileFilters: [
           'config/**',
           'test/**',
@@ -300,9 +315,12 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'pip install pip-tools',
           'pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt',
         ],
+        installTools: {
+          python: {},
+          'pip-tools': {},
+        },
         fileFilters: [
           'docs/requirements-hashed.txt',
         ],


### PR DESCRIPTION
Use built-in installers and switch to client ID to resolve deprecation warning.