### PR TITLE
chore(ci): automatically run go fix on go upgrades

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -61,5 +61,5 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make lint-fix","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^pip-compile"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make go-fix","^make lint-fix","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^pip-compile"]'
           RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS: 'true'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -61,5 +61,5 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make go-fix","^make lint-fix","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^pip-compile"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'
           RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS: 'true'

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ apiserver-certs: ## Generate self-signed serving certs for the dashboard apiserv
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: go-fix
+go-fix: ## Apply stdlib go fix modernizations (e.g. after a Go version bump).
+	go fix ./...
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...

--- a/RENOVATE_SETUP.md
+++ b/RENOVATE_SETUP.md
@@ -21,7 +21,7 @@ Renovate has been configured to:
 ## Why Self-Hosted Renovate?
 
 We use self-hosted Renovate (via GitHub Workflows) instead of the hosted GitHub App because:
-- **Post-upgrade tasks are only supported in self-hosted mode** - We need to run `go mod tidy` and `make lint-fix` automatically
+- **Post-upgrade tasks are only supported in self-hosted mode** - We need to run `go mod tidy`, `make go-fix`, and `make lint-fix` automatically
 - Full control over when and how Renovate runs
 - No external dependencies on Renovate's hosted infrastructure
 
@@ -108,9 +108,10 @@ When Renovate creates a PR for Go or golangci-lint updates, it will:
 
 1. Update all version references across the repository
 2. Run `go mod tidy` to update dependencies
-3. Run `make lint-fix` to automatically fix linting issues
+3. Run `make go-fix` to apply stdlib fixers for the new toolchain (e.g. `interface{}` → `any`, iterator helpers)
+4. Run `make lint-fix` to automatically fix linting issues
 
-The `lint-fix` command is run with `|| true` to allow the PR to be created even if there are linting errors that can't be auto-fixed.
+`go-fix` and `lint-fix` are run with `|| true` so the PR is still created if a fixer fails or leaves issues that need manual review.
 
 **Note**: Post-upgrade tasks only work with self-hosted Renovate. The hosted GitHub App does not support this feature.
 
@@ -152,7 +153,7 @@ Key configuration options:
 - **Labels**: PRs are labeled with `dependencies`
 - **Concurrent Limit**: Maximum of 3 PRs at once
 - **Automerge**: Disabled (requires manual review)
-- **Post-upgrade tasks**: Runs `go mod tidy` and `make lint-fix`
+- **Post-upgrade tasks**: Runs `go mod tidy`, `make go-fix`, and `make lint-fix`
   - These only work because we're using self-hosted Renovate
   - Commands must be whitelisted in the workflow
 
@@ -234,6 +235,7 @@ To test the workflow without making real changes:
 
 The workflow only allows specific commands in `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS`:
 - `go mod tidy` - Safe, only updates dependency checksums
+- `make go-fix` - Runs `go fix ./...` (stdlib modernizations for the new Go version)
 - `make lint-fix` - Runs golangci-lint with auto-fix
 
 If you need to add more commands, update both:

--- a/renovate.json5
+++ b/renovate.json5
@@ -156,6 +156,9 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          // go fix applies stdlib fixers for the new toolchain (any, min/max, iterators, …).
+          // Run before lint-fix so golangci-lint can clean up anything fix leaves behind.
+          'make go-fix || true',
           'make lint-fix || true',
         ],
         installTools: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated Go code-fix step to Renovate’s upgrade workflow.
  * Introduced a new `go-fix` Makefile command for applying standard Go fixes.

* **Documentation**
  * Updated Renovate setup guidance to include the new Go fix step in upgrade instructions and allowed commands.

* **Chores**
  * Adjusted Renovate’s post-upgrade command list to use the new Go fix flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->