### PR TITLE
fix(api): make CRD validation rule ordering deterministic in generated manifests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,6 +215,7 @@ You may optionally include a scope in parentheses after the type:
    - Use regex validation for character restrictions
    - Use metav1 types for time and duration fields instead of custom types
    - For numbers where negative values don't make sense, enforce a minimum of zero
+   - Prefer `// +k8s:immutable` for immutability only when the field has no other `XValidation` rules; otherwise use explicit `+kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"` for all CEL rules on that field. Do **not** mix `+k8s:` markers with `XValidation` on one field — controller-gen emits nondeterministic rule order and CRD bases flap in CI ([controller-tools#1429](https://github.com/kubernetes-sigs/controller-tools/issues/1429); see `docs/contributing/writing-cel-rules.md`)
 3. Update example files in `internal/controller/testdata/` for both spec and status changes
 4. Run `make build-installer` to regenerate CRDs, DeepCopy methods, and install manifests
 5. Update controller logic

--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -36,22 +36,28 @@ type PullRequestSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	Title string `json:"title"`
+	// Immutability is enforced via an explicit XValidation rule rather than the k8s immutable
+	// marker: controller-gen iterates markers of different names in random map order, so mixing
+	// the two makes the emitted x-kubernetes-validations rule order nondeterministic.
+
 	// TargetBranch is the head the git reference we are merging from Head ---> Base
 	// Must not start with '-', contain ':', or contain '..'.
-	// +k8s:immutable
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=100
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains(':')",message="branch must not contain ':'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains('..')",message="branch must not contain '..'"
 	TargetBranch string `json:"targetBranch"`
+	// Immutability via explicit XValidation rather than the k8s immutable marker — see TargetBranch.
+
 	// SourceBranch is the base the git reference that we are merging into Head ---> Base
 	// Must not start with '-', contain ':', or contain '..'.
-	// +k8s:immutable
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=100
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains(':')",message="branch must not contain ':'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains('..')",message="branch must not contain '..'"

--- a/docs/contributing/maintaining-crds.md
+++ b/docs/contributing/maintaining-crds.md
@@ -80,7 +80,7 @@ CI’s **Check Codegen** job runs `make build-installer` and fails on drift; see
 ## API design reminders
 
 - Put validation on Go types with kubebuilder markers (`// +kubebuilder:validation:…`, CEL `XValidation`, and so on); do not hand-edit `config/crd/bases/` except via generation.
-- Prefer **`// +k8s:immutable`** on fields that must not change after set (controller-gen v0.21+); it emits the same `self == oldSelf` rule as hand-written immutability `XValidation` (see `PullRequest` `sourceBranch` / `targetBranch`).
+- Prefer **`// +k8s:immutable`** on fields that must not change after set (controller-gen v0.21+) when that field has **no other** `XValidation` rules. It emits the same `self == oldSelf` CEL rule as a hand-written immutability `XValidation`. If the field also needs custom CEL checks, use explicit `XValidation` for immutability too — **do not mix `+k8s:` markers with `XValidation` on one field** ([controller-tools#1429](https://github.com/kubernetes-sigs/controller-tools/issues/1429); see [Writing CEL Validation Rules](writing-cel-rules.md)). Example in-tree: `PullRequest` `sourceBranch` / `targetBranch`.
 - Use **`// +k8s:enum`** on a `type Foo string` plus `const` block only when **every** field typed `Foo` shares the same allowed values. Remove redundant field `Enum` markers only in that case. Do **not** put `+k8s:enum` on a type that is also used from status fields allowing `""` or a subset of consts (controller-gen applies the type enum to all references; field `Enum` is not merged for extras like `""`). Example in-tree: `ContextMode` on `WebRequestCommitStatus`. Plain `string` fields still use field `Enum`.
 - Express reconciler RBAC with **`// +kubebuilder:rbac`** on controllers; regenerate manifests rather than editing `config/rbac/role.yaml` by hand.
 - For SCM-facing types and commit-status controllers, see [Adding an SCM Provider](adding-an-scm-provider.md) and [Developing a CommitStatus](developing-a-commitstatus.md).
@@ -90,6 +90,7 @@ CI’s **Check Codegen** job runs `make build-installer` and fails on drift; see
 | Topic | Page |
 |--------|------|
 | User-facing CR reference | [CRD Specs](../crd-specs.md) |
+| CEL rules and marker mixing | [Writing CEL Validation Rules](writing-cel-rules.md) |
 | Status subresource / SSA | [Maintaining resource status](updating-status.md) |
 | CI codegen checks | [Continuous Integration](ci.md) |
 | Contributor overview | [Contributing overview](index.md) |

--- a/docs/contributing/writing-cel-rules.md
+++ b/docs/contributing/writing-cel-rules.md
@@ -12,6 +12,37 @@ and `make build-installer` compiles them into the CRD bases under `config/crd/`.
 RepoURL string `json:"repoURL,omitempty"`
 ```
 
+## Don't mix `+k8s:` markers with `XValidation` on one field
+
+controller-gen v0.21+ also understands [`+k8s:` declarative validation
+markers](https://www.kubernetes.dev/docs/code/declarative-validation/) (for example
+`+k8s:immutable`, `+k8s:minLength`). Like hand-written `XValidation` markers, these compile into
+`x-kubernetes-validations` CEL rules on the field.
+
+**Do not put both marker families on the same field.** When a field mixes `+k8s:` markers with
+`+kubebuilder:validation:XValidation`, controller-gen emits the rules from each family in
+declared order internally, but the *relative* order of the two families is
+[nondeterministic across
+runs](https://github.com/kubernetes-sigs/controller-tools/issues/1429). Committed CRD bases under
+`config/crd/bases/` then flap between equivalent orderings, which breaks CI checks that diff
+generated manifests.
+
+**Workaround:** keep all CEL rules on a field under one marker family. When a field needs both
+immutability and custom CEL checks, replace `+k8s:immutable` with an explicit immutability rule so
+every rule is an `XValidation` marker:
+
+```go
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
+// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
+Branch string `json:"branch"`
+```
+
+In-tree example: `PullRequest` `sourceBranch` / `targetBranch` in
+[`api/v1alpha1/pullrequest_types.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/api/v1alpha1/pullrequest_types.go).
+
+`+k8s:immutable` (and other `+k8s:` markers that emit CEL) is still fine on fields that have **no**
+other `XValidation` rules on the same field.
+
 ## The apiserver cost budget
 
 When a CRD is created or updated, the kube-apiserver estimates a **static worst-case cost** for


### PR DESCRIPTION
### Summary

  make build-installer produced nondeterministic output: across repeated runs, the field is immutable rule in x-kubernetes-validations for
  PullRequestSpec.targetBranch and sourceBranch would randomly swap position relative to the branch-name validation rules, dirtying
  config/crd/bases/promoter.argoproj.io_pullrequests.yaml and the dist/ install bundles. Roughly 1 in 5 runs of controller-gen crd flipped
  the order.

  ### Root cause

  The two branch fields mixed two different marker families that both append to x-kubernetes-validations: the +k8s:immutable marker and
  +kubebuilder:validation:XValidation markers. In controller-tools (v0.21.0, and still on main), applyMarkers in pkg/crd/schema.go collects
  markers by iterating a Go map keyed by marker name, then applies only a stable sort by apply-priority. Immutable and XValidation share
  the default priority, so the stable sort preserves the random map-iteration order — the relative position of the rules from the two
  marker families is left to chance. Rule order within a single marker name is always stable, which is why only the immutable rule moved.

  Upstream, kubernetes-sigs/controller-tools#1324 attempted to fix this by sorting rules, but was closed unmerged — CEL rules execute in
  order, so sorting changes semantics. The underlying map iteration is unchanged on main, so the bug remains live whenever +k8s:*
  validation markers are mixed with XValidation on the same field.

https://github.com/kubernetes-sigs/controller-tools/issues/1429

  ### Fix

  Replace +k8s:immutable with an explicit +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable" on both
  fields, placed first in the rule list to match the previously committed ordering. With all rules coming from one marker family,
  controller-gen emits them in declared source order, deterministically.

  This is semantically identical for these fields: +k8s:immutable emits exactly that rule and message, and its additional parent-level
  "immutable once set" rule is only generated for optional fields — both of these fields are Required.

  Until the upstream iteration-order bug is fixed, the working rule for this codebase is: don't add +k8s:* validation markers to a field
  that also carries XValidation rules.

  ### Verification

  - 10 consecutive runs of controller-gen crd produce byte-identical output (previously flipped within 5 runs).
  - make build-installer leaves config/crd/bases/ and dist/ with zero diff against the committed files.
  - go build ./... and go vet pass. No schema change is emitted — the generated CRD is byte-identical to what was already committed, so no
  testdata or migration updates are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted how branch-field immutability is enforced internally; no change to user-facing behavior or validation rules.
* **Documentation**
  * Added and updated guidance for CRD validation practices, warning against mixing immutability markers with CEL/XValidation and showing the preferred pattern to avoid CI diffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->