### PR TITLE
feat: support squash merges via GitRepository spec.mergeMethod

### DIFF
--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -26,6 +26,7 @@ import (
 
 // GitRepositorySpec defines the desired state of GitRepository
 // +kubebuilder:validation:ExactlyOneOf=github;gitlab;forgejo;gitea;bitbucketCloud;azureDevOps;fake
+// +kubebuilder:validation:XValidation:rule="!has(self.bitbucketCloud) || !has(self.mergeMethod) || self.mergeMethod != 'squash'",message="squash merge is not supported for Bitbucket Cloud"
 type GitRepositorySpec struct {
 	GitHub         *GitHubRepo         `json:"github,omitempty"`
 	GitLab         *GitLabRepo         `json:"gitlab,omitempty"`
@@ -36,6 +37,31 @@ type GitRepositorySpec struct {
 	Fake           *FakeRepo           `json:"fake,omitempty"`
 	// +kubebuilder:validation:Required
 	ScmProviderRef ScmProviderObjectReference `json:"scmProviderRef"`
+	// MergeMethod determines how promotion pull requests are merged: a merge commit
+	// ("merge") or a single squash commit ("squash"). Defaults to "merge".
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=merge;squash
+	// +kubebuilder:default:=merge
+	MergeMethod MergeMethod `json:"mergeMethod,omitempty"`
+}
+
+// MergeMethod is how a pull request is merged into the target branch.
+type MergeMethod string
+
+const (
+	// MergeMethodMerge merges the pull request with a merge commit.
+	MergeMethodMerge MergeMethod = "merge"
+	// MergeMethodSquash squashes the pull request into a single commit on the target branch.
+	MergeMethodSquash MergeMethod = "squash"
+)
+
+// GetMergeMethod returns the configured merge method, defaulting to MergeMethodMerge when unset.
+// The CRD default covers API-created objects; this guards in-memory constructed objects.
+func (s *GitRepositorySpec) GetMergeMethod() MergeMethod {
+	if s.MergeMethod == "" {
+		return MergeMethodMerge
+	}
+	return s.MergeMethod
 }
 
 // ScmProviderObjectReference is a reference to a SCM provider object.

--- a/api/view/v1alpha1/zz_generated.openapi.go
+++ b/api/view/v1alpha1/zz_generated.openapi.go
@@ -2938,6 +2938,13 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_GitRepositorySpec(ref com
 							Ref:     ref(apiv1alpha1.ScmProviderObjectReference{}.OpenAPIModelName()),
 						},
 					},
+					"mergeMethod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MergeMethod determines how promotion pull requests are merged: a merge commit (\"merge\") or a single squash commit (\"squash\"). Defaults to \"merge\".",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"scmProviderRef"},
 			},

--- a/applyconfiguration/api/v1alpha1/gitrepositoryspec.go
+++ b/applyconfiguration/api/v1alpha1/gitrepositoryspec.go
@@ -17,6 +17,10 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	apiv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+)
+
 // GitRepositorySpecApplyConfiguration represents a declarative configuration of the GitRepositorySpec type for use
 // with apply.
 //
@@ -32,6 +36,9 @@ type GitRepositorySpecApplyConfiguration struct {
 	AzureDevOps    *AzureDevOpsRepoApplyConfiguration            `json:"azureDevOps,omitempty"`
 	Fake           *FakeRepoApplyConfiguration                   `json:"fake,omitempty"`
 	ScmProviderRef *ScmProviderObjectReferenceApplyConfiguration `json:"scmProviderRef,omitempty"`
+	// MergeMethod determines how promotion pull requests are merged: a merge commit
+	// ("merge") or a single squash commit ("squash"). Defaults to "merge".
+	MergeMethod *apiv1alpha1.MergeMethod `json:"mergeMethod,omitempty"`
 }
 
 // GitRepositorySpecApplyConfiguration constructs a declarative configuration of the GitRepositorySpec type for use with
