### PR TITLE
fix: keep GitRepository until referencing PullRequests are removed

### DIFF
--- a/internal/controller/clusterscmprovider_controller.go
+++ b/internal/controller/clusterscmprovider_controller.go
@@ -24,12 +24,16 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	"github.com/argoproj-labs/gitops-promoter/internal/settings"
@@ -90,6 +94,16 @@ func (r *ClusterScmProviderReconciler) SetupWithManager(ctx context.Context, mgr
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.ClusterScmProvider{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("clusterscmprovider").
+		Watches(
+			&promoterv1alpha1.GitRepository{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueClusterScmProviderForGitRepository),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(event.CreateEvent) bool { return false },
+				UpdateFunc:  func(event.UpdateEvent) bool { return false },
+				DeleteFunc:  func(event.DeleteEvent) bool { return true },
+				GenericFunc: func(event.GenericEvent) bool { return false },
+			}),
+		).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)
@@ -108,10 +122,6 @@ func (r *ClusterScmProviderReconciler) handleFinalizer(ctx context.Context, clus
 
 		var dependentRepos []string
 		for _, gitRepo := range gitRepos.Items {
-			// Skip GitRepositories that are also being deleted (allows cascade deletion)
-			if !gitRepo.DeletionTimestamp.IsZero() {
-				continue
-			}
 			if gitRepo.Spec.ScmProviderRef.Name == clusterScmProvider.Name &&
 				gitRepo.Spec.ScmProviderRef.Kind == promoterv1alpha1.ClusterScmProviderKind {
 				// Include namespace in identifier since this is cluster-scoped
@@ -187,4 +197,17 @@ func (r *ClusterScmProviderReconciler) removeSecretFinalizer(ctx context.Context
 		promoterv1alpha1.ClusterScmProviderSecretFinalizer,
 		checkOtherProviders,
 	)
+}
+
+func (r *ClusterScmProviderReconciler) enqueueClusterScmProviderForGitRepository(_ context.Context, obj client.Object) []reconcile.Request {
+	gitRepo, ok := obj.(*promoterv1alpha1.GitRepository)
+	if !ok || gitRepo.Spec.ScmProviderRef.Name == "" {
+		return nil
+	}
+	if gitRepo.Spec.ScmProviderRef.Kind != promoterv1alpha1.ClusterScmProviderKind {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: gitRepo.Spec.ScmProviderRef.Name},
+	}}
 }

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -90,7 +90,12 @@ func (r *GitRepositoryReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			&promoterv1alpha1.PullRequest{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueGitRepositoryForPullRequest),
 			// Delete fires once the PullRequest leaves the informer cache (fully removed from the API).
-			builder.WithPredicates(predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }}),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(event.CreateEvent) bool { return false },
+				UpdateFunc:  func(event.UpdateEvent) bool { return false },
+				DeleteFunc:  func(event.DeleteEvent) bool { return true },
+				GenericFunc: func(event.GenericEvent) bool { return false },
+			}),
 		).
 		Complete(r)
 	if err != nil {

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -24,12 +24,16 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
@@ -82,6 +86,13 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *GitRepositoryReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.GitRepository{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&promoterv1alpha1.PullRequest{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueGitRepositoryForPullRequest),
+			builder.WithPredicates(predicate.Funcs{
+				DeleteFunc: func(e event.DeleteEvent) bool { return true },
+			}),
+		).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)
@@ -99,10 +110,6 @@ func (r *GitRepositoryReconciler) handleFinalizer(ctx context.Context, gitRepo *
 
 		var dependentPRs []string
 		for _, pr := range pullRequests.Items {
-			// Skip PullRequests that are also being deleted (allows cascade deletion)
-			if !pr.DeletionTimestamp.IsZero() {
-				continue
-			}
 			if pr.Spec.RepositoryReference.Name == gitRepo.Name {
 				dependentPRs = append(dependentPRs, pr.Name)
 			}
@@ -119,4 +126,21 @@ func (r *GitRepositoryReconciler) handleFinalizer(ctx context.Context, gitRepo *
 		"GitRepository",
 		checkDependencies,
 	)
+}
+
+func (r *GitRepositoryReconciler) enqueueGitRepositoryForPullRequest(ctx context.Context, obj client.Object) []reconcile.Request {
+	pr, ok := obj.(*promoterv1alpha1.PullRequest)
+	if !ok {
+		return nil
+	}
+	repoName := pr.Spec.RepositoryReference.Name
+	if repoName == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: pr.GetNamespace(),
+			Name:      repoName,
+		},
+	}}
 }

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -89,9 +89,8 @@ func (r *GitRepositoryReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		Watches(
 			&promoterv1alpha1.PullRequest{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueGitRepositoryForPullRequest),
-			builder.WithPredicates(predicate.Funcs{
-				DeleteFunc: func(e event.DeleteEvent) bool { return true },
-			}),
+			// Delete fires once the PullRequest leaves the informer cache (fully removed from the API).
+			builder.WithPredicates(predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }}),
 		).
 		Complete(r)
 	if err != nil {

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -132,7 +132,7 @@ func (r *GitRepositoryReconciler) handleFinalizer(ctx context.Context, gitRepo *
 	)
 }
 
