### PR TITLE
chore(pr): remove finalizer during terminal cleanup delete

### DIFF
--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -201,6 +201,18 @@ func (r *PullRequestReconciler) cleanupTerminalStates(ctx context.Context, pr *p
 	} else {
 		logger.Info("Cleaning up closed and merged pull request", "pullRequestID", pr.Status.ID)
 	}
+
+	// TODO: The PullRequest finalizer could be removed immediately after a successful merge/close on the SCM
+	// (when we first know SCM cleanup is done), and optionally initiate Delete in that same reconciliation, to
+	// save an extra reconcile. We remove it here alongside Delete instead to keep the terminal-cleanup path
+	// simple and reliable.
+	if controllerutil.ContainsFinalizer(pr, promoterv1alpha1.PullRequestFinalizer) {
+		controllerutil.RemoveFinalizer(pr, promoterv1alpha1.PullRequestFinalizer)
+		if err := r.Update(ctx, pr); err != nil {
+			return false, fmt.Errorf("failed to remove finalizer before cleanup delete: %w", err)
+		}
+	}
+
 	if err := r.Delete(ctx, pr); err != nil && !k8serrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete PullRequest")
 		return false, fmt.Errorf("failed to delete PullRequest: %w", err)


### PR DESCRIPTION
## Summary

When a PullRequest reaches a terminal state (`merged`, `closed`, or `externallyMergedOrClosed`), `cleanupTerminalStates` now removes `pullrequest.promoter.argoproj.io/finalizer` in the same reconciliation as the `Delete` call. The SCM obligation is already satisfied at that point, so the separate deletion-time finalizer pass is unnecessary.

### Standard post-merge deletion reconcile series

After `spec.state` is set to `merged` and the PR controller merges on the SCM:

| # | Trigger | What happens |
|---|---------|--------------|
| 1 | `spec.state=merged` | Merge reconcile: SCM merge API call, `status.state=merged` set in memory, immediate requeue so defer persists status |
| 2 | Requeue from (1) | **Cleanup reconcile**: `cleanupTerminalStates` sees terminal status → removes PR finalizer + calls `Delete` |
| 3 | `deletionTimestamp` set | **CTP finalizer reconcile**: ChangeTransferPolicy copies PR status, removes `changetransferpolicy.promoter.argoproj.io/pullrequest-finalizer` |
| 4 | All finalizers cleared | Object removed from etcd; any stale queue entry logs `PullRequest not found` |

The same series applies to `closed` and `externallyMergedOrClosed` cleanup, except reconcile (1) is a close or provider-sync reconcile instead of a merge.

### Reconcile avoided by this change

**Before:** reconcile (2) only called `Delete`, leaving the PR finalizer in place. That triggered an extra reconcile where `handleFinalizer` ran on the terminating object, confirmed the SCM PR was already gone, and removed `pullrequest.promoter.argoproj.io/finalizer` — with no SCM work left to do.

**After:** that dedicated finalizer-removal reconcile is eliminated; finalizer removal happens inside reconcile (2) alongside `Delete`.

Reconciles (1), (3), and (4) are unchanged. A TODO in `cleanupTerminalStates` notes a possible future optimization to remove the finalizer immediately after merge/close on the SCM (before the cleanup requeue), deferred to keep this change small.

## Test plan

- [ ] Merge a PullRequest manually (as in argopromote west test) and confirm PR controller logs show cleanup + finalizer removal in one reconcile, without a subsequent `handleFinalizer`-only pass
- [ ] Verify external delete of an open PullRequest still closes the SCM PR via `handleFinalizer` (unchanged path)
- [ ] Run `make test-parallel` (controller envtest suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pull request cleanup process to ensure proper resource removal when pull requests reach terminal states (merged or closed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->