### PR TITLE
feat(ui): communicate when a new dry commit is incoming for environments

### DIFF
--- a/ui/components-lib/src/components/Card.scss
+++ b/ui/components-lib/src/components/Card.scss
@@ -55,12 +55,19 @@
   color: $argo-color-gray-7;
 }
 
-.env-card__proposed-loading {
+.env-card__proposed-loading-bar {
   width: 100%;
   height: 2px;
   background: $argo-running;
   border-radius: 1px;
   animation: proposed-loading-pulse 1.5s ease-in-out infinite;
+}
+
+.env-card__proposed-loading-text {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: $argo-color-gray-7;
 }
 
 @keyframes proposed-loading-pulse {
@@ -75,7 +82,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .env-card__proposed-loading {
+  .env-card__proposed-loading-bar {
     animation: none;
     opacity: 1;
   }

--- a/ui/components-lib/src/components/Card.scss
+++ b/ui/components-lib/src/components/Card.scss
@@ -55,6 +55,32 @@
   color: $argo-color-gray-7;
 }
 
+.env-card__proposed-loading {
+  width: 100%;
+  height: 2px;
+  background: $argo-running;
+  border-radius: 1px;
+  animation: proposed-loading-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes proposed-loading-pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .env-card__proposed-loading {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 .history-toggle {
   background: none;
   border: none;

--- a/ui/components-lib/src/components/Card.tsx
+++ b/ui/components-lib/src/components/Card.tsx
@@ -3,7 +3,11 @@ import { StatusType } from './StatusIcon';
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import CommitInfo from './CommitInfo';
 import HistoryNavigation from './HistoryNavigation';
-import { EnrichedEnvDetails, enrichFromEnvironments } from '@shared/utils/PSData';
+import {
+  EnrichedEnvDetails,
+  enrichFromEnvironments,
+  getProcessingEnvs,
+} from '@shared/utils/PSData';
 import type { Environment } from '@shared/types/promotion';
 import './Card.scss';
 
@@ -43,6 +47,8 @@ const Card: React.FC<CardProps> = ({ environments }) => {
     return (historyMode[branch] || 0) > 0;
   };
 
+  const processingEnvs = useMemo(() => getProcessingEnvs(environments), [environments]);
+
   // Get enriched environments with current history index
   const enrichedEnvs = useMemo(() => {
     return environments.map((env) => {
@@ -57,6 +63,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
         {enrichedEnvs.map((env: EnrichedEnvDetails, index) => {
           const branch = env.branch;
           const proposedStatus = env.promotionStatus;
+          const isProcessing = processingEnvs.has(branch);
           const inHistoryMode = isInHistoryMode(branch);
           const isNavigationVisible = hoveredIcon === branch;
           const environment = environments.find((e) => e.branch === branch);
@@ -165,8 +172,9 @@ const Card: React.FC<CardProps> = ({ environments }) => {
 
                   {/* Proposed Commits Section (normal mode only) */}
                   {!inHistoryMode &&
-                    proposedStatus !== 'promoted' &&
-                    proposedStatus !== 'success' && (
+                    (isProcessing ? (
+                      <div className="env-card__proposed-loading" />
+                    ) : proposedStatus !== 'promoted' && proposedStatus !== 'success' ? (
                       <CommitInfo
                         title="Proposed"
                         deploymentCommit={proposedDeploymentCommit}
@@ -181,7 +189,7 @@ const Card: React.FC<CardProps> = ({ environments }) => {
                         prUrl={env.prUrl}
                         prNumber={env.prNumber?.toString()}
                       />
-                    )}
+                    ) : null)}
                 </div>
               </div>
               {index < enrichedEnvs.length - 1 && (

--- a/ui/components-lib/src/components/Card.tsx
+++ b/ui/components-lib/src/components/Card.tsx
@@ -1,5 +1,5 @@
 import { FaServer, FaHistory } from 'react-icons/fa';
-import { StatusType } from './StatusIcon';
+import { StatusIcon, StatusType } from './StatusIcon';
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import CommitInfo from './CommitInfo';
 import HistoryNavigation from './HistoryNavigation';
@@ -173,7 +173,22 @@ const Card: React.FC<CardProps> = ({ environments }) => {
                   {/* Proposed Commits Section (normal mode only) */}
                   {!inHistoryMode &&
                     (isProcessing ? (
-                      <div className="env-card__proposed-loading" />
+                      // Processing: stand in for the Proposed section with a labeled
+                      // loading placeholder while the newer commit is hydrated.
+                      <div className="commit-group env-card__proposed-loading">
+                        <div className="commit-group-header">
+                          <StatusIcon phase="pending" type="health" />
+                          <h4 className="commit-group-title">Proposed</h4>
+                        </div>
+                        <div
+                          className="env-card__proposed-loading-bar"
+                          role="progressbar"
+                          aria-label="Preparing newer commit"
+                        />
+                        <div className="env-card__proposed-loading-text">
+                          preparing newer commit&hellip;
+                        </div>
+                      </div>
                     ) : proposedStatus !== 'promoted' && proposedStatus !== 'success' ? (
                       <CommitInfo
                         title="Proposed"

--- a/ui/extension/getProcessingEnvs.test.ts
+++ b/ui/extension/getProcessingEnvs.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { getProcessingEnvs } from '@shared/utils/PSData';
+import type { Environment } from '@shared/types/promotion';
+
+interface EnvOverrides {
+  branch?: string;
+  activeDrySha?: string;
+  noteDrySha?: string;
+  proposedDrySha?: string;
+  hydratedSha?: string;
+  hydratedCommitTime?: string;
+}
+
+const makeEnv = (o: EnvOverrides = {}): Environment => ({
+  branch: o.branch ?? 'main',
+  active: {
+    dry: o.activeDrySha ? { sha: o.activeDrySha } : undefined,
+  },
+  proposed: {
+    dry: o.proposedDrySha ? { sha: o.proposedDrySha } : undefined,
+    hydrated:
+      o.hydratedSha || o.hydratedCommitTime
+        ? { sha: o.hydratedSha, commitTime: o.hydratedCommitTime ?? null }
+        : undefined,
+    note: o.noteDrySha ? { drySha: o.noteDrySha } : undefined,
+  },
+});
+
+describe('getProcessingEnvs', () => {
+  it('returns an empty set when no env has a dry sha', () => {
+    const envs = [makeEnv({ branch: 'dev' }), makeEnv({ branch: 'prod' })];
+    expect(getProcessingEnvs(envs).size).toBe(0);
+  });
+
+  it('returns an empty set when all envs share the target dry sha (at rest)', () => {
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'old',
+        noteDrySha: 'aaa',
+        proposedDrySha: 'aaa',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'old',
+        noteDrySha: 'aaa',
+        proposedDrySha: 'aaa',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    expect(getProcessingEnvs(envs).size).toBe(0);
+  });
+
+  it('marks a lagging env as processing when its note has caught up but differs from target', () => {
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'new',
+        proposedDrySha: 'new',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'older',
+        noteDrySha: 'old',
+        proposedDrySha: 'old',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    const result = getProcessingEnvs(envs);
+    expect(result.has('prod')).toBe(true);
+    expect(result.has('dev')).toBe(false);
+  });
+
+  it('marks a pending env as processing when its note is transiently absent (falls back to dry sha)', () => {
+    // Leading env defines target via note; lagging env has a proposed change
+    // (active.dry != proposed.dry) but its note hasn't been written yet.
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'new',
+        proposedDrySha: 'new',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'older',
+        proposedDrySha: 'old',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    const result = getProcessingEnvs(envs);
+    expect(result.has('prod')).toBe(true);
+  });
+
+  it('does not mark an env with no proposed change (active.dry == proposed.dry) as processing', () => {
+    // prod has already deployed what it is proposing — nothing is pending,
+    // so it must not show the processing placeholder even though it lags the target.
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'new',
+        proposedDrySha: 'new',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'old',
+        proposedDrySha: 'old',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    const result = getProcessingEnvs(envs);
+    expect(result.has('prod')).toBe(false);
+    expect(result.size).toBe(0);
+  });
+
+  it('does not mark an env with no proposed commit as processing', () => {
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'new',
+        proposedDrySha: 'new',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({ branch: 'prod' }),
+    ];
+    const result = getProcessingEnvs(envs);
+    expect(result.has('prod')).toBe(false);
+    expect(result.size).toBe(0);
+  });
+
+  it('does not mark an env whose effective dry sha matches the target even if its hydrated commit is older', () => {
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'same',
+        proposedDrySha: 'same',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'older',
+        proposedDrySha: 'same',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    expect(getProcessingEnvs(envs).size).toBe(0);
+  });
+
+  it('prefers note.drySha over proposed.dry.sha when both are present', () => {
+    // prod's note says it has reached the target, even though its dry.sha differs.
+    const envs = [
+      makeEnv({
+        branch: 'dev',
+        activeDrySha: 'older',
+        noteDrySha: 'target',
+        proposedDrySha: 'target',
+        hydratedSha: 'h1',
+        hydratedCommitTime: '2026-06-16T00:00:00Z',
+      }),
+      makeEnv({
+        branch: 'prod',
+        activeDrySha: 'older',
+        noteDrySha: 'target',
+        proposedDrySha: 'stale',
+        hydratedSha: 'h2',
+        hydratedCommitTime: '2026-06-15T00:00:00Z',
+      }),
+    ];
+    expect(getProcessingEnvs(envs).has('prod')).toBe(false);
+  });
+});

--- a/ui/extension/package-lock.json
+++ b/ui/extension/package-lock.json
@@ -420,26 +420,24 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -451,7 +449,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -883,14 +880,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1074,9 +1071,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1394,9 +1391,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1411,9 +1408,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1428,9 +1425,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1445,9 +1442,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1462,9 +1459,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1479,9 +1476,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1496,9 +1493,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1513,9 +1510,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1530,9 +1527,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1547,9 +1544,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1564,9 +1561,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1581,9 +1578,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1598,9 +1595,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1608,16 +1605,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1632,9 +1631,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1649,9 +1648,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1663,9 +1662,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3954,9 +3953,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4115,16 +4114,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4389,9 +4388,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5106,9 +5105,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5697,9 +5706,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6141,9 +6150,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6161,7 +6170,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6530,14 +6539,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -6546,21 +6555,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -7273,14 +7282,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7755,17 +7764,17 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7781,7 +7790,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -7830,6 +7839,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -8212,9 +8239,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/shared/src/types/promotion.ts
+++ b/ui/shared/src/types/promotion.ts
@@ -59,6 +59,7 @@ export interface Environment {
     dry?: Commit;
     hydrated?: Commit;
     commitStatuses?: CommitStatus[];
+    note?: { drySha?: string };
   };
   pullRequest?: PullRequest;
   history?: History[];

--- a/ui/shared/src/utils/PSData.ts
+++ b/ui/shared/src/utils/PSData.ts
@@ -150,6 +150,24 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
   };
 }
 
+// Returns the set of branch names whose environments are currently being processed.
+export function getProcessingEnvs(environments: Environment[]): Set<string> {
+  const effective = (e: Environment) => e.proposed?.note?.drySha || e.proposed?.dry?.sha || '';
+  let target = '',
+    newest = -Infinity;
+  for (const e of environments) {
+    const sha = e.proposed?.dry?.sha;
+    if (!sha) continue;
+    const t = Date.parse(e.proposed?.hydrated?.commitTime ?? '') || 0;
+    if (!target || t > newest) {
+      target = sha;
+      newest = t;
+    }
+  }
+  if (!target) return new Set();
+  return new Set(environments.filter((e) => effective(e) !== target).map((e) => e.branch));
+}
+
 // Takes the PS objects (for dashboard)
 export function enrichFromCRD(
   ps: PromotionStrategy,

--- a/ui/shared/src/utils/PSData.ts
+++ b/ui/shared/src/utils/PSData.ts
@@ -150,21 +150,18 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
   };
 }
 
-// Returns the set of branch names whose environments are currently being processed,
-// i.e. the newest hydrated dry commit has not yet propagated to that environment.
-//
-// The target is the hydrated dry SHA (proposed.note.drySha) of the environment with
-// the newest proposed hydrated commit. An environment is "processing" when its own
-// hydrated dry SHA differs from that target — its proposed branch has not yet been
-// re-hydrated against the newest dry commit. The comparison is symmetric (note.drySha
-// on both sides): at rest every environment shares the same hydrated dry SHA and the
-// set is empty.
+// Returns branch names whose proposed commit has not yet been hydrated to the
+// newest dry commit. Envs with no proposed commit are not processing.
 export function getProcessingEnvs(environments: Environment[]): Set<string> {
-  const hydratedDrySha = (e: Environment) => e.proposed?.note?.drySha ?? '';
+  const effectiveDrySha = (e: Environment) =>
+    e.proposed?.note?.drySha || e.proposed?.dry?.sha || '';
+  const hasProposedChange = (e: Environment) =>
+    !!e.proposed?.dry?.sha && e.active?.dry?.sha !== e.proposed?.dry?.sha;
+
   let target = '',
     newest = -Infinity;
   for (const e of environments) {
-    const sha = hydratedDrySha(e);
+    const sha = effectiveDrySha(e);
     if (!sha) continue;
     const t = Date.parse(e.proposed?.hydrated?.commitTime ?? '') || 0;
     if (!target || t > newest) {
@@ -175,10 +172,7 @@ export function getProcessingEnvs(environments: Environment[]): Set<string> {
   if (!target) return new Set();
   return new Set(
     environments
-      .filter((e) => {
-        const sha = hydratedDrySha(e);
-        return sha !== '' && sha !== target;
-      })
+      .filter((e) => hasProposedChange(e) && effectiveDrySha(e) !== target)
       .map((e) => e.branch),
   );
 }

--- a/ui/shared/src/utils/PSData.ts
+++ b/ui/shared/src/utils/PSData.ts
@@ -150,13 +150,21 @@ function getEnvDetails(environment: Environment, index: number = 0): EnrichedEnv
   };
 }
 
-// Returns the set of branch names whose environments are currently being processed.
+// Returns the set of branch names whose environments are currently being processed,
+// i.e. the newest hydrated dry commit has not yet propagated to that environment.
+//
+// The target is the hydrated dry SHA (proposed.note.drySha) of the environment with
+// the newest proposed hydrated commit. An environment is "processing" when its own
+// hydrated dry SHA differs from that target — its proposed branch has not yet been
+// re-hydrated against the newest dry commit. The comparison is symmetric (note.drySha
+// on both sides): at rest every environment shares the same hydrated dry SHA and the
+// set is empty.
 export function getProcessingEnvs(environments: Environment[]): Set<string> {
-  const effective = (e: Environment) => e.proposed?.note?.drySha || e.proposed?.dry?.sha || '';
+  const hydratedDrySha = (e: Environment) => e.proposed?.note?.drySha ?? '';
   let target = '',
     newest = -Infinity;
   for (const e of environments) {
-    const sha = e.proposed?.dry?.sha;
+    const sha = hydratedDrySha(e);
     if (!sha) continue;
     const t = Date.parse(e.proposed?.hydrated?.commitTime ?? '') || 0;
     if (!target || t > newest) {
@@ -165,7 +173,14 @@ export function getProcessingEnvs(environments: Environment[]): Set<string> {
     }
   }
   if (!target) return new Set();
-  return new Set(environments.filter((e) => effective(e) !== target).map((e) => e.branch));
+  return new Set(
+    environments
+      .filter((e) => {
+        const sha = hydratedDrySha(e);
+        return sha !== '' && sha !== target;
+      })
+      .map((e) => e.branch),
+  );
 }
 
 // Takes the PS objects (for dashboard)


### PR DESCRIPTION
closes #657. Shows a processing state when a new dry sha is picked up by the promoter, but all environment PR's have not been created/updated yet.

### Results:

**New promotion:**

https://github.com/user-attachments/assets/7be1abab-69bd-4c0d-b273-1e21b92121b4

**Interrupted promotion:**

https://github.com/user-attachments/assets/76d4dcfc-e320-4f22-9edf-bb513e4e5b23



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposed environments now show a “loading” placeholder (including a status icon, progress/placeholder text, and a full-width animated bar) while the relevant environments are processing.
  * The animation respects reduced-motion settings by disabling the pulse and keeping the loading bar visible.
* **Bug Fixes**
  * Proposed commit details are no longer shown when an environment is still processing, preventing stale/partial display.
* **Tests**
  * Added coverage for environment “processing” detection logic, including cases around missing notes and dry SHA selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->