-func (r *GitRepositoryReconciler) enqueueGitRepositoryForPullRequest(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *GitRepositoryReconciler) enqueueGitRepositoryForPullRequest(_ context.Context, obj client.Object) []reconcile.Request {
 	pr, ok := obj.(*promoterv1alpha1.PullRequest)
 	if !ok {
 		return nil

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -155,13 +155,7 @@ var _ = Describe("GitRepository Controller", func() {
 
 		AfterEach(func() {
 			var pr promoterv1alpha1.PullRequest
-			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err != nil {
-				if errors.IsNotFound(err) {
-					return
-				}
-				return
-			}
-			if pr.DeletionTimestamp != nil {
+			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err == nil && pr.DeletionTimestamp != nil {
 				var kept []string
 				for _, f := range pr.Finalizers {
 					if f != blockingFinalizer {

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -148,6 +148,7 @@ var _ = Describe("GitRepository Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
+				g.Expect(pullRequest.Finalizers).NotTo(ContainElement(promoterv1alpha1.PullRequestFinalizer))
 				g.Expect(pullRequest.Finalizers).To(ContainElement(blockingFinalizer))
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
@@ -155,38 +156,40 @@ var _ = Describe("GitRepository Controller", func() {
 		AfterEach(func() {
 			var pr promoterv1alpha1.PullRequest
 			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err != nil {
-				return
-			}
-			if pr.DeletionTimestamp == nil {
-				return
-			}
-			var kept []string
-			for _, f := range pr.Finalizers {
-				if f != blockingFinalizer {
-					kept = append(kept, f)
+				if errors.IsNotFound(err) {
+					return
 				}
+				return
 			}
-			if len(kept) != len(pr.Finalizers) {
-				base := pr.DeepCopy()
-				pr.Finalizers = kept
-				_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+			if pr.DeletionTimestamp != nil {
+				var kept []string
+				for _, f := range pr.Finalizers {
+					if f != blockingFinalizer {
+						kept = append(kept, f)
+					}
+				}
+				if len(kept) != len(pr.Finalizers) {
+					base := pr.DeepCopy()
+					pr.Finalizers = kept
+					_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+				}
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, typeNamespacedName, &pr)
+					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 			}
 
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, gitRepo))
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, typeNamespacedName, &pr)
+				err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
 				g.Expect(errors.IsNotFound(err)).To(BeTrue())
 			}, constants.EventuallyTimeout).Should(Succeed())
 
-			var repo promoterv1alpha1.GitRepository
-			if err := k8sClient.Get(ctx, typeNamespacedName, &repo); err != nil {
-				return
-			}
-			if repo.DeletionTimestamp != nil {
-				_ = k8sClient.Delete(ctx, &repo)
-			}
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmProvider))
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmSecret))
 		})
 
-		It("should not delete the GitRepository while the PullRequest object still exists", func() {
+		It("should block GitRepository deletion until the PullRequest is gone, then finish deleting", func() {
 			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -205,6 +208,31 @@ var _ = Describe("GitRepository Controller", func() {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
 			}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+
+			By("Removing the blocking finalizer so the PullRequest object can leave the API")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			var kept []string
+			for _, f := range pullRequest.Finalizers {
+				if f != blockingFinalizer {
+					kept = append(kept, f)
+				}
+			}
+			pullRequest.Finalizers = kept
+			Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+
+			By("Verifying the PullRequest is fully removed, not only marked for deletion")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Verifying the GitRepository deletion completes after the PullRequest object is gone")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(),
+					"GitRepository should be deleted after the last referencing PullRequest is removed from the API")
+			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -19,13 +19,15 @@ package controller
 import (
 	"context"
 	_ "embed"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
@@ -95,6 +97,114 @@ var _ = Describe("GitRepository Controller", func() {
 				// Verify that the controller has added the finalizer
 				g.Expect(gitrepository.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
 			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
+
+	Context("When a referencing PullRequest is terminating but not yet removed", func() {
+		const blockingFinalizer = "promoter.argoproj.io/test-will-not-remove"
+
+		var ctx context.Context
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var pullRequest *promoterv1alpha1.PullRequest
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "gitrepo-terminating-pr-race")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Adding a bogus finalizer so the PullRequest keeps a deletionTimestamp without leaving the API")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			pullRequest.Finalizers = append(pullRequest.Finalizers, blockingFinalizer)
+			Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+
+			Expect(k8sClient.Delete(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
+				g.Expect(pullRequest.Finalizers).To(ContainElement(blockingFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			var pr promoterv1alpha1.PullRequest
+			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err != nil {
+				return
+			}
+			if pr.DeletionTimestamp == nil {
+				return
+			}
+			var kept []string
+			for _, f := range pr.Finalizers {
+				if f != blockingFinalizer {
+					kept = append(kept, f)
+				}
+			}
+			if len(kept) != len(pr.Finalizers) {
+				base := pr.DeepCopy()
+				pr.Finalizers = kept
+				_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+			}
+
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, &pr)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			var repo promoterv1alpha1.GitRepository
+			if err := k8sClient.Get(ctx, typeNamespacedName, &repo); err != nil {
+				return
+			}
+			if repo.DeletionTimestamp != nil {
+				_ = k8sClient.Delete(ctx, &repo)
+			}
+		})
+
+		It("should not delete the GitRepository while the PullRequest object still exists", func() {
+			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.DeletionTimestamp).ToNot(BeNil())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Reproducing the race: GitRepository must not disappear while a terminating PullRequest remains in etcd")
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
+				g.Expect(err).ToNot(HaveOccurred(),
+					"GitRepository was deleted while a referencing PullRequest still exists (deletionTimestamp carveout bug)")
+				g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer),
+					"GitRepository finalizer should remain until all referencing PullRequests are gone")
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
+			}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -358,7 +358,7 @@ func (r *PullRequestReconciler) getPullRequestProvider(ctx context.Context, pr p
 		ctx, r.Client, r.SettingsMgr.GetControllerNamespace(), pr.Spec.RepositoryReference, &pr,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get PullRequest provider: %w", err)
+		return nil, err //nolint:wrapcheck // Reconcile adds "failed to get PullRequest provider"
 	}
 
 	switch {

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -55,10 +55,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// isNotFoundError returns true if the error chain contains a Kubernetes not-found error.
-func isNotFoundError(err error) bool {
-	return k8serrors.IsNotFound(err)
-}
+const gitRepositoryDeletedDuringTerminationMsg = "this PullRequest's GitRepository has been deleted, so it cannot ensure that the corresponding SCM pull request is closed - " +
+	"either restore the GitRepository or remove the " + promoterv1alpha1.PullRequestFinalizer + " finalizer and manually close the pull request if it is not already closed"
 
 // PullRequestReconciler reconciles a PullRequest object
 type PullRequestReconciler struct {
@@ -104,20 +102,12 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	provider, err := r.getPullRequestProvider(ctx, pr)
 	if err != nil {
-		// If the PullRequest is being deleted and the provider cannot be resolved because a
-		// referenced resource (e.g. GitRepository) no longer exists, we cannot close the PR
-		// on the SCM but we must still remove the finalizer to unblock garbage collection.
-		// Leaving the finalizer in place would cause the PullRequest to remain stuck in
-		// Terminating state indefinitely, blocking the PromotionStrategy reconciliation.
-		if !pr.DeletionTimestamp.IsZero() && isNotFoundError(err) {
-			logger.Info("PullRequest is being deleted but provider cannot be resolved due to missing dependency; removing finalizer without closing SCM PR", "error", err)
-			if controllerutil.ContainsFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer) {
-				controllerutil.RemoveFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer)
-				if updateErr := r.Update(ctx, &pr); updateErr != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer after missing dependency: %w", updateErr)
-				}
-			}
-			return ctrl.Result{}, nil
+		if !pr.DeletionTimestamp.IsZero() && k8serrors.IsNotFound(err) {
+			logger.Error(err, gitRepositoryDeletedDuringTerminationMsg,
+				"pullRequest", client.ObjectKeyFromObject(&pr).String(),
+				"gitRepository", pr.Spec.RepositoryReference.Name,
+			)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", gitRepositoryDeletedDuringTerminationMsg, err)
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get PullRequest provider: %w", err)
 	}

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -55,9 +55,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const gitRepositoryDeletedDuringTerminationMsg = "this PullRequest's GitRepository has been deleted, so it cannot ensure that the corresponding SCM pull request is closed - " +
-	"either restore the GitRepository or remove the " + promoterv1alpha1.PullRequestFinalizer + " finalizer and manually close the pull request if it is not already closed"
-
 // PullRequestReconciler reconciles a PullRequest object
 type PullRequestReconciler struct {
 	client.Client
@@ -102,12 +99,10 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	provider, err := r.getPullRequestProvider(ctx, pr)
 	if err != nil {
-		if !pr.DeletionTimestamp.IsZero() && k8serrors.IsNotFound(err) {
-			logger.Error(err, gitRepositoryDeletedDuringTerminationMsg,
-				"pullRequest", client.ObjectKeyFromObject(&pr).String(),
-				"gitRepository", pr.Spec.RepositoryReference.Name,
-			)
-			return ctrl.Result{}, fmt.Errorf("%s: %w", gitRepositoryDeletedDuringTerminationMsg, err)
+		if !pr.DeletionTimestamp.IsZero() {
+			if blockedErr := deletionBlockedByMissingDependencyError(err); blockedErr != nil {
+				return ctrl.Result{}, blockedErr
+			}
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get PullRequest provider: %w", err)
 	}
@@ -495,6 +490,37 @@ func (t trailers) String() string {
 		fmt.Fprintf(&result, "%s: %s\n", k, t[k])
 	}
 	return result.String()
+}
+
+// deletionBlockedByMissingDependencyError returns an operator-facing error when provider resolution
+// fails during PullRequest deletion because a dependency is missing. Nil means err is not that case.
+func deletionBlockedByMissingDependencyError(err error) error {
+	details, isNotFound := utils.NotFoundInErrorChain(err)
+	if !isNotFound {
+		return nil
+	}
+
+	var msg string
+	if details == nil {
+		msg = fmt.Sprintf(
+			"this PullRequest cannot close its SCM pull request because a required dependency was not found - "+
+				"either restore the missing resource or remove the %s finalizer from this PullRequest and manually close the SCM pull request if it is not already closed",
+			promoterv1alpha1.PullRequestFinalizer,
+		)
+	} else {
+		typeRef := details.Kind
+		if details.Group != "" {
+			typeRef = details.Group + "/" + details.Kind
+		}
+		msg = fmt.Sprintf(
+			"this PullRequest cannot close its SCM pull request because %s %q is missing - "+
+				"either restore that resource or remove the %s finalizer from this PullRequest and manually close the SCM pull request if it is not already closed",
+			typeRef,
+			details.Name,
+			promoterv1alpha1.PullRequestFinalizer,
+		)
+	}
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 func (r *PullRequestReconciler) closePullRequest(ctx context.Context, pr *promoterv1alpha1.PullRequest, provider scms.PullRequestProvider) error {

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -40,7 +40,7 @@ import (
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +54,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+// isNotFoundError returns true if the error chain contains a Kubernetes not-found error.
+func isNotFoundError(err error) bool {
+	return k8serrors.IsNotFound(err)
+}
 
 // PullRequestReconciler reconciles a PullRequest object
 type PullRequestReconciler struct {
@@ -82,7 +87,7 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	defer utils.HandleReconciliationResult(ctx, startTime, &pr, r.Client, r.Recorder, constants.PullRequestControllerFieldOwner, &result, &err)
 
 	if err := r.Get(ctx, req.NamespacedName, &pr); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.Info("PullRequest not found", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{}, nil
 		}
@@ -99,6 +104,21 @@ func (r *PullRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	provider, err := r.getPullRequestProvider(ctx, pr)
 	if err != nil {
+		// If the PullRequest is being deleted and the provider cannot be resolved because a
+		// referenced resource (e.g. GitRepository) no longer exists, we cannot close the PR
+		// on the SCM but we must still remove the finalizer to unblock garbage collection.
+		// Leaving the finalizer in place would cause the PullRequest to remain stuck in
+		// Terminating state indefinitely, blocking the PromotionStrategy reconciliation.
+		if !pr.DeletionTimestamp.IsZero() && isNotFoundError(err) {
+			logger.Info("PullRequest is being deleted but provider cannot be resolved due to missing dependency; removing finalizer without closing SCM PR", "error", err)
+			if controllerutil.ContainsFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer) {
+				controllerutil.RemoveFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer)
+				if updateErr := r.Update(ctx, &pr); updateErr != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer after missing dependency: %w", updateErr)
+				}
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to get PullRequest provider: %w", err)
 	}
 
@@ -196,7 +216,7 @@ func (r *PullRequestReconciler) cleanupTerminalStates(ctx context.Context, pr *p
 	} else {
 		logger.Info("Cleaning up closed and merged pull request", "pullRequestID", pr.Status.ID)
 	}
-	if err := r.Delete(ctx, pr); err != nil && !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, pr); err != nil && !k8serrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete PullRequest")
 		return false, fmt.Errorf("failed to delete PullRequest: %w", err)
 	}

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -354,14 +354,11 @@ func (r *PullRequestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 }
 
 func (r *PullRequestReconciler) getPullRequestProvider(ctx context.Context, pr promoterv1alpha1.PullRequest) (scms.PullRequestProvider, error) {
-	scmProvider, secret, err := utils.GetScmProviderAndSecretFromRepositoryReference(ctx, r.Client, r.SettingsMgr.GetControllerNamespace(), pr.Spec.RepositoryReference, &pr)
+	scmProvider, secret, gitRepository, err := utils.GetScmProviderSecretAndGitRepositoryFromRepositoryReference(
+		ctx, r.Client, r.SettingsMgr.GetControllerNamespace(), pr.Spec.RepositoryReference, &pr,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ScmProvider and secret: %w", err)
-	}
-
-	gitRepository, err := utils.GetGitRepositoryFromObjectKey(ctx, r.Client, client.ObjectKey{Namespace: pr.Namespace, Name: pr.Spec.RepositoryReference.Name})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get GitRepository: %w", err)
+		return nil, fmt.Errorf("failed to get PullRequest provider: %w", err)
 	}
 
 	switch {

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -1051,6 +1051,7 @@ var _ = Describe("PullRequest Controller", func() {
 				}, constants.EventuallyTimeout).Should(Succeed())
 			}
 
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, gitRepo))
 			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmProvider))
 			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmSecret))
 		})
@@ -1082,11 +1083,12 @@ var _ = Describe("PullRequest Controller", func() {
 				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
 				g.Expect(pullRequest.Finalizers).To(ContainElement(promoterv1alpha1.PullRequestFinalizer))
 
-				g.Expect(pullRequest.Status.Conditions).ToNot(BeEmpty())
-				g.Expect(meta.IsStatusConditionFalse(pullRequest.Status.Conditions, string(conditions.Ready))).To(BeTrue())
-				g.Expect(pullRequest.Status.Conditions[0].Reason).To(Equal(string(conditions.ReconciliationError)))
+				ready := meta.FindStatusCondition(pullRequest.Status.Conditions, string(conditions.Ready))
+				g.Expect(ready).NotTo(BeNil())
+				g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(ready.Reason).To(Equal(string(conditions.ReconciliationError)))
 
-				msg := pullRequest.Status.Conditions[0].Message
+				msg := ready.Message
 				g.Expect(msg).To(ContainSubstring("Reconciliation failed"))
 				g.Expect(msg).To(ContainSubstring("cannot close its SCM pull request"))
 				g.Expect(msg).To(ContainSubstring("promoter.argoproj.io/GitRepository"))

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -33,9 +33,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 //go:embed testdata/PullRequest.yaml
@@ -1002,6 +1004,100 @@ var _ = Describe("PullRequest Controller", func() {
 				g.Expect(*pullRequest.Status.ExternallyMergedOrClosed).To(BeTrue())
 				g.Expect(pullRequest.Status.State).To(BeEmpty())
 			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
+
+	Context("When deleting a PullRequest after GitRepository is removed", func() {
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var pullRequest *promoterv1alpha1.PullRequest
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "delete-missing-gitrepo")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+				g.Expect(pullRequest.Finalizers).To(ContainElement(promoterv1alpha1.PullRequestFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			var pr promoterv1alpha1.PullRequest
+			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err == nil {
+				if pr.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer) {
+					base := pr.DeepCopy()
+					controllerutil.RemoveFinalizer(&pr, promoterv1alpha1.PullRequestFinalizer)
+					_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+				}
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &pr))
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, typeNamespacedName, &pr)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
+			}
+
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmProvider))
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmSecret))
+		})
+
+		It("should keep the finalizer and report which dependency is missing", func() {
+			By("Removing GitRepository finalizer so the object can be deleted while the PullRequest remains")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+			base := gitRepo.DeepCopy()
+			controllerutil.RemoveFinalizer(gitRepo, promoterv1alpha1.GitRepositoryFinalizer)
+			Expect(k8sClient.Patch(ctx, gitRepo, client.MergeFrom(base))).To(Succeed())
+			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
+				g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Deleting the PullRequest")
+			Expect(k8sClient.Delete(ctx, pullRequest)).To(Succeed())
+
+			By("Verifying deletion is blocked with an operator-facing dependency error")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.DeletionTimestamp).ToNot(BeNil())
+				g.Expect(pullRequest.Finalizers).To(ContainElement(promoterv1alpha1.PullRequestFinalizer))
+
+				g.Expect(pullRequest.Status.Conditions).ToNot(BeEmpty())
+				g.Expect(meta.IsStatusConditionFalse(pullRequest.Status.Conditions, string(conditions.Ready))).To(BeTrue())
+				g.Expect(pullRequest.Status.Conditions[0].Reason).To(Equal(string(conditions.ReconciliationError)))
+
+				msg := pullRequest.Status.Conditions[0].Message
+				g.Expect(msg).To(ContainSubstring("Reconciliation failed"))
+				g.Expect(msg).To(ContainSubstring("cannot close its SCM pull request"))
+				g.Expect(msg).To(ContainSubstring("promoter.argoproj.io/GitRepository"))
+				g.Expect(msg).To(ContainSubstring(name))
+				g.Expect(msg).To(ContainSubstring(promoterv1alpha1.PullRequestFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Finalizers).To(ContainElement(promoterv1alpha1.PullRequestFinalizer))
+			}, "3s", "500ms").Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/scmprovider_controller.go
+++ b/internal/controller/scmprovider_controller.go
@@ -24,12 +24,16 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
@@ -88,6 +92,16 @@ func (r *ScmProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *ScmProviderReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.ScmProvider{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&promoterv1alpha1.GitRepository{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueScmProviderForGitRepository),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(event.CreateEvent) bool { return false },
+				UpdateFunc:  func(event.UpdateEvent) bool { return false },
+				DeleteFunc:  func(event.DeleteEvent) bool { return true },
+				GenericFunc: func(event.GenericEvent) bool { return false },
+			}),
+		).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)
@@ -105,10 +119,6 @@ func (r *ScmProviderReconciler) handleFinalizer(ctx context.Context, scmProvider
 
 		var dependentRepos []string
 		for _, gitRepo := range gitRepos.Items {
-			// Skip GitRepositories that are also being deleted (allows cascade deletion)
-			if !gitRepo.DeletionTimestamp.IsZero() {
-				continue
-			}
 			if gitRepo.Spec.ScmProviderRef.Name == scmProvider.Name &&
 				gitRepo.Spec.ScmProviderRef.Kind == promoterv1alpha1.ScmProviderKind {
 				dependentRepos = append(dependentRepos, gitRepo.Name)
@@ -183,4 +193,20 @@ func (r *ScmProviderReconciler) removeSecretFinalizer(ctx context.Context, scmPr
 		promoterv1alpha1.ScmProviderSecretFinalizer,
 		checkOtherProviders,
 	)
+}
+
+func (r *ScmProviderReconciler) enqueueScmProviderForGitRepository(_ context.Context, obj client.Object) []reconcile.Request {
+	gitRepo, ok := obj.(*promoterv1alpha1.GitRepository)
+	if !ok || gitRepo.Spec.ScmProviderRef.Name == "" {
+		return nil
+	}
+	if gitRepo.Spec.ScmProviderRef.Kind != promoterv1alpha1.ScmProviderKind {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: gitRepo.Namespace,
+			Name:      gitRepo.Spec.ScmProviderRef.Name,
+		},
+	}}
 }

--- a/internal/controller/scmprovider_controller_test.go
+++ b/internal/controller/scmprovider_controller_test.go
@@ -19,13 +19,15 @@ package controller
 import (
 	"context"
 	_ "embed"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
@@ -87,6 +89,130 @@ var _ = Describe("ScmProvider Controller", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				// Verify that the controller has added the finalizer
 				g.Expect(scmprovider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
+
+	Context("When a referencing GitRepository is terminating but not yet removed", func() {
+		const blockingFinalizer = "promoter.argoproj.io/test-will-not-remove"
+
+		var ctx context.Context
+		var name string
+		var scmSecret *v1.Secret
+		var scmProvider *promoterv1alpha1.ScmProvider
+		var gitRepo *promoterv1alpha1.GitRepository
+		var typeNamespacedName types.NamespacedName
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			name, scmSecret, scmProvider, gitRepo, _ = pullRequestResources(ctx, "scmprovider-terminating-gitrepo-race")
+
+			typeNamespacedName = types.NamespacedName{
+				Name:      name,
+				Namespace: "default",
+			}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmProvider)).To(Succeed())
+				g.Expect(scmProvider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Adding a bogus finalizer so the GitRepository keeps a deletionTimestamp without leaving the API")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+			base := gitRepo.DeepCopy()
+			gitRepo.Finalizers = append(gitRepo.Finalizers, blockingFinalizer)
+			Expect(k8sClient.Patch(ctx, gitRepo, client.MergeFrom(base))).To(Succeed())
+
+			Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.DeletionTimestamp).ToNot(BeNil())
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			var repo promoterv1alpha1.GitRepository
+			if err := k8sClient.Get(ctx, typeNamespacedName, &repo); err == nil && repo.DeletionTimestamp != nil {
+				var kept []string
+				for _, f := range repo.Finalizers {
+					if f != blockingFinalizer {
+						kept = append(kept, f)
+					}
+				}
+				if len(kept) != len(repo.Finalizers) {
+					base := repo.DeepCopy()
+					repo.Finalizers = kept
+					_ = k8sClient.Patch(ctx, &repo, client.MergeFrom(base))
+				}
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, typeNamespacedName, &repo)
+					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
+			}
+
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmProvider))
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, scmSecret))
+		})
+
+		It("should block ScmProvider deletion until the GitRepository is gone, then finish deleting", func() {
+			Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmProvider)).To(Succeed())
+				g.Expect(scmProvider.DeletionTimestamp).ToNot(BeNil())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Reproducing the race: ScmProvider must not disappear while a terminating GitRepository remains in etcd")
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
+				g.Expect(err).ToNot(HaveOccurred(),
+					"ScmProvider was deleted while a referencing GitRepository still exists (deletionTimestamp carveout bug)")
+				g.Expect(scmProvider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer),
+					"ScmProvider finalizer should remain until all referencing GitRepositories are gone")
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+				g.Expect(gitRepo.DeletionTimestamp).ToNot(BeNil())
+			}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+
+			By("Removing the blocking finalizer so the GitRepository object can leave the API")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+			base := gitRepo.DeepCopy()
+			var kept []string
+			for _, f := range gitRepo.Finalizers {
+				if f != blockingFinalizer {
+					kept = append(kept, f)
+				}
+			}
+			gitRepo.Finalizers = kept
+			Expect(k8sClient.Patch(ctx, gitRepo, client.MergeFrom(base))).To(Succeed())
+
+			By("Verifying the GitRepository is fully removed, not only marked for deletion")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Verifying the ScmProvider deletion completes after the GitRepository object is gone")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(),
+					"ScmProvider should be deleted after the last referencing GitRepository is removed from the API")
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})

