### PR TITLE
feat: add in-cluster dashboard deployment manifest

### DIFF
--- a/config/dashboard/deployment.yaml
+++ b/config/dashboard/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: promoter-dashboard
+  namespace: promoter-system
+  labels:
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: dashboard
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dashboard
+          image: quay.io/argoprojlabs/gitops-promoter:latest
+          command:
+            - /usr/bin/tini
+            - "--"
+            - /gitops-promoter
+            - dashboard
+          args:
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 250m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      serviceAccountName: promoter-dashboard
+      terminationGracePeriodSeconds: 10

--- a/config/dashboard/kustomization.yaml
+++ b/config/dashboard/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - rbac.yaml

--- a/config/dashboard/rbac.yaml
+++ b/config/dashboard/rbac.yaml
@@ -23,6 +23,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/dashboard/rbac.yaml
+++ b/config/dashboard/rbac.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promoter-dashboard
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups:
+      - view.promoter.argoproj.io
+    resources:
+      - promotionstrategydetails
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - promoter.argoproj.io
+    resources:
+      - promotionstrategies
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promoter-dashboard
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promoter-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: promoter-dashboard
+    namespace: promoter-system

--- a/config/dashboard/service.yaml
+++ b/config/dashboard/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: promoter-dashboard
+  namespace: promoter-system
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    app.kubernetes.io/component: dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/config/dashboard/serviceaccount.yaml
+++ b/config/dashboard/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promoter-dashboard
+  namespace: promoter-system
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: kustomize

--- a/docs/advanced-usage/dashboard-apiserver.md
+++ b/docs/advanced-usage/dashboard-apiserver.md
@@ -26,7 +26,30 @@ The dashboard process watches `PromotionStrategyDetails` and forwards each bundl
 the browser over Server-Sent Events (SSE). SSE does not flow through the
 kube-aggregator proxy.
 
-## What gets deployed
+## In-cluster dashboard deployment
+
+In addition to running the dashboard locally via CLI, you can deploy it as an in-cluster
+Deployment + Service so that teams can access a shared, always-available dashboard through
+existing ingress infrastructure:
+
+```bash
+kubectl apply -k config/dashboard
+```
+
+This deploys:
+
+| Resource | Purpose |
+| --- | --- |
+| `ServiceAccount promoter-dashboard` | dedicated identity for the dashboard pod |
+| `ClusterRole / ClusterRoleBinding promoter-dashboard` | read-only access to `PromotionStrategyDetails` and `PromotionStrategies` |
+| `Deployment promoter-dashboard` | runs `gitops-promoter dashboard --port=8080` |
+| `Service promoter-dashboard` | `80 -> 8080` |
+
+Add your own Ingress, Gateway API HTTPRoute, or other routing and authentication
+resources on top of the Service. The dashboard requires the APIService (below) to be
+deployed and healthy.
+
+## What gets deployed (APIService)
 
 `config/apiserver` ships a self-contained kustomize base (under
 `config/apiserver/base`) plus cert overlays:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -582,7 +582,9 @@ kubectl get promotionstrategydetails -A
 
 ### Launch the UI
 
-To launch the UI, first download the gitops-promoter CLI from the [releases page](https://github.com/argoproj-labs/gitops-promoter/releases).
+/// tab | Local (CLI)
+
+Download the gitops-promoter CLI from the [releases page](https://github.com/argoproj-labs/gitops-promoter/releases).
 
 Make the file executable and add it to your PATH.
 
@@ -601,5 +603,22 @@ By default, the UI uses your current kubeconfig context. If you want to use a di
 ```bash
 gitops-promoter dashboard --port <your-port> --kubecontext <your-kube-context>
 ```
+
+///
+
+/// tab | In-cluster deployment
+
+For a shared, always-available dashboard that teams can access through your existing ingress
+infrastructure, deploy the dashboard as an in-cluster Deployment + Service:
+
+```bash
+kubectl apply -k config/dashboard
+```
+
+This deploys a `promoter-dashboard` Deployment (running `dashboard --port 8080`), a Service
+(port 80 → 8080), and minimal read-only RBAC. Add your own Ingress, Gateway API HTTPRoute, or
+other routing and authentication resources on top of the Service.
+
+///
 
 ![Video of the GitOps Promoter UI as a change is promoted through three environments](assets/demo.gif)


### PR DESCRIPTION
## Summary

- Adds self-contained kustomize overlay (`config/dashboard/`) that deploys the dashboard UI as an in-cluster Deployment + Service
- Includes ServiceAccount, ClusterRole/Binding with minimal read-only RBAC (promotionstrategydetails + promotionstrategies)
- Hardened security context matching existing apiserver pattern (runAsNonRoot, readOnlyRootFilesystem, drop ALL)
- Users deploy with `kubectl apply -k config/dashboard` and add their own Ingress/Gateway on top

Closes #1645

## Test plan

- [ ] `kustomize build config/dashboard` produces valid output
- [ ] Deploy to cluster with existing APIService — dashboard pod starts, `/healthz` returns 200
- [ ] Verify RBAC: dashboard can read promotionstrategydetails and promotionstrategies, nothing else
- [ ] Verify security context: pod runs as non-root with read-only filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-cluster dashboard deployment via Kustomize (`kubectl apply -k config/dashboard`), including Service, ServiceAccount, and minimal read-only RBAC.
  * Introduced security hardening for the dashboard pod (run as non-root, default seccomp, no privilege escalation, dropped capabilities, read-only filesystem) and set resource requests/limits.
  * Enabled liveness/readiness probes using `GET /healthz`.
* **Documentation**
  * Updated getting-started UI instructions with tabs for Local (CLI) vs in-cluster deployment, including guidance to add your own routing/authentication.
  * Clarified that the next section covers APIService configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->