@@ -101,5 +108,13 @@ func (b *GitRepositorySpecApplyConfiguration) WithFake(value *FakeRepoApplyConfi
 // If called multiple times, the ScmProviderRef field is set to the value of the last call.
 func (b *GitRepositorySpecApplyConfiguration) WithScmProviderRef(value *ScmProviderObjectReferenceApplyConfiguration) *GitRepositorySpecApplyConfiguration {
 	b.ScmProviderRef = value
+	return b
+}
+
+// WithMergeMethod sets the MergeMethod field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MergeMethod field is set to the value of the last call.
+func (b *GitRepositorySpecApplyConfiguration) WithMergeMethod(value apiv1alpha1.MergeMethod) *GitRepositorySpecApplyConfiguration {
+	b.MergeMethod = &value
 	return b
 }

--- a/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
+++ b/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
@@ -179,6 +179,15 @@ spec:
                 - namespace
                 - projectId
                 type: object
+              mergeMethod:
+                default: merge
+                description: |-
+                  MergeMethod determines how promotion pull requests are merged: a merge commit
+                  ("merge") or a single squash commit ("squash"). Defaults to "merge".
+                enum:
+                - merge
+                - squash
+                type: string
               scmProviderRef:
                 description: ScmProviderObjectReference is a reference to a SCM provider
                   object.
@@ -204,6 +213,9 @@ spec:
             - scmProviderRef
             type: object
             x-kubernetes-validations:
+            - message: squash merge is not supported for Bitbucket Cloud
+              rule: '!has(self.bitbucketCloud) || !has(self.mergeMethod) || self.mergeMethod
+                != ''squash'''
             - message: exactly one of the fields in [github gitlab forgejo gitea bitbucketCloud
                 azureDevOps fake] must be set
               rule: '[has(self.github),has(self.gitlab),has(self.forgejo),has(self.gitea),has(self.bitbucketCloud),has(self.azureDevOps),has(self.fake)].filter(x,x==true).size()

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -135,14 +135,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               title:
                 description: Title is the title of the pull request.
                 minLength: 1

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -4379,6 +4379,15 @@ spec:
                 - namespace
                 - projectId
                 type: object
+              mergeMethod:
+                default: merge
+                description: |-
+                  MergeMethod determines how promotion pull requests are merged: a merge commit
+                  ("merge") or a single squash commit ("squash"). Defaults to "merge".
+                enum:
+                - merge
+                - squash
+                type: string
               scmProviderRef:
                 description: ScmProviderObjectReference is a reference to a SCM provider
                   object.
@@ -4404,6 +4413,9 @@ spec:
             - scmProviderRef
             type: object
             x-kubernetes-validations:
+            - message: squash merge is not supported for Bitbucket Cloud
+              rule: '!has(self.bitbucketCloud) || !has(self.mergeMethod) || self.mergeMethod
+                != ''squash'''
             - message: exactly one of the fields in [github gitlab forgejo gitea bitbucketCloud
                 azureDevOps fake] must be set
               rule: '[has(self.github),has(self.gitlab),has(self.forgejo),has(self.gitea),has(self.bitbucketCloud),has(self.azureDevOps),has(self.fake)].filter(x,x==true).size()
@@ -6055,14 +6067,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               state:
                 default: open
                 description: |-
@@ -6081,14 +6093,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               title:
                 description: Title is the title of the pull request.
                 minLength: 1

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -4379,6 +4379,15 @@ spec:
                 - namespace
                 - projectId
                 type: object
+              mergeMethod:
+                default: merge
+                description: |-
+                  MergeMethod determines how promotion pull requests are merged: a merge commit
+                  ("merge") or a single squash commit ("squash"). Defaults to "merge".
+                enum:
+                - merge
+                - squash
+                type: string
               scmProviderRef:
                 description: ScmProviderObjectReference is a reference to a SCM provider
                   object.
@@ -4404,6 +4413,9 @@ spec:
             - scmProviderRef
             type: object
             x-kubernetes-validations:
+            - message: squash merge is not supported for Bitbucket Cloud
+              rule: '!has(self.bitbucketCloud) || !has(self.mergeMethod) || self.mergeMethod
+                != ''squash'''
             - message: exactly one of the fields in [github gitlab forgejo gitea bitbucketCloud
                 azureDevOps fake] must be set
               rule: '[has(self.github),has(self.gitlab),has(self.forgejo),has(self.gitea),has(self.bitbucketCloud),has(self.azureDevOps),has(self.fake)].filter(x,x==true).size()
@@ -6055,14 +6067,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               state:
                 default: open
                 description: |-
@@ -6081,14 +6093,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               title:
                 description: Title is the title of the pull request.
                 minLength: 1

--- a/dist/install-without-ui.yaml
+++ b/dist/install-without-ui.yaml
@@ -4379,6 +4379,15 @@ spec:
                 - namespace
                 - projectId
                 type: object
+              mergeMethod:
+                default: merge
+                description: |-
+                  MergeMethod determines how promotion pull requests are merged: a merge commit
+                  ("merge") or a single squash commit ("squash"). Defaults to "merge".
+                enum:
+                - merge
+                - squash
+                type: string
               scmProviderRef:
                 description: ScmProviderObjectReference is a reference to a SCM provider
                   object.
@@ -4404,6 +4413,9 @@ spec:
             - scmProviderRef
             type: object
             x-kubernetes-validations:
+            - message: squash merge is not supported for Bitbucket Cloud
+              rule: '!has(self.bitbucketCloud) || !has(self.mergeMethod) || self.mergeMethod
+                != ''squash'''
             - message: exactly one of the fields in [github gitlab forgejo gitea bitbucketCloud
                 azureDevOps fake] must be set
               rule: '[has(self.github),has(self.gitlab),has(self.forgejo),has(self.gitea),has(self.bitbucketCloud),has(self.azureDevOps),has(self.fake)].filter(x,x==true).size()
@@ -6055,14 +6067,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               state:
                 default: open
                 description: |-
@@ -6081,14 +6093,14 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
                 - message: branch must not start with '-'
                   rule: '!self.startsWith(''-'')'
                 - message: branch must not contain ':'
                   rule: '!self.contains('':'')'
                 - message: branch must not contain '..'
                   rule: '!self.contains(''..'')'
+                - message: field is immutable
+                  rule: self == oldSelf
               title:
                 description: Title is the title of the pull request.
                 minLength: 1

--- a/docs/crd-specs.md
+++ b/docs/crd-specs.md
@@ -57,6 +57,26 @@ auth mechanism.
 {!internal/controller/testdata/GitRepository.yaml!}
 ```
 
+#### Merge method
+
+The `mergeMethod` field controls how promotion pull requests are merged: `merge` (the default) asks the SCM for a
+merge commit, and `squash` asks for a single squash commit per promotion. Use `squash` when your repository policy
+disallows merge commits.
+
+Because a squash commit never makes the proposed branch's commits reachable from the active branch, the promoter
+automatically resets the proposed branch to the active branch tip after each squash merge (a content no-op, since the
+squash commit's tree is identical to the merged proposed tip). The reset is guarded with `--force-with-lease`, so a
+hydrator push that races it is never overwritten; in that case the promoter falls back to its regular conflict
+resolution for that promotion cycle.
+
+Provider notes:
+
+* **Bitbucket Cloud** does not support `squash` (rejected at admission).
+* **GitHub** repositories must have "Allow squash merging" enabled, otherwise merging fails and surfaces as a
+  `Ready=False` condition on the PullRequest resource.
+* **GitLab** projects should leave squashing "allowed" (not "required" or "forbidden") so the per-MR squash flag set by
+  the promoter takes effect.
+
 ### ScmProvider
 
 An ScmProvider represents a scm instance (such as github). It references a Secret to enable access via some configured

--- a/docs/monitoring/events.md
+++ b/docs/monitoring/events.md
@@ -25,6 +25,7 @@ All resources may produce the following events:
 | Event Type | Event Reason        | Description                                                                                                      |
 |------------|---------------------|------------------------------------------------------------------------------------------------------------------|
 | Normal     | ResolvedConflict    | A git merge conflict was resolved for a ChangeTransferPolicy.                                                    |
+| Normal     | AlignedProposedBranch | The proposed branch was reset to the active branch tip after a squash merge.                                   |
 | Normal     | PullRequestCreated  | A pull request was created for a ChangeTransferPolicy.                                                           |
 | Normal     | PullRequestMerged   | A pull request was merged for a ChangeTransferPolicy.                                                            |
 | Normal     | PullRequestUpdated  | A pull request was updated for a ChangeTransferPolicy.                                                           |

--- a/hack/celcost/report.md
+++ b/hack/celcost/report.md
@@ -15,7 +15,7 @@ Estimated static CEL costs versus kube-apiserver limits, computed from `k8s.io/a
 | CommitStatus | v1alpha1 | 3 | 0.00% |
 | ControllerConfiguration | v1alpha1 | 2,840 | 0.00% |
 | GitCommitStatus | v1alpha1 | 0 | 0.00% |
-| GitRepository | v1alpha1 | 128 | 0.00% |
+| GitRepository | v1alpha1 | 135 | 0.00% |
 | PromotionStrategy | v1alpha1 | 72,438,744 | 72.44% |
 | PullRequest | v1alpha1 | 270 | 0.00% |
 | RevertCommit | v1alpha1 | 0 | 0.00% |
@@ -148,7 +148,8 @@ Source: `promoter.argoproj.io_gitrepositories.yaml`
 | Path | Cost | % of rule limit | Expression |
 |---|---:|---:|---|
 | `.spec` | 128 | 0.00% | `[has(self.github),has(self.gitlab),has(self.forgejo),has(self.gitea),has(self.bitbucketCloud),has(self.azureDevOps),h...` |
-| **Total** | **128** | **0.00%** | |
+| `.spec` | 7 | 0.00% | `!has(self.bitbucketCloud) \|\| !has(self.mergeMethod) \|\| self.mergeMethod != 'squash'` |
+| **Total** | **135** | **0.00%** | |
 
 #### PromotionStrategy
 
@@ -194,12 +195,12 @@ Source: `promoter.argoproj.io_pullrequests.yaml`
 
 | Path | Cost | % of rule limit | Expression |
 |---|---:|---:|---|
-| `.spec.sourceBranch` | 42 | 0.00% | `self == oldSelf` |
 | `.spec.sourceBranch` | 42 | 0.00% | `!self.contains(':')` |
 | `.spec.sourceBranch` | 42 | 0.00% | `!self.contains('..')` |
-| `.spec.targetBranch` | 42 | 0.00% | `self == oldSelf` |
+| `.spec.sourceBranch` | 42 | 0.00% | `self == oldSelf` |
 | `.spec.targetBranch` | 42 | 0.00% | `!self.contains(':')` |
 | `.spec.targetBranch` | 42 | 0.00% | `!self.contains('..')` |
+| `.spec.targetBranch` | 42 | 0.00% | `self == oldSelf` |
 | `(root)` | 9 | 0.00% | `self.spec.state == 'open' \|\| has(self.status.id) && self.status.id != ""` |
 | `.spec.sourceBranch` | 3 | 0.00% | `!self.startsWith('-')` |
 | `.spec.targetBranch` | 3 | 0.00% | `!self.startsWith('-')` |

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -163,6 +163,19 @@ func (r *ChangeTransferPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, fmt.Errorf("failed to calculate ChangeTransferPolicy status: %w", err)
 	}
 
+	alignedProposedBranch, err := r.alignProposedBranchAfterSquash(ctx, gitOperations, gitRepo, &ctp)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to align proposed branch after squash merge: %w", err)
+	}
+
+	// Same contract as the gitMergeStrategyOurs requeue below: the alignment force-pushed
+	// origin/<proposedBranch> past what calculateStatus recorded, so continuing this reconcile
+	// would apply the PR with a stale MergeSha and stale Status fields. Requeue so the next
+	// reconcile re-derives Status.Proposed from the new tip.
+	if alignedProposedBranch {
+		return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
+	}
+
 	mergedProposedBranch, err := r.gitMergeStrategyOurs(ctx, gitOperations, &ctp)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to git merge for conflict resolution: %w", err)