--- a/internal/utils/api_errors.go
+++ b/internal/utils/api_errors.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"errors"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NotFoundInErrorChain walks err and reports whether any link is NotFound, and Status.Details from
+// the innermost NotFound StatusError that includes kind and name. Details.Kind is the API Kind
+// (for example GitRepository) as returned by the API server and client.
+func NotFoundInErrorChain(err error) (details *metav1.StatusDetails, isNotFound bool) {
+	for unwrapped := err; unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
+		if !k8serrors.IsNotFound(unwrapped) {
+			continue
+		}
+		isNotFound = true
+
+		var statusErr *k8serrors.StatusError
+		if !errors.As(unwrapped, &statusErr) {
+			continue
+		}
+		d := statusErr.Status().Details
+		if d == nil || d.Kind == "" || d.Name == "" {
+			continue
+		}
+		details = d
+	}
+	return details, isNotFound
+}

--- a/internal/utils/api_errors.go
+++ b/internal/utils/api_errors.go
@@ -8,8 +8,9 @@ import (
 )
 
 // NotFoundInErrorChain walks err and reports whether any link is NotFound, and Status.Details from
-// the innermost NotFound StatusError that includes kind and name. Details.Kind is the API Kind
-// (for example GitRepository) as returned by the API server and client.
+// the innermost NotFound StatusError that includes type and name. Status.Details.Kind is the API
+// Kind (for example GitRepository) when returned by the API server or client, and the resource
+// plural (for example scmproviders) when constructed by api/errors.NewNotFound.
 func NotFoundInErrorChain(err error) (details *metav1.StatusDetails, isNotFound bool) {
 	for unwrapped := err; unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
 		if !k8serrors.IsNotFound(unwrapped) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -74,14 +74,14 @@ func GetScmProviderFromGitRepository(ctx context.Context, k8sClient client.Clien
 	return provider, nil
 }
 
-// GetGitRepositoryFromObjectKey returns the GitRepository object from the repository reference
+// GetGitRepositoryFromObjectKey returns the GitRepository for objectKey.
+//
+//nolint:wrapcheck // trivial client.Get wrapper; callers add context
 func GetGitRepositoryFromObjectKey(ctx context.Context, k8sClient client.Client, objectKey client.ObjectKey) (*promoterv1alpha1.GitRepository, error) {
 	var gitRepo promoterv1alpha1.GitRepository
-	err := k8sClient.Get(ctx, objectKey, &gitRepo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get GitRepository: %w", err)
+	if err := k8sClient.Get(ctx, objectKey, &gitRepo); err != nil {
+		return nil, err
 	}
-
 	return &gitRepo, nil
 }
 
@@ -140,7 +140,7 @@ func GetScmProviderSecretAndGitRepositoryFromRepositoryReference(ctx context.Con
 	}
 	scmProvider, secret, err := getScmProviderAndSecretFromGitRepository(ctx, k8sClient, controllerNamespace, gitRepo, obj)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, err //nolint:wrapcheck // err is already contextualized by getScmProviderAndSecretFromGitRepository
 	}
 	return scmProvider, secret, gitRepo, nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
@@ -649,4 +650,45 @@ var _ = Describe("EnqueueChangeTransferPolicies", func() {
 		expected := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName("my-strategy", "main"))
 		Expect(capturedName).To(Equal(expected))
 	})
