### PR TITLE
chore: simplify listing by promotion strategy ref

### DIFF
--- a/docs/contributing/developing-a-commitstatus.md
+++ b/docs/contributing/developing-a-commitstatus.md
@@ -202,6 +202,107 @@ commitStatus.Spec.Phase = promoterv1alpha1.CommitPhaseFailure
 commitStatus.Spec.Description = fmt.Sprintf("Applications are degraded: %s", errorDetail)
 ```
 
+## Watching PromotionStrategy
+
+Gate CRDs reference a `PromotionStrategy` via `spec.promotionStrategyRef`. When that strategy changes (for example environments or commit-status keys are updated), every gate that references it should reconcile so it can refresh owned `CommitStatus` resources.
+
+Built-in controllers watch `PromotionStrategy` and enqueue reconcile requests for matching gates. Use a **cache field index** on `.spec.promotionStrategyRef.name` so those lookups stay efficient and so `client.MatchingFields` works on the manager's cached client.
+
+### When to register an index
+
+Register a field index when your controller (or another component using the same informer cache) lists gate resources with:
+
+```go
+client.MatchingFields{".spec.promotionStrategyRef.name": promotionStrategyName}
+```
+
+Without `IndexField` registration, that `List` fails at runtime. Listing the whole namespace and filtering in memory works but does not scale and is easy to miss in unit tests.
+
+This applies to **cache-backed** `client.Client` calls (the default from `mgr.GetClient()`). It is separate from CRD `selectableFields`, which affect API-server field selectors on direct API reads.
+
+### Register the index
+
+In this repository, gate kinds share `controller.PromotionStrategyRefField` and `controller.RegisterGatePromotionStrategyRefFieldIndexes` in [`internal/controller/fieldindex.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/fieldindex.go). Registration runs from any process that serves cache-backed lists filtered by promotion strategy:
+
+- **Manager** — `PromotionStrategyReconciler.SetupWithManager` (alongside the `CommitStatus` `.spec.sha` index).
+- **Dashboard API** — `internal/apiserver/run.go` on the read cache before bundle assembly.
+
+If you add a new in-repo gate kind, extend `PromotionStrategyRefIndexValues` and `RegisterGatePromotionStrategyRefFieldIndexes` with your type. See [Maintaining CRDs](maintaining-crds.md#5-field-index-for-commit-status-gate-kinds).
+
+For a controller outside this repo, register the index in your gate reconciler's `SetupWithManager`:
+
+```go
+const promotionStrategyRefField = ".spec.promotionStrategyRef.name"
+
+func (r *MyCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+    if err := mgr.GetFieldIndexer().IndexField(ctx, &promoterv1alpha1.MyCommitStatus{}, promotionStrategyRefField,
+        func(rawObj client.Object) []string {
+            cs := rawObj.(*promoterv1alpha1.MyCommitStatus)
+            return []string{cs.Spec.PromotionStrategyRef.Name}
+        },
+    ); err != nil {
+        return fmt.Errorf("failed to set field index %s: %w", promotionStrategyRefField, err)
+    }
+    // …
+}
+```
+
+### Watch handler
+
+Watch `PromotionStrategy` and list gates with `MatchingFields` instead of scanning the namespace:
+
+```go
+func (r *MyCommitStatusReconciler) enqueueMyCommitStatusForPromotionStrategy() handler.EventHandler {
+    return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+        ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
+        if !ok {
+            return nil
+        }
+
+        var list promoterv1alpha1.MyCommitStatusList
+        if err := r.List(ctx, &list,
+            client.InNamespace(ps.Namespace),
+            client.MatchingFields{promotionStrategyRefField: ps.Name},
+        ); err != nil {
+            log.FromContext(ctx).Error(err, "failed to list MyCommitStatus resources")
+            return nil
+        }
+
+        requests := make([]ctrl.Request, 0, len(list.Items))
+        for i := range list.Items {
+            requests = append(requests, ctrl.Request{
+                NamespacedName: client.ObjectKeyFromObject(&list.Items[i]),
+            })
+        }
+        return requests
+    })
+}
+```
+
+Wire the watch in `SetupWithManager`:
+
+```go
+ctrl.NewControllerManagedBy(mgr).
+    For(&promoterv1alpha1.MyCommitStatus{}).
+    Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueMyCommitStatusForPromotionStrategy()).
+    Complete(r)
+```
+
+Built-in gate controllers follow this pattern; see [`timedcommitstatus_controller.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/timedcommitstatus_controller.go) for a reference implementation.
+
+### Tests
+
+Fake clients used in tests must register the same index, or `MatchingFields` lists will fail:
+
+```go
+fake.NewClientBuilder().
+    WithScheme(scheme).
+    WithIndex(&promoterv1alpha1.MyCommitStatus{}, promotionStrategyRefField, indexFunc).
+    Build()
+```
+
+In-tree API server tests use `newFakeClientBuilder()` in [`internal/apiserver/builder_test.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/apiserver/builder_test.go), which registers indexes for all gate kinds.
+
 ## Triggering Reconciliation of ChangeTransferPolicies
 
 When your commit status controller detects important state transitions (e.g., a gate transitioning from pending to success), you may want to trigger immediate reconciliation of the affected ChangeTransferPolicy to minimize promotion latency.

--- a/docs/contributing/maintaining-crds.md
+++ b/docs/contributing/maintaining-crds.md
@@ -66,6 +66,17 @@ Follow an existing controller test as a template, for example [`promotionstrateg
 
 If the type is reconciled and has status SSA behavior, also follow [Maintaining resource status](updating-status.md) for field owners, `observedGeneration`, and status apply tests.
 
+### 5. Field index for commit-status gate kinds
+
+When the new kind is a **commit-status gate** CRD with `spec.promotionStrategyRef` (same shape as `ArgoCDCommitStatus`, `TimedCommitStatus`, and the other built-in gates):
+
+1. Add the type to [`internal/controller/fieldindex.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/fieldindex.go) — extend `PromotionStrategyRefIndexValues` and `RegisterGatePromotionStrategyRefFieldIndexes`.
+2. In the gate controller, watch `PromotionStrategy` and list your kind with `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` (do not namespace-list and filter in memory). See [Watching PromotionStrategy](developing-a-commitstatus.md#watching-promotionstrategy).
+3. If bundle assembly or other code lists the new gate by promotion strategy, ensure that cache also calls `RegisterGatePromotionStrategyRefFieldIndexes` (today: manager setup via `PromotionStrategyReconciler` and the dashboard read cache in `internal/apiserver/run.go`).
+4. Register the same index on fake clients in tests that use `MatchingFields` (follow `newFakeClientBuilder()` in [`internal/apiserver/builder_test.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/apiserver/builder_test.go)).
+
+Skip this step for types that do not reference a `PromotionStrategy` or never use field selectors on the cache client.
+
 ## Regenerate and verify
 
 After Go type and marker changes:

--- a/internal/apiserver/builder.go
+++ b/internal/apiserver/builder.go
@@ -28,6 +28,7 @@ import (
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	viewv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/view/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/controller"
 )
 
 // detailsUIDNamespace is a fixed UUID namespace used to derive deterministic UIDs
@@ -105,44 +106,28 @@ func buildBundle(ctx context.Context, reader client.Reader, namespace, name, res
 
 	// Commit-status managers reference the PS by spec.promotionStrategyRef.name.
 	argocdList := &promoterv1alpha1.ArgoCDCommitStatusList{}
-	if err := reader.List(ctx, argocdList, client.InNamespace(namespace)); err != nil {
+	if err := reader.List(ctx, argocdList, client.InNamespace(namespace), client.MatchingFields{controller.PromotionStrategyRefField: name}); err != nil {
 		return nil, fmt.Errorf("failed to list ArgoCDCommitStatuses: %w", err)
 	}
-	for i := range argocdList.Items {
-		if argocdList.Items[i].Spec.PromotionStrategyRef.Name == name {
-			bundle.ArgoCDCommitStatuses = append(bundle.ArgoCDCommitStatuses, argocdList.Items[i])
-		}
-	}
+	bundle.ArgoCDCommitStatuses = nilIfEmpty(argocdList.Items)
 
 	gitCSList := &promoterv1alpha1.GitCommitStatusList{}
-	if err := reader.List(ctx, gitCSList, client.InNamespace(namespace)); err != nil {
+	if err := reader.List(ctx, gitCSList, client.InNamespace(namespace), client.MatchingFields{controller.PromotionStrategyRefField: name}); err != nil {
 		return nil, fmt.Errorf("failed to list GitCommitStatuses: %w", err)
 	}
-	for i := range gitCSList.Items {
-		if gitCSList.Items[i].Spec.PromotionStrategyRef.Name == name {
-			bundle.GitCommitStatuses = append(bundle.GitCommitStatuses, gitCSList.Items[i])
-		}
-	}
+	bundle.GitCommitStatuses = nilIfEmpty(gitCSList.Items)
 
 	timedCSList := &promoterv1alpha1.TimedCommitStatusList{}
-	if err := reader.List(ctx, timedCSList, client.InNamespace(namespace)); err != nil {
+	if err := reader.List(ctx, timedCSList, client.InNamespace(namespace), client.MatchingFields{controller.PromotionStrategyRefField: name}); err != nil {
 		return nil, fmt.Errorf("failed to list TimedCommitStatuses: %w", err)
 	}
-	for i := range timedCSList.Items {
-		if timedCSList.Items[i].Spec.PromotionStrategyRef.Name == name {
-			bundle.TimedCommitStatuses = append(bundle.TimedCommitStatuses, timedCSList.Items[i])
-		}
-	}
+	bundle.TimedCommitStatuses = nilIfEmpty(timedCSList.Items)
 
 	webReqCSList := &promoterv1alpha1.WebRequestCommitStatusList{}
-	if err := reader.List(ctx, webReqCSList, client.InNamespace(namespace)); err != nil {
+	if err := reader.List(ctx, webReqCSList, client.InNamespace(namespace), client.MatchingFields{controller.PromotionStrategyRefField: name}); err != nil {
 		return nil, fmt.Errorf("failed to list WebRequestCommitStatuses: %w", err)
 	}
-	for i := range webReqCSList.Items {
-		if webReqCSList.Items[i].Spec.PromotionStrategyRef.Name == name {
-			bundle.WebRequestCommitStatuses = append(bundle.WebRequestCommitStatuses, webReqCSList.Items[i])
-		}
-	}
+	bundle.WebRequestCommitStatuses = nilIfEmpty(webReqCSList.Items)
 
 	// Git config: GitRepository -> ScmProvider / ClusterScmProvider.
 	// The credentials Secret referenced by the provider is intentionally never read.

--- a/internal/apiserver/builder_test.go
+++ b/internal/apiserver/builder_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/controller"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
@@ -50,9 +51,23 @@ func psLabeledMeta(name string) metav1.ObjectMeta {
 	return m
 }
 
+// newFakeClientBuilder returns a fake client builder with gate promotionStrategyRef field indexes.
+func newFakeClientBuilder() *fake.ClientBuilder {
+	b := fake.NewClientBuilder().WithScheme(utils.GetScheme())
+	for _, obj := range []client.Object{
+		&promoterv1alpha1.ArgoCDCommitStatus{},
+		&promoterv1alpha1.GitCommitStatus{},
+		&promoterv1alpha1.TimedCommitStatus{},
+		&promoterv1alpha1.WebRequestCommitStatus{},
+	} {
+		b = b.WithIndex(obj, controller.PromotionStrategyRefField, controller.PromotionStrategyRefIndexValues)
+	}
+	return b
+}
+
 // newFakeReader builds a fake controller-runtime read client over the promoter scheme.
 func newFakeReader(objs ...client.Object) client.Reader {
-	return fake.NewClientBuilder().WithScheme(utils.GetScheme()).WithObjects(objs...).Build()
+	return newFakeClientBuilder().WithObjects(objs...).Build()
 }
 
 // seedObjects returns a representative PromotionStrategy and all of its related

--- a/internal/apiserver/run.go
+++ b/internal/apiserver/run.go
@@ -25,6 +25,7 @@ import (
 	clientrest "k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
+	"github.com/argoproj-labs/gitops-promoter/internal/controller"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
@@ -42,6 +43,10 @@ func Run(ctx context.Context, restConfig *clientrest.Config, opts *Options) erro
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create read cache: %w", err)
+	}
+
+	if err := controller.RegisterGatePromotionStrategyRefFieldIndexes(ctx, readCache); err != nil {
+		return fmt.Errorf("failed to register gate field indexes: %w", err)
 	}
 
 	provider := NewBundleProvider(readCache)

--- a/internal/apiserver/watch_behavior_test.go
+++ b/internal/apiserver/watch_behavior_test.go
@@ -33,11 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	viewv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/view/v1alpha1"
-	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
 // mustDetailsList asserts the runtime.Object returned by List is the typed list.
@@ -184,7 +182,7 @@ var _ = Describe("Watch fan-out behavior", func() {
 		})
 
 		It("sends DELETED to a selector watcher when the object stops matching", func() {
-			cl := fake.NewClientBuilder().WithScheme(utils.GetScheme()).
+			cl := newFakeClientBuilder().
 				WithObjects(makePS("prod-ps", map[string]string{"env": "prod"})).
 				Build()
 			provider := newProviderWithReader(cl)

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -445,18 +445,18 @@ func enqueueArgoCDCommitStatusForPromotionStrategy(mcMgr mcmanager.Manager) mcha
 		}
 		logger := log.FromContext(ctx)
 		var list promoterv1alpha1.ArgoCDCommitStatusList
-		if err := mcMgr.GetLocalManager().GetClient().List(ctx, &list, client.InNamespace(ps.Namespace)); err != nil {
+		if err := mcMgr.GetLocalManager().GetClient().List(ctx, &list,
+			client.InNamespace(ps.Namespace),
+			client.MatchingFields{PromotionStrategyRefField: ps.Name},
+		); err != nil {
 			logger.Error(err, "failed to list ArgoCDCommitStatus resources for PromotionStrategy watch")
 			return nil
 		}
-		var reqs []mcreconcile.Request
+		reqs := make([]mcreconcile.Request, 0, len(list.Items))
 		for i := range list.Items {
-			acs := &list.Items[i]
-			if acs.Spec.PromotionStrategyRef.Name == ps.Name {
-				reqs = append(reqs, mcreconcile.Request{
-					Request: reconcile.Request{NamespacedName: client.ObjectKeyFromObject(acs)},
-				})
-			}
+			reqs = append(reqs, mcreconcile.Request{
+				Request: reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])},
+			})
 		}
 		return reqs
 	})

--- a/internal/controller/fieldindex.go
+++ b/internal/controller/fieldindex.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PromotionStrategyRefField is the cache field index path for gate CRDs that
+// reference a PromotionStrategy via spec.promotionStrategyRef.name.
+const PromotionStrategyRefField = ".spec.promotionStrategyRef.name"
+
+// PromotionStrategyRefIndexValues returns the PromotionStrategy name referenced
+// by a gate CRD for field-indexed list/watch queries.
+func PromotionStrategyRefIndexValues(rawObj client.Object) []string {
+	switch o := rawObj.(type) {
+	case *promoterv1alpha1.ArgoCDCommitStatus:
+		return []string{o.Spec.PromotionStrategyRef.Name}
+	case *promoterv1alpha1.GitCommitStatus:
+		return []string{o.Spec.PromotionStrategyRef.Name}
+	case *promoterv1alpha1.TimedCommitStatus:
+		return []string{o.Spec.PromotionStrategyRef.Name}
+	case *promoterv1alpha1.WebRequestCommitStatus:
+		return []string{o.Spec.PromotionStrategyRef.Name}
+	default:
+		return nil
+	}
+}
+
+// RegisterGatePromotionStrategyRefFieldIndexes registers PromotionStrategyRefField
+// on all commit-status gate CRD kinds.
+func RegisterGatePromotionStrategyRefFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error {
+	gateKinds := []client.Object{
+		&promoterv1alpha1.ArgoCDCommitStatus{},
+		&promoterv1alpha1.GitCommitStatus{},
+		&promoterv1alpha1.TimedCommitStatus{},
+		&promoterv1alpha1.WebRequestCommitStatus{},
+	}
+	for _, obj := range gateKinds {
+		if err := indexer.IndexField(ctx, obj, PromotionStrategyRefField, PromotionStrategyRefIndexValues); err != nil {
+			return fmt.Errorf("failed to set field index %s for %T: %w", PromotionStrategyRefField, obj, err)
+		}
+	}
+	return nil
+}

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -441,21 +441,20 @@ func (r *GitCommitStatusReconciler) enqueueGitCommitStatusForPromotionStrategy()
 			return nil
 		}
 
-		// List all GitCommitStatus resources in the same namespace
 		var gcsList promoterv1alpha1.GitCommitStatusList
-		if err := r.List(ctx, &gcsList, client.InNamespace(ps.Namespace)); err != nil {
+		if err := r.List(ctx, &gcsList,
+			client.InNamespace(ps.Namespace),
+			client.MatchingFields{PromotionStrategyRefField: ps.Name},
+		); err != nil {
 			log.FromContext(ctx).Error(err, "failed to list GitCommitStatus resources")
 			return nil
 		}
 
-		// Enqueue all GitCommitStatus resources that reference this PromotionStrategy
-		var requests []ctrl.Request
-		for _, gcs := range gcsList.Items {
-			if gcs.Spec.PromotionStrategyRef.Name == ps.Name {
-				requests = append(requests, ctrl.Request{
-					NamespacedName: client.ObjectKeyFromObject(&gcs),
-				})
-			}
+		requests := make([]ctrl.Request, 0, len(gcsList.Items))
+		for i := range gcsList.Items {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(&gcsList.Items[i]),
+			})
 		}
 
 		return requests

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -175,6 +175,10 @@ func (r *PromotionStrategyReconciler) SetupWithManager(ctx context.Context, mgr 
 		return fmt.Errorf("failed to set field index for .spec.sha: %w", err)
 	}
 
+	if err := RegisterGatePromotionStrategyRefFieldIndexes(ctx, mgr.GetFieldIndexer()); err != nil {
+		return err
+	}
+
 	// Use Direct methods to read configuration from the API server without cache during setup.
 	// The cache is not started during SetupWithManager, so we must use the non-cached API reader.
 	rateLimiter, err := settings.GetRateLimiterDirect[promoterv1alpha1.PromotionStrategyConfiguration, ctrl.Request](ctx, r.SettingsMgr)

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -359,21 +359,20 @@ func (r *TimedCommitStatusReconciler) enqueueTimedCommitStatusForPromotionStrate
 			return nil
 		}
 
-		// List all TimedCommitStatus resources in the same namespace
 		var tcsList promoterv1alpha1.TimedCommitStatusList
-		if err := r.List(ctx, &tcsList, client.InNamespace(ps.Namespace)); err != nil {
+		if err := r.List(ctx, &tcsList,
+			client.InNamespace(ps.Namespace),
+			client.MatchingFields{PromotionStrategyRefField: ps.Name},
+		); err != nil {
 			log.FromContext(ctx).Error(err, "failed to list TimedCommitStatus resources")
 			return nil
 		}
 
-		// Enqueue all TimedCommitStatus resources that reference this PromotionStrategy
-		var requests []ctrl.Request
-		for _, tcs := range tcsList.Items {
-			if tcs.Spec.PromotionStrategyRef.Name == ps.Name {
-				requests = append(requests, ctrl.Request{
-					NamespacedName: client.ObjectKeyFromObject(&tcs),
-				})
-			}
+		requests := make([]ctrl.Request, 0, len(tcsList.Items))
+		for i := range tcsList.Items {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(&tcsList.Items[i]),
+			})
 		}
 
 		return requests

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -528,21 +528,20 @@ func (r *WebRequestCommitStatusReconciler) enqueueWebRequestCommitStatusForPromo
 			return nil
 		}
 
-		// List all WebRequestCommitStatus resources in the same namespace
 		var wrcsList promoterv1alpha1.WebRequestCommitStatusList
-		if err := r.List(ctx, &wrcsList, client.InNamespace(ps.Namespace)); err != nil {
+		if err := r.List(ctx, &wrcsList,
+			client.InNamespace(ps.Namespace),
+			client.MatchingFields{PromotionStrategyRefField: ps.Name},
+		); err != nil {
 			log.FromContext(ctx).Error(err, "failed to list WebRequestCommitStatus resources")
 			return nil
 		}
 
-		// Enqueue all WebRequestCommitStatus resources that reference this PromotionStrategy
-		var requests []ctrl.Request
-		for _, wrcs := range wrcsList.Items {
-			if wrcs.Spec.PromotionStrategyRef.Name == ps.Name {
-				requests = append(requests, ctrl.Request{
-					NamespacedName: client.ObjectKeyFromObject(&wrcs),
-				})
-			}
+		requests := make([]ctrl.Request, 0, len(wrcsList.Items))
+		for i := range wrcsList.Items {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(&wrcsList.Items[i]),
+			})
 		}
 
 		return requests


### PR DESCRIPTION
Use field indexes instead of loops for simplicity and speed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how commit-status updates react to promotion strategy changes, making matching resources reconcile more reliably and efficiently.
  * Added support for safer, faster lookups instead of scanning all resources in a namespace.

* **Documentation**
  * Expanded contributor guidance for working with commit-status resources and CRDs.
  * Added examples and testing notes for field-based matching and cache-backed indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->