@@ -1309,6 +1322,42 @@ func (r *ChangeTransferPolicyReconciler) gitMergeStrategyOurs(ctx context.Contex
 	r.Recorder.Eventf(ctp, nil, "Normal", constants.ResolvedConflictReason, "ResolvingConflict", constants.ResolvedConflictMessage, ctp.Spec.ProposedBranch, ctp.Spec.ActiveBranch)
 
 	return true, nil
+}
+
+// alignProposedBranchAfterSquash resets the proposed branch to the active tip after a squash
+// merge left the branches content-identical but history-divergent. Squash merges never make the
+// proposed commits reachable from the active branch, so without this step every subsequent pull
+// request's commit list accumulates the already-promoted commits.
+//
+// Returns true if the proposed branch was force-pushed (with lease). Callers should requeue
+// rather than continue this reconcile when true is returned, so that the next reconcile
+// re-derives Status.Proposed from the new tip (same contract as gitMergeStrategyOurs).
+func (r *ChangeTransferPolicyReconciler) alignProposedBranchAfterSquash(ctx context.Context, gitOperations *git.EnvironmentOperations, gitRepo *promoterv1alpha1.GitRepository, ctp *promoterv1alpha1.ChangeTransferPolicy) (bool, error) {
+	if gitRepo.Spec.GetMergeMethod() != promoterv1alpha1.MergeMethodSquash {
+		return false, nil
+	}
+
+	// Only align when the branches are content-identical: nothing promoted yet, or a new
+	// hydration is pending, means there is nothing to safely align (and skipping the git calls is
+	// the fast path while waiting on the hydrator).
+	if ctp.Status.Active.Dry.Sha == "" || ctp.Status.Active.Dry.Sha != ctp.Status.Proposed.Dry.Sha {
+		return false, nil
+	}
+
+	if ctp.Status.Proposed.Hydrated.Sha == ctp.Status.Active.Hydrated.Sha {
+		return false, nil
+	}
+
+	aligned, err := gitOperations.AlignProposedBranchAfterSquash(ctx, ctp.Spec.ProposedBranch, ctp.Spec.ActiveBranch)
+	if err != nil {
+		return false, fmt.Errorf("failed to align proposed branch %q to active branch %q after squash merge: %w", ctp.Spec.ProposedBranch, ctp.Spec.ActiveBranch, err)
+	}
+
+	if aligned {
+		r.Recorder.Eventf(ctp, nil, "Normal", constants.AlignedProposedBranchReason, "AligningProposedBranch", constants.AlignedProposedBranchMessage, ctp.Spec.ProposedBranch, ctp.Spec.ActiveBranch)
+	}
+
+	return aligned, nil
 }
 
 // handleFinalizer ensures ChangeTransferPolicyPullRequestCleanupFinalizer is on the CTP while it exists so deletion

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1037,6 +1037,122 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 						"the SCM to merge a sha origin no longer has on the source branch")
 			})
 		})