+})
+
+var _ = Describe("API error helpers", func() {
+	It("extracts the innermost NotFound StatusDetails from a wrapped client error", func() {
+		inner := apierrors.NewNotFound(
+			schema.GroupResource{Group: "promoter.argoproj.io", Resource: "scmproviders"},
+			"my-scm",
+		)
+		err := fmt.Errorf("failed to get ScmProvider and secret: %w", fmt.Errorf("failed to get ScmProvider: %w", inner))
+
+		details, isNotFound := utils.NotFoundInErrorChain(err)
+		Expect(isNotFound).To(BeTrue())
+		Expect(details).To(Equal(&metav1.StatusDetails{
+			Group: "promoter.argoproj.io",
+			Kind:  "scmproviders",
+			Name:  "my-scm",
+		}))
+	})
+
+	It("reports NotFound without resource details", func() {
+		err := fmt.Errorf("wrap: %w", &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    404,
+				Reason:  metav1.StatusReasonNotFound,
+				Message: "not found",
+			},
+		})
+
+		details, isNotFound := utils.NotFoundInErrorChain(err)
+		Expect(isNotFound).To(BeTrue())
+		Expect(details).To(BeNil())
+	})
+
+	It("returns false for non-NotFound errors", func() {
+		err := fmt.Errorf("connection refused")
+		details, isNotFound := utils.NotFoundInErrorChain(err)
+		Expect(isNotFound).To(BeFalse())
+		Expect(details).To(BeNil())
+	})
+
 })

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -685,10 +685,9 @@ var _ = Describe("API error helpers", func() {
 	})
 
 	It("returns false for non-NotFound errors", func() {
-		err := fmt.Errorf("connection refused")
+		err := errors.New("connection refused")
 		details, isNotFound := utils.NotFoundInErrorChain(err)
 		Expect(isNotFound).To(BeFalse())
 		Expect(details).To(BeNil())
 	})
-
 })


### PR DESCRIPTION
## Summary

Builds on the investigation in #1539 (thanks @ZeBidule). The root cause is that the `GitRepository` finalizer treated a `PullRequest` with only a `deletionTimestamp` as non-blocking, so the repository CR could disappear while a terminating `PullRequest` still needed it for SCM cleanup.

- **GitRepository:** block deletion until referencing `PullRequest` objects are gone from the API (not merely terminating); watch `PullRequest` deletes to requeue the repo.
- **PullRequest:** when a terminating PR loses its `GitRepository`, log a tailored operator message and return an error instead of silently removing `pullrequest.promoter.argoproj.io/finalizer`.
- **Test:** regression for the race using a bogus finalizer so the PR stays in etcd with `deletionTimestamp` set.

Preserves @ZeBidule's commit for credit; follow-up commit implements the stricter finalizer approach from [review on #1539](https://github.com/argoproj-labs/gitops-promoter/pull/1539#discussion_r3348874885).

## Test plan

- [x] `make lint`
- [x] `make test-parallel`
- [x] Focused regression: `ginkgo.focus="should not delete the GitRepository while the PullRequest object still exists"`


Made with [Cursor](https://cursor.com)