### PR TITLE
fix: remove PR finalizer when GitRepository is deleted during termination

### DIFF
--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -40,7 +40,7 @@ import (
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,6 +53,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+// isNotFoundError returns true if the error chain contains a Kubernetes not-found error.
+func isNotFoundError(err error) bool {
+	return k8serrors.IsNotFound(err)
+}
 
 // PullRequestReconciler reconciles a PullRequest object
 type PullRequestReconciler struct {
@@ -81,7 +86,7 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	defer utils.HandleReconciliationResult(ctx, startTime, &pr, r.Client, r.Recorder, &err)
 
 	if err := r.Get(ctx, req.NamespacedName, &pr); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.Info("PullRequest not found", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{}, nil
 		}
@@ -98,6 +103,21 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	provider, err := r.getPullRequestProvider(ctx, pr)
 	if err != nil {
+		// If the PullRequest is being deleted and the provider cannot be resolved because a
+		// referenced resource (e.g. GitRepository) no longer exists, we cannot close the PR
+		// on the SCM but we must still remove the finalizer to unblock garbage collection.
+		// Leaving the finalizer in place would cause the PullRequest to remain stuck in
+		// Terminating state indefinitely, blocking the PromotionStrategy reconciliation.
+		if !pr.DeletionTimestamp.IsZero() && isNotFoundError(err) {
+			logger.Info("PullRequest is being deleted but provider cannot be resolved due to missing dependency; removing finalizer without closing SCM PR", "error", err)
+			if controllerutil.ContainsFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer) {
+				controllerutil.RemoveFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer)
+				if updateErr := r.Update(ctx, &pr); updateErr != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer after missing dependency: %w", updateErr)
+				}
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to get PullRequest provider: %w", err)
 	}
 
@@ -195,7 +215,7 @@ func (r *PullRequestReconciler) cleanupTerminalStates(ctx context.Context, pr *p
 	} else {
 		logger.Info("Cleaning up closed and merged pull request", "pullRequestID", pr.Status.ID)
 	}
-	if err := r.Delete(ctx, pr); err != nil && !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, pr); err != nil && !k8serrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete PullRequest")
 		return false, fmt.Errorf("failed to delete PullRequest: %w", err)
 	}

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -33,9 +33,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 //go:embed testdata/PullRequest.yaml
@@ -829,6 +831,61 @@ var _ = Describe("PullRequest Controller", func() {
 					g.Expect(ctp.Status.PullRequest.State).To(BeEmpty(), "State should be empty when externally merged/closed (we don't know if merged or closed)")
 				}, constants.EventuallyTimeout).Should(Succeed())
 			}
+		})
+	})
+
+	Context("When a PullRequest is deleted after its GitRepository is gone", func() {
+		var ctx context.Context
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var pullRequest *promoterv1alpha1.PullRequest
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			By("Creating test resources")
+			name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "deleted-gitrepo")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			By("Waiting for PullRequest to be open and have a finalizer")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+				g.Expect(controllerutil.ContainsFinalizer(pullRequest, promoterv1alpha1.PullRequestFinalizer)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		It("should remove the finalizer and allow deletion even when the GitRepository no longer exists", func() {
+			By("Deleting the GitRepository while the PullRequest still exists")
+			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, gitRepo)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Deleting the PullRequest")
+			Expect(k8sClient.Delete(ctx, pullRequest)).To(Succeed())
+
+			By("Verifying the PullRequest is eventually deleted despite the missing GitRepository")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Problem

When a `PullRequest` CRD has a `deletionTimestamp` but its referenced `GitRepository` no longer exists, `getPullRequestProvider` fails with a not-found error **before** `handleFinalizer` is ever reached. This causes the finalizer to remain permanently, leaving the `PullRequest` stuck in `Terminating` state indefinitely.

This has a cascading effect:
1. The stuck `PullRequest` causes `ChangeTransferPolicy` reconciliation to report `PullRequestNotReady`
2. The `PromotionStrategy` oscillates between `Unknown` and `True`
3. The ArgoCD application for the addon flaps between `Healthy` and `Degraded`

The error logged repeatedly is:
```
ERROR Reconciler error {"controller": "pullrequest", ..., "error": "failed to get PullRequest provider: failed to get ScmProvider and secret: failed to get GitRepository: failed to get GitRepository: GitRepository.promoter.argoproj.io \"<name>\" not found"}
```

This was observed in production when a `GitRepository` CRD was deleted (e.g. an addon was removed from the promotion list) while a `PullRequest` CRD referencing it still had a pending `deletionTimestamp`.

## Fix

In `Reconcile()`, after `getPullRequestProvider` fails with a not-found error, check whether the `PullRequest` is already being deleted. If so, skip provider resolution and remove the finalizer directly. There is nothing to close on the SCM since we cannot resolve the provider, and unblocking garbage collection is the correct behavior.

The existing `handleEmptyIDDeletion` already handles the case where `status.ID` is empty. This fix handles the complementary case where `status.ID` is set (a PR was created on the SCM) but the `GitRepository` is gone.

## Test

Adds a regression test: creates a `PullRequest` backed by a `GitRepository`, waits for it to be open, deletes the `GitRepository`, then deletes the `PullRequest` and asserts it is eventually garbage-collected without manual finalizer intervention.