### PR TITLE
chore(ci): use renovate for github dependency bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,9 @@ updates:
   # The coupled Kubernetes platform packages (k8s.io/*, controller-runtime,
   # multicluster-runtime, and their staging deps) are ALSO owned by Renovate so
   # they can be bumped in lockstep with the Makefile envtest versions; they are
-  # ignored here to avoid duplicate PRs. See renovate.json5 for configuration.
+  # ignored here to avoid duplicate PRs. go-github (major /vNN paths) and
+  # ghinstallation are also Renovate-owned for import rewrites on major bumps.
+  # See renovate.json5 for configuration.
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -21,6 +23,8 @@ updates:
       - dependency-name: "sigs.k8s.io/structured-merge-diff/*"
       - dependency-name: "sigs.k8s.io/json"
       - dependency-name: "sigs.k8s.io/randfill"
+      - dependency-name: "github.com/google/go-github/*"
+      - dependency-name: "github.com/bradleyfalzon/ghinstallation/*"
     groups:
       # etcd modules (api, client/pkg, client/v3) release together; one PR beats three.
       go-etcd:

--- a/renovate.json5
+++ b/renovate.json5
@@ -108,6 +108,31 @@
       automerge: false,
     },
     // ----------------------------------------------------------------------
+    // Group A2: GitHub API client (go-github major paths + ghinstallation)
+    // go-github uses /vNN module paths; Renovate rewrites imports on major jumps.
+    // Dependabot ignores these packages to avoid duplicate PRs.
+    // ----------------------------------------------------------------------
+    {
+      description: 'go-github and ghinstallation bump together; rewrite imports on major path changes',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/google/go-github/**',
+        'github.com/bradleyfalzon/ghinstallation/**',
+      ],
+      enabled: true,
+      groupName: 'GitHub API client',
+      semanticCommits: 'enabled',
+      semanticCommitType: 'chore',
+      semanticCommitScope: 'deps',
+      automerge: false,
+      postUpdateOptions: [
+        'gomodUpdateImportPaths',
+        'gomodTidy',
+      ],
+    },
+    // ----------------------------------------------------------------------
     // Group B: Go toolchain + golangci-lint (+ golang base image)
     // ----------------------------------------------------------------------
     {


### PR DESCRIPTION
Dependabot doesn't know how to do the path updates, so we gotta use Renovate for major bumps on these two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management automation with improved Dependabot and Renovate configurations for Go module updates, ensuring synchronized version management and automatic import path handling during major version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->