+
+		// A squash merge writes a brand-new single-parent commit to the active branch; the merged
+		// proposed commits never become reachable from active. Without the post-squash alignment
+		// (alignProposedBranchAfterSquash), the long-lived branches diverge permanently and every
+		// subsequent PR's commit list accumulates the already-promoted commits. This test drives two
+		// full squash promotion cycles and asserts that the proposed branch is realigned to the
+		// active tip between them and that the active history stays linear.
+		Context("When the merge method is squash and auto-merge is on", func() {
+			var name string
+			var gitRepo *promoterv1alpha1.GitRepository
+			var changeTransferPolicy *promoterv1alpha1.ChangeTransferPolicy
+			var typeNamespacedName types.NamespacedName
+			var scmSecret *v1.Secret
+			var scmProvider *promoterv1alpha1.ScmProvider
+
+			BeforeEach(func() {
+				name, scmSecret, scmProvider, gitRepo, _, changeTransferPolicy = changeTransferPolicyResources(ctx, "ctp-squash-auto-merge", "default")
+
+				typeNamespacedName = types.NamespacedName{
+					Name:      name,
+					Namespace: "default",
+				}
+
+				gitRepo.Spec.MergeMethod = promoterv1alpha1.MergeMethodSquash
+				changeTransferPolicy.Spec.ProposedBranch = testBranchDevelopmentNext
+				changeTransferPolicy.Spec.ActiveBranch = testBranchDevelopment
+				changeTransferPolicy.Spec.AutoMerge = ptr.To(true)
+
+				Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+				Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Create(ctx, changeTransferPolicy)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				By("Cleaning up resources")
+				_ = k8sClient.Delete(ctx, changeTransferPolicy)
+			})
+
+			// activeTipParents clones the test repo and returns the active branch tip's sha and its
+			// parent shas.
+			activeTipParents := func(g Gomega) (string, []string) {
+				checkPath, err := os.MkdirTemp("", "*")
+				g.Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = os.RemoveAll(checkPath) }()
+				_, err = runGitCmd(ctx, checkPath, "clone", testGitRepoCloneURL(gitRepo), ".")
+				g.Expect(err).NotTo(HaveOccurred())
+				out, err := runGitCmd(ctx, checkPath, "rev-list", "--parents", "-1", "origin/"+testBranchDevelopment)
+				g.Expect(err).NotTo(HaveOccurred())
+				fields := strings.Fields(strings.TrimSpace(out))
+				g.Expect(fields).NotTo(BeEmpty())
+				return fields[0], fields[1:]
+			}
+
+			It("promotes with single-parent squash commits and realigns the proposed branch between cycles", func() {
+				By("Resetting the fake SCM's merge-sha-mismatch counter")
+				fake.ResetMergeShaMismatchCount()
+
+				gitPath, err := os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = os.RemoveAll(gitPath) }()
+
+				By("Hydrating the proposed branch with a first dry commit")
+				firstDrySha, _ := makeChangeAndHydrateRepo(gitPath, gitRepo, "first squash dry commit", "")
+
+				By("Waiting for the first squash promotion to land on the active branch")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, changeTransferPolicy)).To(Succeed())
+					g.Expect(changeTransferPolicy.Status.Active.Dry.Sha).To(Equal(firstDrySha))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Asserting the active tip is a single-parent squash commit and the proposed branch was realigned to it")
+				var firstSquashSha string
+				Eventually(func(g Gomega) {
+					tip, parents := activeTipParents(g)
+					g.Expect(parents).To(HaveLen(1), "active tip should be a single-parent squash commit")
+					firstSquashSha = tip
+
+					checkPath, err := os.MkdirTemp("", "*")
+					g.Expect(err).NotTo(HaveOccurred())
+					defer func() { _ = os.RemoveAll(checkPath) }()
+					_, err = runGitCmd(ctx, checkPath, "clone", testGitRepoCloneURL(gitRepo), ".")
+					g.Expect(err).NotTo(HaveOccurred())
+					proposedSha, err := runGitCmd(ctx, checkPath, "rev-parse", "origin/"+testBranchDevelopmentNext)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(strings.TrimSpace(proposedSha)).To(Equal(tip),
+						"proposed branch must be realigned to the active tip after a squash merge")
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Hydrating a second dry commit on top of the realigned proposed branch")
+				secondGitPath, err := os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = os.RemoveAll(secondGitPath) }()
+				secondDrySha, _ := makeChangeAndHydrateRepo(secondGitPath, gitRepo, "second squash dry commit", "")
+				Expect(secondDrySha).NotTo(Equal(firstDrySha))
+
+				By("Waiting for the second squash promotion to land on the active branch")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, changeTransferPolicy)).To(Succeed())
+					g.Expect(changeTransferPolicy.Status.Active.Dry.Sha).To(Equal(secondDrySha))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Asserting the active history stays linear across squash promotions")
+				Eventually(func(g Gomega) {
+					_, parents := activeTipParents(g)
+					g.Expect(parents).To(HaveLen(1), "active tip should be a single-parent squash commit")
+					g.Expect(parents[0]).To(Equal(firstSquashSha),
+						"the second squash commit's parent should be the first squash commit; anything else means stale commits accumulated")
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Asserting the SCM was never asked to merge with a stale mergeSha")
+				Expect(fake.MergeShaMismatchCount()).To(BeNumerically("==", 0),
+					"the post-squash alignment requeue must prevent the PullRequest controller from "+
+						"asking the SCM to merge a sha origin no longer has on the source branch")
+			})
+		})
 	})
 })
 

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -229,4 +229,50 @@ var _ = Describe("GitRepository Controller", func() {
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})
+
+	Context("When validating the mergeMethod field", func() {
+		ctx := context.Background()
+
+		newGitRepo := func(name string, spec promoterv1alpha1.GitRepositorySpec) *promoterv1alpha1.GitRepository {
+			spec.ScmProviderRef = promoterv1alpha1.ScmProviderObjectReference{
+				Kind: promoterv1alpha1.ScmProviderKind,
+				Name: name,
+			}
+			return &promoterv1alpha1.GitRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: spec,
+			}
+		}
+
+		It("rejects squash for Bitbucket Cloud repositories", func() {
+			repo := newGitRepo("merge-method-bitbucket-squash", promoterv1alpha1.GitRepositorySpec{
+				BitbucketCloud: &promoterv1alpha1.BitbucketCloudRepo{Owner: "test-owner", Name: "test-repo"},
+				MergeMethod:    promoterv1alpha1.MergeMethodSquash,
+			})
+			err := k8sClient.Create(ctx, repo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("squash merge is not supported for Bitbucket Cloud"))
+		})
+
+		It("accepts the default merge method for Bitbucket Cloud repositories", func() {
+			repo := newGitRepo("merge-method-bitbucket-merge", promoterv1alpha1.GitRepositorySpec{
+				BitbucketCloud: &promoterv1alpha1.BitbucketCloudRepo{Owner: "test-owner", Name: "test-repo"},
+			})
+			Expect(k8sClient.Create(ctx, repo)).To(Succeed())
+			Expect(repo.Spec.MergeMethod).To(Equal(promoterv1alpha1.MergeMethodMerge), "CRD default should apply")
+			Expect(k8sClient.Delete(ctx, repo)).To(Succeed())
+		})
+
+		It("accepts squash for providers that support it", func() {
+			repo := newGitRepo("merge-method-github-squash", promoterv1alpha1.GitRepositorySpec{
+				GitHub:      &promoterv1alpha1.GitHubRepo{Owner: "test-owner", Name: "test-repo"},
+				MergeMethod: promoterv1alpha1.MergeMethodSquash,
+			})
+			Expect(k8sClient.Create(ctx, repo)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, repo)).To(Succeed())
+		})
+	})
 })

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -150,6 +152,99 @@ var _ = Describe("PullRequest Controller", func() {
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
 				}, constants.EventuallyTimeout).Should(Succeed())
