### PR TITLE
feat: support HTTP_PROXY envs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,6 +121,11 @@ func runController(
 		os.Exit(1)
 	}
 
+	if err := utils.ConfigureDefaultTransportFromEnv(); err != nil {
+		setupLog.Error(err, "failed to configure HTTP TLS roots from environment")
+		os.Exit(1)
+	}
+
 	// Recover any panic and log using the configured logger. This ensures that panics get logged in JSON format if
 	// JSON logging is enabled.
 	defer func() {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -507,6 +507,24 @@ func runCmd(ctx context.Context, gap scms.GitOperationsProvider, directory strin
 	return runCmdWithEnv(ctx, gap, directory, nil, args...)
 }
 
+// proxyRelatedEnvVars returns proxy/TLS env vars from the current process so git subprocesses
+// honor HTTPS_PROXY and GIT_SSL_CAINFO when the controller is run behind an MITM proxy.
+// cmd.Env replaces the entire child environment; without this, git bypasses the proxy.
+func proxyRelatedEnvVars() []string {
+	var out []string
+	for _, key := range []string{
+		"HTTPS_PROXY", "https_proxy",
+		"HTTP_PROXY", "http_proxy",
+		"NO_PROXY", "no_proxy",
+		"GIT_SSL_CAINFO", "SSL_CERT_FILE",
+	} {
+		if v := os.Getenv(key); v != "" {
+			out = append(out, key+"="+v)
+		}
+	}
+	return out
+}
+
 // runCmdWithEnv runs a git command, appending extraEnv to the standard auth environment, and
 // returns stdout, stderr, and error.
 func runCmdWithEnv(ctx context.Context, gap scms.GitOperationsProvider, directory string, extraEnv []string, args ...string) (string, string, error) {
@@ -527,7 +545,8 @@ func runCmdWithEnv(ctx context.Context, gap scms.GitOperationsProvider, director
 		"GIT_PASSWORD=" + token,
 		"PATH=" + os.Getenv("PATH"),
 		"GIT_TERMINAL_PROMPT=0",
-	}, extraEnv...)
+	}, proxyRelatedEnvVars()...)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,6 +3,7 @@ package git_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -938,6 +939,69 @@ var _ = Describe("ActivePath support", func() {
 		content, err := os.ReadFile(filepath.Join(workDir, "config.yaml"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.TrimSpace(string(content))).To(Equal("version: proposed"), "ours strategy keeps proposed content")
+	})
+})
+
+var _ = Describe("Git subprocess proxy env", func() {
+	It("forwards proxy and TLS env vars via runCmd", func() {
+		want := map[string]string{
+			"HTTPS_PROXY":    "http://proxy.test:8443",
+			"HTTP_PROXY":     "http://proxy.test:8080",
+			"NO_PROXY":         "localhost,127.0.0.1",
+			"GIT_SSL_CAINFO":   "/tmp/test-ca.pem",
+			"SSL_CERT_FILE":    "/tmp/test-cert.pem",
+		}
+		for key, val := range want {
+			GinkgoT().Setenv(key, val)
+		}
+
+		workDir := GinkgoT().TempDir()
+		envDump := filepath.Join(workDir, "proxy-env-dump")
+		gitBin := filepath.Join(workDir, "git")
+		script := fmt.Sprintf(`#!/bin/sh
+ENV_DUMP=%q
+if [ "$1" = "ls-remote" ] && [ "$2" = "--heads" ]; then
+  : > "$ENV_DUMP"
+  for key in HTTPS_PROXY HTTP_PROXY NO_PROXY GIT_SSL_CAINFO SSL_CERT_FILE; do
+    eval "val=\$$key"
+    echo "$key=$val" >> "$ENV_DUMP"
+  done
+  echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef	refs/heads/main"
+  exit 0
+fi
+echo "unexpected git args: $*" >&2
+exit 1
+`, envDump)
+		Expect(os.WriteFile(gitBin, []byte(script), 0o755)).To(Succeed())
+		GinkgoT().Setenv("PATH", workDir)
+
+		repo := &v1alpha1.GitRepository{
+			Spec: v1alpha1.GitRepositorySpec{
+				GitHub: &v1alpha1.GitHubRepo{Owner: "test-owner", Name: "testrepo"},
+				ScmProviderRef: v1alpha1.ScmProviderObjectReference{
+					Kind: "ScmProvider",
+					Name: "testprovider",
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "testrepo", Namespace: "default"},
+		}
+		gap := &fakeGitProvider{tempDirPath: filepath.Join(workDir, "ignored-repo")}
+
+		shas, err := git.LsRemote(context.Background(), gap, repo, "main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shas).To(HaveKeyWithValue("main", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+
+		dump, err := os.ReadFile(envDump)
+		Expect(err).NotTo(HaveOccurred())
+		got := map[string]string{}
+		for _, line := range strings.Split(strings.TrimSpace(string(dump)), "\n") {
+			key, val, ok := strings.Cut(line, "=")
+			Expect(ok).To(BeTrue(), "unexpected dump line %q", line)
+			got[key] = val
+		}
+		for key, val := range want {
+			Expect(got[key]).To(Equal(val), "proxy env var %s", key)
+		}
 	})
 })
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -947,9 +947,9 @@ var _ = Describe("Git subprocess proxy env", func() {
 		want := map[string]string{
 			"HTTPS_PROXY":    "http://proxy.test:8443",
 			"HTTP_PROXY":     "http://proxy.test:8080",
-			"NO_PROXY":         "localhost,127.0.0.1",
-			"GIT_SSL_CAINFO":   "/tmp/test-ca.pem",
-			"SSL_CERT_FILE":    "/tmp/test-cert.pem",
+			"NO_PROXY":       "localhost,127.0.0.1",
+			"GIT_SSL_CAINFO": "/tmp/test-ca.pem",
+			"SSL_CERT_FILE":  "/tmp/test-cert.pem",
 		}
 		for key, val := range want {
 			GinkgoT().Setenv(key, val)

--- a/internal/utils/http_tls.go
+++ b/internal/utils/http_tls.go
@@ -12,7 +12,7 @@ import (
 // RootCAs are loaded from SSL_CERT_FILE or GIT_SSL_CAINFO when set.
 //
 // On macOS, Go's default verifier uses the platform trust store and does not honor
-// SSL_CERT_FILE for http.DefaultTransport. That breaks MITM load-test proxies unless
+// SSL_CERT_FILE for http.DefaultTransport. That breaks MITM proxies unless
 // we install an explicit root pool (curl honors --cacert; Go needs this hook).
 func ConfigureDefaultTransportFromEnv() error {
 	caPath := os.Getenv("SSL_CERT_FILE")

--- a/internal/utils/http_tls.go
+++ b/internal/utils/http_tls.go
@@ -13,7 +13,7 @@ import (
 //
 // On macOS, Go's default verifier uses the platform trust store and does not honor
 // SSL_CERT_FILE for http.DefaultTransport. That breaks MITM proxies unless
-// we install an explicit root pool (curl honors --cacert; Go needs this hook).
+// we install an explicit root pool.
 func ConfigureDefaultTransportFromEnv() error {
 	caPath := os.Getenv("SSL_CERT_FILE")
 	if caPath == "" {

--- a/internal/utils/http_tls.go
+++ b/internal/utils/http_tls.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// ConfigureDefaultTransportFromEnv replaces http.DefaultTransport with a clone whose
+// RootCAs are loaded from SSL_CERT_FILE or GIT_SSL_CAINFO when set.
+//
+// On macOS, Go's default verifier uses the platform trust store and does not honor
+// SSL_CERT_FILE for http.DefaultTransport. That breaks MITM load-test proxies unless
+// we install an explicit root pool (curl honors --cacert; Go needs this hook).
+func ConfigureDefaultTransportFromEnv() error {
+	caPath := os.Getenv("SSL_CERT_FILE")
+	if caPath == "" {
+		caPath = os.Getenv("GIT_SSL_CAINFO")
+	}
+	if caPath == "" {
+		return nil
+	}
+
+	pem, err := os.ReadFile(caPath)
+	if err != nil {
+		return fmt.Errorf("read TLS CA file %q: %w", caPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return fmt.Errorf("parse TLS CA file %q: no certificates found", caPath)
+	}
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("http.DefaultTransport is %T, expected *http.Transport", http.DefaultTransport)
+	}
+	cloned := base.Clone()
+	if cloned.TLSClientConfig == nil {
+		cloned.TLSClientConfig = &tls.Config{}
+	}
+	cloned.TLSClientConfig.RootCAs = pool
+	http.DefaultTransport = cloned
+	return nil
+}

--- a/internal/utils/http_tls.go
+++ b/internal/utils/http_tls.go
@@ -9,16 +9,14 @@ import (
 )
 
 // ConfigureDefaultTransportFromEnv replaces http.DefaultTransport with a clone whose
-// RootCAs are loaded from SSL_CERT_FILE or GIT_SSL_CAINFO when set.
+// RootCAs are loaded from SSL_CERT_FILE when set.
 //
 // On macOS, Go's default verifier uses the platform trust store and does not honor
 // SSL_CERT_FILE for http.DefaultTransport. That breaks MITM proxies unless
-// we install an explicit root pool.
+// we install an explicit root pool. Git subprocesses use GIT_SSL_CAINFO instead;
+// see internal/git.proxyRelatedEnvVars.
 func ConfigureDefaultTransportFromEnv() error {
 	caPath := os.Getenv("SSL_CERT_FILE")
-	if caPath == "" {
-		caPath = os.Getenv("GIT_SSL_CAINFO")
-	}
 	if caPath == "" {
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic TLS trust store setup from `SSL_CERT_FILE` during startup, with startup terminating if configuration fails.
  * Ensured HTTP/HTTPS proxy and TLS CA settings (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `GIT_SSL_CAINFO`, `SSL_CERT_FILE`) are forwarded to git subprocesses.

* **Tests**
  * Added coverage confirming git subprocesses receive the expected proxy/TLS environment variables during remote lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->