### PR TITLE
feat: configurable merge commit message template for promotion PRs

### DIFF
--- a/api/v1alpha1/controllerconfiguration_types.go
+++ b/api/v1alpha1/controllerconfiguration_types.go
@@ -326,6 +326,9 @@ type Bucket struct {
 // Templates use Go template syntax and have access to Sprig functions for flexible string
 // manipulation and formatting.
 //
+// The optional CommitMessage template customizes the merge commit message; commit trailers required by the
+// promoter are appended automatically after the rendered message.
+//
 // Template data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):
 //   - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest
 //   - .PromotionStrategy – the PromotionStrategy for the CTP
@@ -339,6 +342,15 @@ type PullRequestTemplate struct {
 	// Uses Go template syntax with Sprig functions available for string manipulation.
 	// +required
 	Description string `json:"description"`
+
+	// CommitMessage is an optional template used to generate the merge commit message for the pull request.
+	// When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+	// and Description templates above). When unset, the default behavior is unchanged.
+	// Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+	// after the rendered message; do not attempt to include them in the template.
+	// Uses Go template syntax with Sprig functions available for string manipulation.
+	// +optional
+	CommitMessage string `json:"commitMessage,omitempty"`
 }
 
 // ControllerConfigurationStatus defines the observed state of ControllerConfiguration.

--- a/api/view/v1alpha1/zz_generated.openapi.go
+++ b/api/view/v1alpha1/zz_generated.openapi.go
@@ -4052,7 +4052,7 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_PullRequestTemplate(ref c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PullRequestTemplate defines the template configuration for generating pull requests.\n\nTemplates use Go template syntax and have access to Sprig functions for flexible string manipulation and formatting.\n\nTemplate data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):\n  - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest\n  - .PromotionStrategy – the PromotionStrategy for the CTP",
+				Description: "PullRequestTemplate defines the template configuration for generating pull requests.\n\nTemplates use Go template syntax and have access to Sprig functions for flexible string manipulation and formatting.\n\nThe optional CommitMessage template customizes the merge commit message; commit trailers required by the promoter are appended automatically after the rendered message.\n\nTemplate data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):\n  - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest\n  - .PromotionStrategy – the PromotionStrategy for the CTP",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"title": {
@@ -4067,6 +4067,13 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_PullRequestTemplate(ref c
 						SchemaProps: spec.SchemaProps{
 							Description: "Description is the template used to generate the body/description of the pull request. Uses Go template syntax with Sprig functions available for string manipulation.",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"commitMessage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CommitMessage is an optional template used to generate the merge commit message for the pull request. When set, it replaces the default commit message of \"<title>\\n\\n<description>\" (rendered from the Title and Description templates above). When unset, the default behavior is unchanged. Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended after the rendered message; do not attempt to include them in the template. Uses Go template syntax with Sprig functions available for string manipulation.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/applyconfiguration/api/v1alpha1/pullrequesttemplate.go
+++ b/applyconfiguration/api/v1alpha1/pullrequesttemplate.go
@@ -25,6 +25,9 @@ package v1alpha1
 // Templates use Go template syntax and have access to Sprig functions for flexible string
 // manipulation and formatting.
 //
+// The optional CommitMessage template customizes the merge commit message; commit trailers required by the
+// promoter are appended automatically after the rendered message.
+//
 // Template data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):
 // - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest
 // - .PromotionStrategy – the PromotionStrategy for the CTP
@@ -35,6 +38,13 @@ type PullRequestTemplateApplyConfiguration struct {
 	// Description is the template used to generate the body/description of the pull request.
 	// Uses Go template syntax with Sprig functions available for string manipulation.
 	Description *string `json:"description,omitempty"`
+	// CommitMessage is an optional template used to generate the merge commit message for the pull request.
+	// When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+	// and Description templates above). When unset, the default behavior is unchanged.
+	// Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+	// after the rendered message; do not attempt to include them in the template.
+	// Uses Go template syntax with Sprig functions available for string manipulation.
+	CommitMessage *string `json:"commitMessage,omitempty"`
 }
 
 // PullRequestTemplateApplyConfiguration constructs a declarative configuration of the PullRequestTemplate type for use with
@@ -56,5 +66,13 @@ func (b *PullRequestTemplateApplyConfiguration) WithTitle(value string) *PullReq
 // If called multiple times, the Description field is set to the value of the last call.
 func (b *PullRequestTemplateApplyConfiguration) WithDescription(value string) *PullRequestTemplateApplyConfiguration {
 	b.Description = &value
+	return b
+}
+
+// WithCommitMessage sets the CommitMessage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CommitMessage field is set to the value of the last call.
+func (b *PullRequestTemplateApplyConfiguration) WithCommitMessage(value string) *PullRequestTemplateApplyConfiguration {
+	b.CommitMessage = &value
 	return b
 }

--- a/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
+++ b/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
@@ -1113,6 +1113,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-without-ui.yaml
+++ b/dist/install-without-ui.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/docs/crd-specs.md
+++ b/docs/crd-specs.md
@@ -122,6 +122,11 @@ A global ControllerConfiguration is deployed alongside the controller and applie
 
 All fields are required, but defaults are provided in the installation manifests.
 
+The `pullRequest.template` section controls the title and description of promotion PRs. The optional
+`commitMessage` field customizes the merge commit message; when unset, the message defaults to the rendered
+title and description. Commit trailers used by the promoter to reconstruct promotion history are always
+appended automatically after the rendered message.
+
 ```yaml
 {!internal/controller/testdata/ControllerConfiguration.yaml!}
 ```

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1091,6 +1091,17 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		return nil, fmt.Errorf("failed to template pull request: %w", err)
 	}
 
+	baseCommitMessage, err := TemplateCommitMessage(templatePullRequestTemplate, templateData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to template pull request commit message: %w", err)
+	}
+	if baseCommitMessage == "" {
+		baseCommitMessage = fmt.Sprintf("%s\n\n%s", title, description)
+	}
+	// The trailer block must remain the final paragraph of the commit message, so trailing newlines from the
+	// rendered template must not detach it.
+	baseCommitMessage = strings.TrimRight(baseCommitMessage, "\n")
+
 	// Check if the PR already exists to determine the commit message
 	existingPR := &promoterv1alpha1.PullRequest{}
 	prExists := true
@@ -1109,7 +1120,7 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 	var commitMessage string
 	if !prExists {
 		// New PR
-		commitMessage = fmt.Sprintf("%s\n\n%s", title, description)
+		commitMessage = baseCommitMessage
 	} else {
 		// Update existing PR - add trailers
 		commitTrailers := trailers{}
@@ -1132,7 +1143,7 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		commitTrailers[constants.TrailerShaDryActive] = ctp.Status.Active.Dry.Sha
 		commitTrailers[constants.TrailerShaDryProposed] = ctp.Status.Proposed.Dry.Sha
 
-		commitMessage = fmt.Sprintf("%s\n\n%s\n\n%s", title, description, commitTrailers)
+		commitMessage = fmt.Sprintf("%s\n\n%s", baseCommitMessage, commitTrailers)
 	}
 
 	// Determine the state: preserve existing state if PR exists, otherwise default to open
@@ -1377,6 +1388,19 @@ func TemplatePullRequest(prt promoterv1alpha1.PullRequestTemplate, data map[stri
 	}
 
 	return title, description, nil
+}
+
+// TemplateCommitMessage renders the optional commit message template of a pull request template using the
+// provided data map. Returns an empty string if no commit message template is configured.
+func TemplateCommitMessage(prt promoterv1alpha1.PullRequestTemplate, data map[string]any) (string, error) {
+	if prt.CommitMessage == "" {
+		return "", nil
+	}
+	commitMessage, err := utils.RenderStringTemplate(prt.CommitMessage, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to render pull request commit message template: %w", err)
+	}
+	return commitMessage, nil
 }
 
 // boolPtrEqual compares two *bool pointers for equality.

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1103,6 +1103,79 @@ var _ = Describe("TemplatePullRequest", func() {
 	})
 })
 
+var _ = Describe("TemplateCommitMessage", func() {
+	Context("Commit message template with ChangeTransferPolicy and optional PromotionStrategy", func() {
+		ctp := &promoterv1alpha1.ChangeTransferPolicy{
+			Spec: promoterv1alpha1.ChangeTransferPolicySpec{
+				ActiveBranch:   testBranchDevelopment,
+				ProposedBranch: testBranchDevelopmentNext,
+			},
+			Status: promoterv1alpha1.ChangeTransferPolicyStatus{
+				Proposed: promoterv1alpha1.CommitBranchState{
+					Dry: promoterv1alpha1.CommitShaState{
+						Sha:     "abc1234def",
+						Subject: "feat: add new feature",
+					},
+				},
+			},
+		}
+
+		It("returns an empty string when no commit message template is configured", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:       "some title",
+				Description: "some description",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(BeEmpty())
+		})
+
+		It("renders the commit message with only CTP when PromotionStrategy is absent", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }} (dry: {{ trunc 7 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}){{ if .PromotionStrategy }} Strategy: {{ .PromotionStrategy.Name }}{{ end }}",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(Equal("feat: add new feature (dry: abc1234)"))
+		})
+
+		It("renders the commit message with CTP and PromotionStrategy when PromotionStrategy is present", func() {
+			psName := "my-promotion-strategy"
+			ps := &promoterv1alpha1.PromotionStrategy{
+				ObjectMeta: metav1.ObjectMeta{Name: psName, Namespace: "default"},
+				Spec: promoterv1alpha1.PromotionStrategySpec{
+					RepositoryReference: promoterv1alpha1.ObjectReference{Name: "test-repo"},
+					Environments:        []promoterv1alpha1.Environment{{Branch: testBranchDevelopment}},
+				},
+			}
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }}{{ if .PromotionStrategy }} Strategy: {{ .PromotionStrategy.Name }}{{ end }}",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{
+				"ChangeTransferPolicy": ctp,
+				"PromotionStrategy":    ps,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(Equal("feat: add new feature Strategy: " + psName))
+		})
+
+		It("returns an error when the commit message template is invalid", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .Invalid",
+			}
+			_, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to render pull request commit message template"))
+		})
+	})
+})
+
 var _ = Describe("tooManyPRsError", func() {
 	Context("When formatting tooManyPRsError", func() {
 		It("returns an error listing all PR names if 3 or fewer", func() {

--- a/internal/controller/testdata/ControllerConfiguration.yaml
+++ b/internal/controller/testdata/ControllerConfiguration.yaml
@@ -50,6 +50,10 @@ spec:
         **Changes:**
         - Current SHA: {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }}
         - Proposed SHA: {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}
+      # Optional: customize the merge commit message of the promotion PR.
+      # When unset, the message defaults to "<title>\n\n<description>" rendered from the templates above.
+      # Machine-read promotion trailers are always appended automatically after the rendered message.
+      commitMessage: "promote: {{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }} ({{ trunc 7 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }})"
     workQueue:
       requeueDuration: "5m"
       maxConcurrentReconciles: 3


### PR DESCRIPTION
Add an optional commitMessage field to ControllerConfiguration's spec.pullRequest.template. When set, the rendered template replaces the default merge commit message of "<title>\n\n<description>"; when unset, behavior is unchanged. The template uses Go template syntax with Sprig functions and receives the same data as the title/description templates (.ChangeTransferPolicy and .PromotionStrategy), giving access to the dry commit's subject, body, author, date, and SHA via
.ChangeTransferPolicy.Status.Proposed.Dry.

Machine-read commit trailers used to reconstruct promotion history are always appended after the rendered message, and trailing newlines are trimmed from the rendered template so the trailer block remains the final paragraph.

Closes argoproj-labs/gitops-promoter#1562

https://claude.ai/code/session_01JXTyyEttfvJAktebvzwepv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional commit message template to customize merge commit messages for promotion pull requests. Promoter-required commit trailers for tracking promotion history are automatically appended.

* **Documentation**
  * Updated CRD specification documentation to describe the new commit message template configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->