### PR TITLE
fix(test): retry PromotionStrategy update when disabling AutoMerge

### DIFF
--- a/internal/controller/promotionstrategy_controller_test.go
+++ b/internal/controller/promotionstrategy_controller_test.go
@@ -1474,9 +1474,12 @@ var _ = Describe("PromotionStrategy Controller", func() {
 			// notes load and persist, so we can assert them deterministically.
 			By("Disabling AutoMerge for both apps so proposed notes persist")
 			for _, ps := range []*promoterv1alpha1.PromotionStrategy{&promotionStrategyOne, &promotionStrategyTwo} {
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, ps)).To(Succeed())
-				ps.Spec.Environments[0].AutoMerge = ptr.To(false)
-				Expect(k8sClient.Update(ctx, ps)).To(Succeed())
+				Eventually(func(g Gomega) {
+					var latest promoterv1alpha1.PromotionStrategy
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ps.Name, Namespace: ps.Namespace}, &latest)).To(Succeed())
+					latest.Spec.Environments[0].AutoMerge = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, &latest)).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
 			}
 
 			gitPath, err := cloneTestRepo(ctx, gitRepo)


### PR DESCRIPTION
## Summary

- Retry `Get` + `Update` in `Eventually` when the activePath notes hydrator spec disables `AutoMerge`, avoiding 409 conflicts while controllers write status.

Fixes #1555

## Context

CI run https://github.com/argoproj-labs/gitops-promoter/actions/runs/26915662029/job/79404579214?pr=1545 failed with:

```
Operation cannot be fulfilled on promotionstrategies.promoter.argoproj.io "...-ps-app-one":
the object has been modified; please apply your changes to the latest version and try again
```

## Test plan

- [ ] Integration suite passes (especially `should not cross-contaminate proposed note dry SHAs while git notes propagate`)


Made with [Cursor](https://cursor.com)