### PR TITLE
ci: have dependabot bump indirect go dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # By default Dependabot only bumps direct requires. Indirect modules listed in
+    # go.mod (e.g. golang.org/x/crypto) need this to get version-update PRs.
+    allow:
+      - dependency-type: "indirect"
     ignore:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to include indirect Go module dependencies in automated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->