### PR TITLE
test(apiserver): refactor Run for testability and add coverage

### DIFF
--- a/internal/apiserver/run.go
+++ b/internal/apiserver/run.go
@@ -22,63 +22,77 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	clientrest "k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
-// Run wires up the read-only controller-runtime cache, the BundleProvider (watch
-// fan-out + debounced rebuilds), and the generic extension apiserver, then serves
-// until ctx is cancelled.
-func Run(ctx context.Context, restConfig *clientrest.Config, opts *Options) error {
-	if err := opts.Validate(); err != nil {
-		return err
-	}
+// dashboardRuntime holds the components started by Run.
+type dashboardRuntime struct {
+	readCache cache.Cache
+	provider  *BundleProvider
+	server    *PromoterAPIServer
+}
 
+// newDashboardRuntime wires the read cache, bundle provider, and extension apiserver.
+// authorizer, when non-nil, overrides delegated authorization (used by tests).
+func newDashboardRuntime(ctx context.Context, restConfig *clientrest.Config, opts *Options, authorizer authorizer.Authorizer) (*dashboardRuntime, error) {
 	readCache, err := cache.New(restConfig, cache.Options{
 		Scheme:           utils.GetScheme(),
 		DefaultTransform: cacheTransform(),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create read cache: %w", err)
+		return nil, fmt.Errorf("failed to create read cache: %w", err)
 	}
 
 	provider := NewBundleProvider(readCache)
 	if err := provider.SetupInformers(ctx); err != nil {
-		return fmt.Errorf("failed to set up informers: %w", err)
+		return nil, fmt.Errorf("failed to set up informers: %w", err)
 	}
 
 	config, err := opts.Config(provider)
 	if err != nil {
-		return fmt.Errorf("failed to build apiserver config: %w", err)
+		return nil, fmt.Errorf("failed to build apiserver config: %w", err)
+	}
+	if authorizer != nil {
+		config.GenericConfig.Authorization.Authorizer = authorizer
 	}
 
 	server, err := config.Complete().New()
 	if err != nil {
-		return fmt.Errorf("failed to create apiserver: %w", err)
+		return nil, fmt.Errorf("failed to create apiserver: %w", err)
 	}
 
+	return &dashboardRuntime{
+		readCache: readCache,
+		provider:  provider,
+		server:    server,
+	}, nil
+}
+
+func (d *dashboardRuntime) run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		if err := readCache.Start(ctx); err != nil {
+		if err := d.readCache.Start(ctx); err != nil {
 			return fmt.Errorf("read cache stopped: %w", err)
 		}
 		return nil
 	})
 
-	if !readCache.WaitForCacheSync(ctx) {
+	if !d.readCache.WaitForCacheSync(ctx) {
 		return errors.New("failed to sync read cache")
 	}
 
 	g.Go(func() error {
-		provider.Run(ctx)
+		d.provider.Run(ctx)
 		return nil
 	})
 
 	g.Go(func() error {
-		if err := server.GenericAPIServer.PrepareRun().RunWithContext(ctx); err != nil {
+		if err := d.server.GenericAPIServer.PrepareRun().RunWithContext(ctx); err != nil {
 			return fmt.Errorf("apiserver stopped: %w", err)
 		}
 		return nil
@@ -88,4 +102,19 @@ func Run(ctx context.Context, restConfig *clientrest.Config, opts *Options) erro
 		return fmt.Errorf("apiserver run group exited: %w", err)
 	}
 	return nil
+}
+
+// Run wires up the read-only controller-runtime cache, the BundleProvider (watch
+// fan-out + debounced rebuilds), and the generic extension apiserver, then serves
+// until ctx is cancelled.
+func Run(ctx context.Context, restConfig *clientrest.Config, opts *Options) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	runtime, err := newDashboardRuntime(ctx, restConfig, opts, nil)
+	if err != nil {
+		return err
+	}
+	return runtime.run(ctx)
 }

--- a/internal/apiserver/run.go
+++ b/internal/apiserver/run.go
@@ -37,8 +37,8 @@ type dashboardRuntime struct {
 }
 
 // newDashboardRuntime wires the read cache, bundle provider, and extension apiserver.
-// authorizer, when non-nil, overrides delegated authorization (used by tests).
-func newDashboardRuntime(ctx context.Context, restConfig *clientrest.Config, opts *Options, authorizer authorizer.Authorizer) (*dashboardRuntime, error) {
+// authz, when non-nil, overrides delegated authorization (used by tests).
+func newDashboardRuntime(ctx context.Context, restConfig *clientrest.Config, opts *Options, authz authorizer.Authorizer) (*dashboardRuntime, error) {
 	readCache, err := cache.New(restConfig, cache.Options{
 		Scheme:           utils.GetScheme(),
 		DefaultTransform: cacheTransform(),
@@ -56,8 +56,8 @@ func newDashboardRuntime(ctx context.Context, restConfig *clientrest.Config, opt
 	if err != nil {
 		return nil, fmt.Errorf("failed to build apiserver config: %w", err)
 	}
-	if authorizer != nil {
-		config.GenericConfig.Authorization.Authorizer = authorizer
+	if authz != nil {
+		config.GenericConfig.Authorization.Authorizer = authz
 	}
 
 	server, err := config.Complete().New()
@@ -72,6 +72,7 @@ func newDashboardRuntime(ctx context.Context, restConfig *clientrest.Config, opt
 	}, nil
 }
 
+// run starts the read cache, bundle provider workqueue, and extension apiserver until ctx is cancelled.
 func (d *dashboardRuntime) run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -83,6 +84,7 @@ func (d *dashboardRuntime) run(ctx context.Context) error {
 	})
 
 	if !d.readCache.WaitForCacheSync(ctx) {
+		_ = g.Wait()
 		return errors.New("failed to sync read cache")
 	}
 

--- a/internal/apiserver/run_test.go
+++ b/internal/apiserver/run_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/client-go/dynamic"
+	clientrest "k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
+)
+
+func integrationAPIServerOptions() *Options {
+	opts := NewOptions()
+	opts.RecommendedOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
+	opts.RecommendedOptions.SecureServing.BindPort = freeLocalPort()
+	opts.RecommendedOptions.SecureServing.ServerCert.CertDirectory = GinkgoT().TempDir()
+	opts.RecommendedOptions.Authentication.SkipInClusterLookup = true
+	opts.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
+	opts.RecommendedOptions.Authorization.RemoteKubeConfigFileOptional = true
+	return opts
+}
+
+func startRunEnvtest() (*envtest.Environment, *clientrest.Config, client.Client) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		Skip("KUBEBUILDER_ASSETS is not set; run via make test or make test-parallel")
+	}
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "test", "external_crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := env.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	cl, err := client.New(cfg, client.Options{Scheme: utils.GetScheme()})
+	Expect(err).NotTo(HaveOccurred())
+
+	return env, cfg, cl
+}
+
+func stopRunEnvtest(env *envtest.Environment) {
+	if env != nil {
+		Expect(env.Stop()).To(Succeed())
+	}
+}
+
+var _ = Describe("Run", func() {
+	It("returns a validation error for invalid options", func() {
+		opts := NewOptions()
+		opts.RecommendedOptions.SecureServing.BindPort = -1
+
+		err := Run(context.Background(), &clientrest.Config{}, opts)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid apiserver options"))
+	})
+
+	It("returns an error when the context is cancelled before the read cache syncs", func() {
+		env, cfg, _ := startRunEnvtest()
+		defer stopRunEnvtest(env)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := Run(ctx, cfg, integrationAPIServerOptions())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("failed to sync read cache"))
+	})
+})
+
+var _ = Describe("Run integration (envtest + in-process server)", func() {
+	var (
+		env *envtest.Environment
+		cfg *clientrest.Config
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		env, cfg, cl = startRunEnvtest()
+		Expect(cl.Create(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+		})).To(Succeed())
+	})
+
+	AfterEach(func() {
+		stopRunEnvtest(env)
+		env = nil
+	})
+
+	It("serves promotionstrategydetails from the envtest-backed read cache", func() {
+		ps := &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: testPSName, Namespace: testNamespace},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "my-repo"},
+				Environments:        []promoterv1alpha1.Environment{{Branch: "environment/dev"}},
+			},
+		}
+		Expect(cl.Create(context.Background(), ps)).To(Succeed())
+
+		opts := integrationAPIServerOptions()
+		runtime, err := newDashboardRuntime(
+			context.Background(),
+			cfg,
+			opts,
+			authorizerfactory.NewAlwaysAllowAuthorizer(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runtime.server.GenericAPIServer.LoopbackClientConfig).NotTo(BeNil())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			errCh <- runtime.run(ctx)
+		}()
+
+		dyn, err := dynamic.NewForConfig(runtime.server.GenericAPIServer.LoopbackClientConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			list, listErr := dyn.Resource(promotionStrategyDetailsGVR).Namespace(testNamespace).
+				List(context.Background(), metav1.ListOptions{})
+			if listErr != nil {
+				return fmt.Errorf("list promotionstrategydetails: %w", listErr)
+			}
+			if len(list.Items) != 1 {
+				return fmt.Errorf("expected 1 bundle, got %d", len(list.Items))
+			}
+			if list.Items[0].GetName() != testPSName {
+				return fmt.Errorf("expected bundle %q, got %q", testPSName, list.Items[0].GetName())
+			}
+			return nil
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+
+		cancel()
+		Eventually(errCh, 30*time.Second, 100*time.Millisecond).Should(Receive(Succeed()))
+	})
+
+	It("exits promptly when the context is cancelled with an active watch", func() {
+		ps := &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: testPSName, Namespace: testNamespace},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "my-repo"},
+				Environments:        []promoterv1alpha1.Environment{{Branch: "environment/dev"}},
+			},
+		}
+		Expect(cl.Create(context.Background(), ps)).To(Succeed())
+
+		runtime, err := newDashboardRuntime(
+			context.Background(),
+			cfg,
+			integrationAPIServerOptions(),
+			authorizerfactory.NewAlwaysAllowAuthorizer(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			errCh <- runtime.run(ctx)
+		}()
+
+		dyn, err := dynamic.NewForConfig(runtime.server.GenericAPIServer.LoopbackClientConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			_, listErr := dyn.Resource(promotionStrategyDetailsGVR).Namespace(testNamespace).
+				List(context.Background(), metav1.ListOptions{})
+			return listErr
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+
+		w, err := dyn.Resource(promotionStrategyDetailsGVR).Namespace(testNamespace).
+			Watch(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer w.Stop()
+		Eventually(w.ResultChan()).Should(Receive())
+
+		start := time.Now()
+		cancel()
+		Eventually(errCh, 30*time.Second, 100*time.Millisecond).Should(Receive(Succeed()))
+		Expect(time.Since(start)).To(BeNumerically("<", 20*time.Second))
+	})
+})

