### PR TITLE
chore(ci): fix pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: UI Checks
         run: make lint-ui
       - name: Set up Python and venv for docs
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
       - name: Create venv and install MkDocs requirements

--- a/.github/workflows/kubebuilder_helm.yaml
+++ b/.github/workflows/kubebuilder_helm.yaml
@@ -36,7 +36,7 @@ jobs:
           kubebuilder version
 
       - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # pin v4.3
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v4.2.2
 

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -50,10 +50,8 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
-      # sigstore/cosign-installer v4.1.1 (latest release). Action pinned to commit SHA — update tag + SHA from
-      # https://github.com/sigstore/cosign-installer/releases when upgrading (do not use a floating @v4 ref).
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # cosign-installer v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.0.5 # cosign CLI; latest sigstore/cosign, explicit pin for reproducibility
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,10 +54,8 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
-      # sigstore/cosign-installer v4.1.1 (latest release). Action pinned to commit SHA — update tag + SHA from
-      # https://github.com/sigstore/cosign-installer/releases when upgrading (do not use a floating @v4 ref).
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # cosign-installer v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.0.5 # cosign CLI; latest sigstore/cosign, explicit pin for reproducibility
 


### PR DESCRIPTION
Fully-specify pin comments. Floating versions drift from pinned shas causing Zizmor failures. Fully specifying the versions keeps pins in sync with shas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several CI and release workflows to keep tool versions and action pins current.
  * Aligned Helm and cosign installation steps with newer pinned revisions for more consistent, reproducible builds.
  * Refreshed workflow comments and metadata to match the latest pinned versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->