### PR TITLE
feat(pr): enforce terminal state

### DIFF
--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -151,6 +151,7 @@ func (ps *PullRequest) SetObservedGeneration(generation int64) {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`,priority=1
 // +kubebuilder:validation:XValidation:rule=`self.spec.state == 'open' || has(self.status.id) && self.status.id != ""`,message="Cannot transition to 'closed' or 'merged' state when status.id is empty"
+// +kubebuilder:validation:XValidation:rule=`!(has(oldSelf.status.state) && (oldSelf.status.state == 'merged' || oldSelf.status.state == 'closed')) || self.spec.state == oldSelf.spec.state`,message="spec.state is immutable once status.state has reached a terminal state (merged or closed)"
 type PullRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -266,6 +266,10 @@ spec:
             is empty
           rule: self.spec.state == 'open' || has(self.status.id) && self.status.id
             != ""
+        - message: spec.state is immutable once status.state has reached a terminal
+            state (merged or closed)
+          rule: '!(has(oldSelf.status.state) && (oldSelf.status.state == ''merged''
+            || oldSelf.status.state == ''closed'')) || self.spec.state == oldSelf.spec.state'
     served: true
     storage: true
     subresources:

--- a/hack/celcost/report.md
+++ b/hack/celcost/report.md
@@ -17,7 +17,7 @@ Estimated static CEL costs versus kube-apiserver limits, computed from `k8s.io/a
 | GitCommitStatus | v1alpha1 | 0 | 0.00% |
 | GitRepository | v1alpha1 | 128 | 0.00% |
 | PromotionStrategy | v1alpha1 | 72,438,744 | 72.44% |
-| PullRequest | v1alpha1 | 270 | 0.00% |
+| PullRequest | v1alpha1 | 288 | 0.00% |
 | RevertCommit | v1alpha1 | 0 | 0.00% |
 | ScmProvider | v1alpha1 | 135 | 0.00% |
 | TimedCommitStatus | v1alpha1 | 0 | 0.00% |
@@ -200,11 +200,12 @@ Source: `promoter.argoproj.io_pullrequests.yaml`
 | `.spec.targetBranch` | 42 | 0.00% | `self == oldSelf` |
 | `.spec.targetBranch` | 42 | 0.00% | `!self.contains(':')` |
 | `.spec.targetBranch` | 42 | 0.00% | `!self.contains('..')` |
+| `(root)` | 18 | 0.00% | `!(has(oldSelf.status.state) && (oldSelf.status.state == 'merged' \|\| oldSelf.status.state == 'closed')) \|\| self.sp...` |
 | `(root)` | 9 | 0.00% | `self.spec.state == 'open' \|\| has(self.status.id) && self.status.id != ""` |
 | `.spec.sourceBranch` | 3 | 0.00% | `!self.startsWith('-')` |
 | `.spec.targetBranch` | 3 | 0.00% | `!self.startsWith('-')` |
 | `.status.url` | 3 | 0.00% | `self == '' \|\| isURL(self)` |
-| **Total** | **270** | **0.00%** | |
+| **Total** | **288** | **0.00%** | |
 
 #### RevertCommit
 

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -293,6 +293,137 @@ var _ = Describe("PullRequest Controller", func() {
 		})
 	})
 
+	Context("When spec.state transitions are restricted after terminal status", func() {
+		const blockingFinalizer = "promoter.argoproj.io/test-will-not-remove"
+		const terminalStatusImmutableMsg = "spec.state is immutable once status.state has reached a terminal state"
+
+		setupPullRequestWithBlockingFinalizer := func(namePrefix string) (types.NamespacedName, *promoterv1alpha1.PullRequest) {
+			name, scmSecret, scmProvider, gitRepo, pullRequest := pullRequestResources(ctx, namePrefix)
+			typeNamespacedName := types.NamespacedName{Name: name, Namespace: "default"}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			pullRequest.Finalizers = append(pullRequest.Finalizers, blockingFinalizer)
+			Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+
+			return typeNamespacedName, pullRequest
+		}
+
+		removeBlockingFinalizerIfDeleting := func(typeNamespacedName types.NamespacedName) {
+			var pr promoterv1alpha1.PullRequest
+			if err := k8sClient.Get(ctx, typeNamespacedName, &pr); err != nil {
+				return
+			}
+			if pr.DeletionTimestamp == nil {
+				return
+			}
+			var kept []string
+			for _, f := range pr.Finalizers {
+				if f != blockingFinalizer {
+					kept = append(kept, f)
+				}
+			}
+			if len(kept) == len(pr.Finalizers) {
+				return
+			}
+			base := pr.DeepCopy()
+			pr.Finalizers = kept
+			_ = k8sClient.Patch(ctx, &pr, client.MergeFrom(base))
+		}
+
+		It("should reject changing spec.state when status.state is merged", func() {
+			typeNamespacedName, pullRequest := setupPullRequestWithBlockingFinalizer("cel-terminal-merged")
+			defer removeBlockingFinalizerIfDeleting(typeNamespacedName)
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				base := pullRequest.DeepCopy()
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestMerged
+				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				pullRequest.Status.State = promoterv1alpha1.PullRequestMerged
+				g.Expect(k8sClient.Status().Update(ctx, pullRequest)).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			pullRequest.Spec.State = promoterv1alpha1.PullRequestOpen
+			err := k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(terminalStatusImmutableMsg))
+		})
+
+		It("should reject changing spec.state when status.state is closed", func() {
+			typeNamespacedName, pullRequest := setupPullRequestWithBlockingFinalizer("cel-terminal-closed")
+			defer removeBlockingFinalizerIfDeleting(typeNamespacedName)
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				base := pullRequest.DeepCopy()
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestClosed
+				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				pullRequest.Status.State = promoterv1alpha1.PullRequestClosed
+				g.Expect(k8sClient.Status().Update(ctx, pullRequest)).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+			base := pullRequest.DeepCopy()
+			pullRequest.Spec.State = promoterv1alpha1.PullRequestOpen
+			err := k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(terminalStatusImmutableMsg))
+		})
+
+		It("should allow reverting spec.state to open while status.state is still open", func() {
+			name, scmSecret, scmProvider, gitRepo, pullRequest := pullRequestResources(ctx, "cel-abort-inflight")
+			typeNamespacedName := types.NamespacedName{Name: name, Namespace: "default"}
+
+			Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+			Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				base := pullRequest.DeepCopy()
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestMerged
+				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+				g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+				base := pullRequest.DeepCopy()
+				pullRequest.Spec.State = promoterv1alpha1.PullRequestOpen
+				g.Expect(k8sClient.Patch(ctx, pullRequest, client.MergeFrom(base))).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
+
 	Context("When deleting a PullRequest that never created a PR on SCM", func() {
 		var name string
 		var scmSecret *v1.Secret


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests that have reached terminal state (merged or closed) now have immutable state fields, preventing any further state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->