--- a/internal/apiserver/run_test.go
+++ b/internal/apiserver/run_test.go
@@ -40,8 +40,9 @@ import (
 
 func integrationAPIServerOptions() *Options {
 	opts := NewOptions()
-	opts.RecommendedOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
-	opts.RecommendedOptions.SecureServing.BindPort = freeLocalPort()
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+	opts.RecommendedOptions.SecureServing.Listener = listener
 	opts.RecommendedOptions.SecureServing.ServerCert.CertDirectory = GinkgoT().TempDir()
 	opts.RecommendedOptions.Authentication.SkipInClusterLookup = true
 	opts.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
@@ -141,6 +142,7 @@ var _ = Describe("Run integration (envtest + in-process server)", func() {
 		Expect(runtime.server.GenericAPIServer.LoopbackClientConfig).NotTo(BeNil())
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		errCh := make(chan error, 1)
 		go func() {
 			defer GinkgoRecover()
@@ -188,6 +190,7 @@ var _ = Describe("Run integration (envtest + in-process server)", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		errCh := make(chan error, 1)
 		go func() {
 			defer GinkgoRecover()
@@ -200,7 +203,10 @@ var _ = Describe("Run integration (envtest + in-process server)", func() {
 		Eventually(func() error {
 			_, listErr := dyn.Resource(promotionStrategyDetailsGVR).Namespace(testNamespace).
 				List(context.Background(), metav1.ListOptions{})
-			return listErr
+			if listErr != nil {
+				return fmt.Errorf("list promotionstrategydetails: %w", listErr)
+			}
+			return nil
 		}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
 
 		w, err := dyn.Resource(promotionStrategyDetailsGVR).Namespace(testNamespace).

--- a/internal/apiserver/suite_test.go
+++ b/internal/apiserver/suite_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 // TestAPIServer runs the dashboard aggregation apiserver unit specs with the
-// Ginkgo runner. These specs use a fake controller-runtime client and do not
-// require envtest.
+// Ginkgo runner. Most specs use a fake controller-runtime client; Run integration
+// specs use envtest when KUBEBUILDER_ASSETS is set (make test / make test-parallel).
 func TestAPIServer(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Extract dashboardRuntime setup and run loop so Run can be exercised in unit and envtest integration tests without duplicating server wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API server startup reliability by better coordinating read-cache sync and server readiness.
  * Ensured clearer failure behavior when cache synchronization can’t complete (including proper handling when the context is cancelled).

* **Tests**
  * Added integration coverage for server validation, read-cache sync error handling, and end-to-end serving behavior using an in-process test environment.
  * Verified prompt shutdown behavior during active watch activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->