+			})
+		})
+
+		Context("When merging with the squash merge method", func() {
+			var mergeSha string
+
+			BeforeEach(func() {
+				By("Creating test resources")
+				name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "squash-merge-method")
+				gitRepo.Spec.MergeMethod = promoterv1alpha1.MergeMethodSquash
+
+				pullRequest.Spec.TargetBranch = testBranchDevelopment
+				pullRequest.Spec.SourceBranch = testBranchDevelopmentNext
+				pullRequest.Spec.Commit.Message = "squash promote commit message"
+
+				typeNamespacedName = types.NamespacedName{
+					Name:      name,
+					Namespace: "default",
+				}
+
+				By("Pushing a commit to the source branch so the squash merge has content")
+				gitPath, err := os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { _ = os.RemoveAll(gitPath) })
+				_, err = runGitCmd(ctx, gitPath, "clone", testGitRepoCloneURL(gitRepo), ".")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = runGitCmd(ctx, gitPath, "config", "user.name", "testuser")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = runGitCmd(ctx, gitPath, "config", "user.email", "testmail@test.com")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = runGitCmd(ctx, gitPath, "checkout", "-B", testBranchDevelopmentNext, "origin/"+testBranchDevelopmentNext)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(path.Join(gitPath, "manifests-fake.yaml"), []byte("{\"side\": \"proposed\"}\n"), 0o644)).To(Succeed())
+				_, err = runGitCmd(ctx, gitPath, "add", "manifests-fake.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = runGitCmd(ctx, gitPath, "commit", "-m", "proposed hydrated commit")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = runGitCmd(ctx, gitPath, "push", "origin", testBranchDevelopmentNext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+				Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+				By("Waiting for PullRequest to be open")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+					g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				mergeSha = getGitBranchSHA(ctx, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name, pullRequest.Spec.SourceBranch)
+			})
+
+			It("merges as a single-parent squash commit carrying the configured message", func() {
+				By("Requesting the merge")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+					pullRequest.Spec.MergeSha = mergeSha
+					pullRequest.Spec.State = promoterv1alpha1.PullRequestMerged
+					g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Verifying the PullRequest is deleted after the merge")
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Verifying the target branch tip is a single-parent squash commit of the source content")
+				checkPath, err := os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { _ = os.RemoveAll(checkPath) })
+				_, err = runGitCmd(ctx, checkPath, "clone", testGitRepoCloneURL(gitRepo), ".")
+				Expect(err).NotTo(HaveOccurred())
+
+				parentsOut, err := runGitCmd(ctx, checkPath, "rev-list", "--parents", "-1", "origin/"+testBranchDevelopment)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.Fields(strings.TrimSpace(parentsOut))).To(HaveLen(2),
+					"target tip should be a single-parent squash commit, got %q", parentsOut)
+
+				messageOut, err := runGitCmd(ctx, checkPath, "log", "--format=%B", "-1", "origin/"+testBranchDevelopment)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(messageOut).To(ContainSubstring("squash promote commit message"))
+
+				targetTree, err := runGitCmd(ctx, checkPath, "rev-parse", "origin/"+testBranchDevelopment+"^{tree}")
+				Expect(err).NotTo(HaveOccurred())
+				sourceTree, err := runGitCmd(ctx, checkPath, "rev-parse", mergeSha+"^{tree}")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.TrimSpace(targetTree)).To(Equal(strings.TrimSpace(sourceTree)),
+					"squash commit must have exactly the source branch tip's tree")
 			})
 		})
 	})

--- a/internal/controller/testdata/GitRepository.yaml
+++ b/internal/controller/testdata/GitRepository.yaml
@@ -36,6 +36,10 @@ spec:
   scmProviderRef:
     kind: ScmProvider # or ClusterScmProvider
     name: example-scm-provider
+
+  # How promotion pull requests are merged: "merge" (a merge commit, the default) or "squash"
+  # (a single squash commit per promotion). Squash is not supported for Bitbucket Cloud.
+  mergeMethod: merge
 status:
   observedGeneration: 123 # compare with metadata.generation to detect stale status
   conditions:

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -620,6 +620,90 @@ func (g *EnvironmentOperations) MergeWithOursStrategy(ctx context.Context, propo
 	return nil
 }
 
+// AlignProposedBranchAfterSquash force-pushes origin/<activeBranch>'s tip onto
+// refs/heads/<proposedBranch> when a squash merge has left the branches content-identical but
+// history-divergent. Without this, the squashed-away commits stay unreachable from the active
+// branch forever and every subsequent pull request's commit list accumulates them. The push is a
+// content no-op by construction (the trees must be identical) and is guarded by force-with-lease
+// against the proposed sha observed at fetch time, so a hydrator push that races this call fails
+// the lease instead of being clobbered.
+//
+// Returns (false, nil) when no alignment is needed or it is not provably safe:
+//   - the branch tips are already the same commit, or
+//   - origin/<proposedBranch> is an ancestor of origin/<activeBranch> (a true merge happened), or
+//   - the two refs' trees differ (e.g. the hydrator pushed before our fetch).
+//
+// Operates on the object DB and remote refs only: it never checks out or otherwise mutates the
+// clone's worktree/index/HEAD (see the package "Clone state invariant" docs). Requires
+// origin/<proposed> and origin/<active> to have been fetched (GetBranchShas earlier in the
+// reconcile).
+func (g *EnvironmentOperations) AlignProposedBranchAfterSquash(ctx context.Context, proposedBranch, activeBranch string) (bool, error) {
+	logger := log.FromContext(ctx)
+	gitPath := g.ClonePath()
+
+	proposedRef := "origin/" + proposedBranch
+	activeRef := "origin/" + activeBranch
+
+	// This sha is the ref value as of this reconcile's fetch, not a live remote read. It doubles
+	// as the lease expectation for the push below.
+	proposedSha, stderr, err := g.runCmd(ctx, gitPath, "rev-parse", proposedRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve sha for branch %q: %w (stderr: %s)", proposedBranch, err, stderr)
+	}
+	proposedSha = strings.TrimSpace(proposedSha)
+
+	activeSha, stderr, err := g.runCmd(ctx, gitPath, "rev-parse", activeRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve sha for branch %q: %w (stderr: %s)", activeBranch, err, stderr)
+	}
+	activeSha = strings.TrimSpace(activeSha)
+
+	if proposedSha == activeSha {
+		return false, nil
+	}
+
+	// rev-list --count instead of merge-base --is-ancestor: the latter signals "no" with a generic
+	// non-zero exit, which runCmd cannot distinguish from a real failure. A count of 0 means
+	// proposed is reachable from active, i.e. a true merge happened and there is nothing to align.
+	countOut, stderr, err := g.runCmd(ctx, gitPath, "rev-list", "--count", proposedSha, "--not", activeSha)
+	if err != nil {
+		return false, fmt.Errorf("failed to count commits on %q not reachable from %q: %w (stderr: %s)", proposedBranch, activeBranch, err, stderr)
+	}
+	if strings.TrimSpace(countOut) == "0" {
+		return false, nil
+	}
+
+	proposedTree, stderr, err := g.runCmd(ctx, gitPath, "rev-parse", proposedSha+"^{tree}")
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve tree for branch %q: %w (stderr: %s)", proposedBranch, err, stderr)
+	}
+	activeTree, stderr, err := g.runCmd(ctx, gitPath, "rev-parse", activeSha+"^{tree}")
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve tree for branch %q: %w (stderr: %s)", activeBranch, err, stderr)
+	}
+	if strings.TrimSpace(proposedTree) != strings.TrimSpace(activeTree) {
+		// The hydrator pushed new content before our fetch. Skip; the regular conflict-resolution
+		// path (HasConflict -> MergeWithOursStrategy) owns this cycle's divergence.
+		logger.V(4).Info("Skipping post-squash alignment, branch trees differ", "proposedBranch", proposedBranch, "activeBranch", activeBranch)
+		return false, nil
+	}
+
+	// A lease failure here means the hydrator pushed after our fetch; the caller's requeue
+	// re-derives everything from fresh fetches, so nothing the hydrator wrote is ever lost.
+	_, stderr, err = g.runCmd(ctx, gitPath, "push",
+		"--force-with-lease=refs/heads/"+proposedBranch+":"+proposedSha,
+		"origin", activeSha+":refs/heads/"+proposedBranch)
+	if err != nil {
+		logger.Error(err, "Failed to push post-squash alignment", "proposedBranch", proposedBranch, "activeBranch", activeBranch, "stderr", stderr)
+		return false, fmt.Errorf("failed to push post-squash alignment to branch %q: %w (stderr: %s)", proposedBranch, err, stderr)
+	}
+
+	logger.Info("Aligned proposed branch to active tip after squash merge",
+		"proposedBranch", proposedBranch, "activeBranch", activeBranch,
+		"previousProposedSha", proposedSha, "newProposedSha", activeSha)
+	return true, nil
+}
+
 // MergeWithOursStrategyForPath resolves conflicts by taking proposed branch content only within activePath and
 // active branch content everywhere else, then pushes the result to the proposed branch.
 //

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -941,6 +941,235 @@ var _ = Describe("ActivePath support", func() {
 	})
 })
 
+var _ = Describe("AlignProposedBranchAfterSquash", func() {
+	var tempRepoDir string
+	var workDir string
+	var defaultBranch string
+	var repo *v1alpha1.GitRepository
+	var g *git.EnvironmentOperations
+
+	BeforeEach(func() {
+		var err error
+		tempRepoDir, err = os.MkdirTemp("", "git-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(tempRepoDir, "init", "--bare")
+		Expect(err).NotTo(HaveOccurred())
+
+		workDir, err = os.MkdirTemp("", "git-work-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(workDir, "clone", tempRepoDir, ".")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "config", "user.name", "Test User")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "config", "user.email", "test@example.com")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "config", "commit.gpgsign", "false")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.WriteFile(filepath.Join(workDir, "config.yaml"), []byte("version: base\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"base"}`), 0o644)).To(Succeed())
+		_, err = runGitCmd(workDir, "add", "-A")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "base")
+		Expect(err).NotTo(HaveOccurred())
+
+		out, err := runGitCmd(workDir, "rev-parse", "--abbrev-ref", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		defaultBranch = strings.TrimSpace(out)
+
+		_, err = runGitCmd(workDir, "push", "-u", "origin", defaultBranch)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The active branch starts at the base commit.
+		_, err = runGitCmd(workDir, "branch", "active", defaultBranch)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", "active")
+		Expect(err).NotTo(HaveOccurred())
+
+		repo = &v1alpha1.GitRepository{
+			Spec: v1alpha1.GitRepositorySpec{
+				GitHub: &v1alpha1.GitHubRepo{Owner: "test-owner", Name: "testrepo"},
+				ScmProviderRef: v1alpha1.ScmProviderObjectReference{
+					Kind: "ScmProvider",
+					Name: "testprovider",
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "testrepo", Namespace: "default"},
+		}
+	})
+
+	AfterEach(func() {
+		if tempRepoDir != "" {
+			Expect(os.RemoveAll(tempRepoDir)).To(Succeed())
+		}
+		if workDir != "" {
+			Expect(os.RemoveAll(workDir)).To(Succeed())
+		}
+	})
+
+	// commitOnBranch commits the given files on the branch (creating it from the default branch if
+	// needed), pushes, and returns the new commit sha.
+	commitOnBranch := func(branch string, files map[string]string, message string) string {
+		GinkgoHelper()
+		existing, _ := runGitCmd(workDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+		if strings.TrimSpace(existing) == "" {
+			_, err := runGitCmd(workDir, "checkout", "-b", branch, defaultBranch)
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			_, err := runGitCmd(workDir, "checkout", branch)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		for relPath, content := range files {
+			full := filepath.Join(workDir, relPath)
+			Expect(os.MkdirAll(filepath.Dir(full), 0o755)).To(Succeed())
+			Expect(os.WriteFile(full, []byte(content), 0o644)).To(Succeed())
+		}
+		_, err := runGitCmd(workDir, "add", "-A")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", message)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "-u", "origin", branch)
+		Expect(err).NotTo(HaveOccurred())
+		sha, err := runGitCmd(workDir, "rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "checkout", defaultBranch)
+		Expect(err).NotTo(HaveOccurred())
+		return strings.TrimSpace(sha)
+	}
+
+	// squashOntoActive simulates an SCM squash merge of proposed into active: a single new commit
+	// on active whose tree is exactly proposed's tree.
+	squashOntoActive := func() string {
+		GinkgoHelper()
+		treeSha, err := runGitCmd(workDir, "rev-parse", "proposed^{tree}")
+		Expect(err).NotTo(HaveOccurred())
+		activeSha, err := runGitCmd(workDir, "rev-parse", "active")
+		Expect(err).NotTo(HaveOccurred())
+		squashSha, err := runGitCmd(workDir, "commit-tree", strings.TrimSpace(treeSha), "-p", strings.TrimSpace(activeSha), "-m", "squash promote")
+		Expect(err).NotTo(HaveOccurred())
+		squashShaTrimmed := strings.TrimSpace(squashSha)
+		_, err = runGitCmd(workDir, "push", "origin", squashShaTrimmed+":refs/heads/active")
+		Expect(err).NotTo(HaveOccurred())
+		return squashShaTrimmed
+	}
+
+	remoteSha := func(branch string) string {
+		GinkgoHelper()
+		out, err := runGitCmd(tempRepoDir, "rev-parse", "refs/heads/"+branch)
+		Expect(err).NotTo(HaveOccurred())
+		return strings.TrimSpace(out)
+	}
+
+	prepareEnvOps := func() {
+		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
+		_, err := g.GetBranchShas(GinkgoT().Context(), "active", "")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed", "")
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	It("aligns the proposed branch to the active tip after a squash merge", func() {
+		commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 2\n",
+			"hydrator.metadata": `{"drySha":"dry-2"}`,
+		}, "hydrate 2")
+		squashSha := squashOntoActive()
+
+		prepareEnvOps()
+		clonePath := g.ClonePath()
+		headBefore, statusBefore := cloneHeadAndStatus(clonePath)
+
+		aligned, err := g.AlignProposedBranchAfterSquash(GinkgoT().Context(), "proposed", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aligned).To(BeTrue())
+		Expect(remoteSha("proposed")).To(Equal(squashSha))
+
+		headAfter, statusAfter := cloneHeadAndStatus(clonePath)
+		Expect(headAfter).To(Equal(headBefore), "alignment must not move the clone's HEAD")
+		Expect(statusAfter).To(Equal(statusBefore), "alignment must not touch the clone's worktree/index")
+	})
+
+	It("returns false when the proposed branch is an ancestor of the active branch", func() {
+		proposedSha := commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 2\n",
+			"hydrator.metadata": `{"drySha":"dry-2"}`,
+		}, "hydrate 2")
+
+		// A true merge: proposed becomes reachable from active.
+		_, err := runGitCmd(workDir, "checkout", "active")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "merge", "--no-ff", "-m", "merge promote", "proposed")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", "active")
+		Expect(err).NotTo(HaveOccurred())
+
+		prepareEnvOps()
+
+		aligned, err := g.AlignProposedBranchAfterSquash(GinkgoT().Context(), "proposed", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aligned).To(BeFalse())
+		Expect(remoteSha("proposed")).To(Equal(proposedSha))
+	})
+
+	It("returns false when the branch tips are the same commit", func() {
+		_, err := runGitCmd(workDir, "branch", "proposed", defaultBranch)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", "proposed")
+		Expect(err).NotTo(HaveOccurred())
+
+		prepareEnvOps()
+
+		aligned, err := g.AlignProposedBranchAfterSquash(GinkgoT().Context(), "proposed", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aligned).To(BeFalse())
+	})
+
+	It("skips when the hydrator pushed new proposed content before the fetch", func() {
+		commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 2\n",
+			"hydrator.metadata": `{"drySha":"dry-2"}`,
+		}, "hydrate 2")
+		squashOntoActive()
+		hydratorSha := commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 3\n",
+			"hydrator.metadata": `{"drySha":"dry-3"}`,
+		}, "hydrate 3")
+
+		prepareEnvOps()
+
+		aligned, err := g.AlignProposedBranchAfterSquash(GinkgoT().Context(), "proposed", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aligned).To(BeFalse())
+		Expect(remoteSha("proposed")).To(Equal(hydratorSha), "a hydrator commit must never be rewound")
+	})
+
+	It("fails the lease instead of clobbering a hydrator push that raced the alignment", func() {
+		commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 2\n",
+			"hydrator.metadata": `{"drySha":"dry-2"}`,
+		}, "hydrate 2")
+		squashOntoActive()
+
+		prepareEnvOps()
+
+		// The hydrator pushes after our fetch: the lease must reject the alignment push.
+		racedSha := commitOnBranch("proposed", map[string]string{
+			"config.yaml":       "version: 3\n",
+			"hydrator.metadata": `{"drySha":"dry-3"}`,
+		}, "hydrate 3")
+
+		aligned, err := g.AlignProposedBranchAfterSquash(GinkgoT().Context(), "proposed", "active")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to push post-squash alignment"))
+		Expect(aligned).To(BeFalse())
+		Expect(remoteSha("proposed")).To(Equal(racedSha), "a hydrator commit must never be rewound")
+	})
+})
+
 type fakeGitProvider struct {
 	tempDirPath string
 }

--- a/internal/scms/azuredevops/pullrequest.go
+++ b/internal/scms/azuredevops/pullrequest.go
@@ -217,8 +217,14 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 		return fmt.Errorf("failed to create Git client: %w", err)
 	}
 
+	mergeStrategy := git.GitPullRequestMergeStrategyValues.NoFastForward
+	if gitRepo.Spec.GetMergeMethod() == v1alpha1.MergeMethodSquash {
+		mergeStrategy = git.GitPullRequestMergeStrategyValues.Squash
+	}
+
 	// Complete the pull request (merge it) using Azure DevOps completion API
 	completionOptions := git.GitPullRequestCompletionOptions{
+		MergeStrategy:      &mergeStrategy,
 		MergeCommitMessage: &pullRequest.Spec.Commit.Message,
 		DeleteSourceBranch: &[]bool{false}[0], // Keep source branch by default
 	}

--- a/internal/scms/bitbucket_cloud/pullrequest.go
+++ b/internal/scms/bitbucket_cloud/pullrequest.go
@@ -182,6 +182,12 @@ func (pr *PullRequest) Merge(ctx context.Context, prObj v1alpha1.PullRequest) er
 		return fmt.Errorf("failed to get repo: %w", err)
 	}
 
+	// Belt-and-suspenders behind the GitRepository CEL validation: go-bitbucket does not expose a
+	// merge strategy, so a squash setting that somehow reaches this point cannot be honored.
+	if repo.Spec.GetMergeMethod() == v1alpha1.MergeMethodSquash {
+		return errors.New("squash merge is not supported by the Bitbucket Cloud integration")
+	}
+
 	options := &bitbucket.PullRequestsOptions{
 		Owner:             repo.Spec.BitbucketCloud.Owner,
 		RepoSlug:          repo.Spec.BitbucketCloud.Name,

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -189,9 +189,20 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 	}
 	beforeSha = strings.TrimSpace(beforeSha)
 
-	_, err = pr.runGitCmd(ctx, gitPath, "merge", "--no-ff", "origin/"+pullRequest.Spec.SourceBranch, "-m", pullRequest.Spec.Commit.Message)
-	if err != nil {
-		return err
+	if gitRepo.Spec.GetMergeMethod() == v1alpha1.MergeMethodSquash {
+		_, err = pr.runGitCmd(ctx, gitPath, "merge", "--squash", "origin/"+pullRequest.Spec.SourceBranch)
+		if err != nil {
+			return err
+		}
+		_, err = pr.runGitCmd(ctx, gitPath, "commit", "-m", pullRequest.Spec.Commit.Message)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err = pr.runGitCmd(ctx, gitPath, "merge", "--no-ff", "origin/"+pullRequest.Spec.SourceBranch, "-m", pullRequest.Spec.Commit.Message)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = pr.runGitCmd(ctx, gitPath, "push")

--- a/internal/scms/forgejo/pullrequest.go
+++ b/internal/scms/forgejo/pullrequest.go
@@ -169,8 +169,12 @@ func (pr *PullRequest) Merge(ctx context.Context, prObj promoterv1alpha1.PullReq
 		return err
 	}
 
+	style := forgejo.MergeStyleMerge
+	if repo.Spec.GetMergeMethod() == promoterv1alpha1.MergeMethodSquash {
+		style = forgejo.MergeStyleSquash
+	}
 	options := forgejo.MergePullRequestOption{
-		Style:        forgejo.MergeStyleMerge, // TODO: make the merge style configurable
+		Style:        style,
 		Message:      prObj.Spec.Commit.Message,
 		HeadCommitId: prObj.Spec.MergeSha,
 	}

--- a/internal/scms/gitea/pullrequest.go
+++ b/internal/scms/gitea/pullrequest.go
@@ -169,8 +169,12 @@ func (pr *PullRequest) Merge(ctx context.Context, prObj promoterv1alpha1.PullReq
 		return err
 	}
 
+	style := gitea.MergeStyleMerge
+	if repo.Spec.GetMergeMethod() == promoterv1alpha1.MergeMethodSquash {
+		style = gitea.MergeStyleSquash
+	}
 	options := gitea.MergePullRequestOption{
-		Style:        gitea.MergeStyleMerge, // TODO: make the merge style configurable
+		Style:        style,
 		Message:      prObj.Spec.Commit.Message,
 		HeadCommitId: prObj.Spec.MergeSha,
 	}

--- a/internal/scms/github/pullrequest.go
+++ b/internal/scms/github/pullrequest.go
@@ -168,7 +168,7 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 		prNumber,
 		pullRequest.Spec.Commit.Message,
 		&github.PullRequestOptions{
-			MergeMethod:        "merge",
+			MergeMethod:        string(gitRepo.Spec.GetMergeMethod()),
 			DontDefaultIfBlank: false,
 			SHA:                pullRequest.Spec.MergeSha,
 		})

--- a/internal/scms/gitlab/pullrequest.go
+++ b/internal/scms/gitlab/pullrequest.go
@@ -191,15 +191,22 @@ func (pr *PullRequest) Merge(ctx context.Context, prObj v1alpha1.PullRequest) er
 		return fmt.Errorf("failed to get repo: %w", err)
 	}
 
+	squash := repo.Spec.GetMergeMethod() == v1alpha1.MergeMethodSquash
 	options := &gitlab.AcceptMergeRequestOptions{
 		AutoMerge:                gitlab.Ptr(false),
 		ShouldRemoveSourceBranch: gitlab.Ptr(false),
-		Squash:                   gitlab.Ptr(false),
+		Squash:                   gitlab.Ptr(squash),
 		SHA:                      gitlab.Ptr(prObj.Spec.MergeSha),
 	}
 	// Gitlab throws a 422 if you send it an empty commit message. So leave it as nil unless we have a message.
 	if prObj.Spec.Commit.Message != "" {
 		options.MergeCommitMessage = gitlab.Ptr(prObj.Spec.Commit.Message)
+		if squash {
+			// Depending on the project's merge method setting, the squash commit may be what lands
+			// as the target branch's first-parent commit, so it must carry the promoter's trailers
+			// too.
+			options.SquashCommitMessage = gitlab.Ptr(prObj.Spec.Commit.Message)
+		}
 	}
 
 	start := time.Now()

--- a/internal/types/constants/events.go
+++ b/internal/types/constants/events.go
@@ -8,6 +8,11 @@ const (
 	// ResolvedConflictMessage is the message for a resolved conflict event.
 	ResolvedConflictMessage = "Merged %s into %s with 'ours' strategy to resolve conflicts"
 
+	// AlignedProposedBranchReason is the reason for a post-squash proposed branch alignment event.
+	AlignedProposedBranchReason = "AlignedProposedBranch"
+	// AlignedProposedBranchMessage is the message for a post-squash proposed branch alignment event.
+	AlignedProposedBranchMessage = "Reset %s to the tip of %s after squash merge"
+
 	// TooManyMatchingShaReason indicates that there are too many matching SHAs for the active or proposed commit status.
 	TooManyMatchingShaReason = "TooManyMatchingSha"
 	// TooManyMatchingShaActiveMessage is the message for too many matching SHAs for the active commit status.


### PR DESCRIPTION
Adds a repo-wide mergeMethod field (merge|squash, default merge) to the GitRepository spec and threads it through every SCM provider's Merge():

- GitHub: MergeMethod merge/squash (message param carries the trailers as the squash commit body; the SHA head-guard works for squash too)
- GitLab: Squash flag plus SquashCommitMessage so the promoter's trailers land on the resulting first-parent commit regardless of the project's merge method setting
- Gitea/Forgejo: MergeStyleSquash (resolves the existing TODOs)
- Azure DevOps: explicit MergeStrategy (NoFastForward/Squash)
- Bitbucket Cloud: squash rejected at admission via CEL (the SDK does not expose a merge strategy) with a runtime guard as backstop
- Fake provider: real squash merges for the test git server

A squash merge writes a single-parent commit to the active branch whose tree is identical to the merged proposed tip, but the proposed commits never become reachable from active, so the long-lived hydrated branches diverge permanently and every later PR's commit list accumulates the already-promoted commits. To fix that, the ChangeTransferPolicy controller now realigns the proposed branch after each squash merge: when the branches are content-identical (same dry sha, identical trees) but history-divergent, it force-pushes the active tip onto the proposed branch with --force-with-lease keyed to the proposed sha observed at fetch time. The push is a content no-op by construction; a hydrator push that races it fails the lease instead of being clobbered, and a hydrator push that lands before the fetch makes the trees differ so the alignment skips and the existing ours-merge conflict path owns that cycle. The reconcile requeues after an alignment (same contract as gitMergeStrategyOurs) so the next reconcile re-derives Status.Proposed and PR.Spec.MergeSha never goes stale.

Promotion state tracking is unaffected: dry SHAs come from the hydrator.metadata file in the branch tree, downstream gating falls back to it when the hydrator note is absent, and calculateHistory's first-parent trailer walk works with single-parent squash commits.

https://claude.ai/code/session_014objp5iEuqJS8BJyXyXHKu