### PR TITLE
chore(deps): automate cosign CLI bumps via Renovate

### DIFF
--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v3.0.5 # cosign CLI; latest sigstore/cosign, explicit pin for reproducibility
+          cosign-release: v3.0.5
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v3.0.5 # cosign CLI; latest sigstore/cosign, explicit pin for reproducibility
+          cosign-release: v3.0.5
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610

--- a/renovate.json5
+++ b/renovate.json5
@@ -170,6 +170,20 @@
       },
     },
     // ----------------------------------------------------------------------
+    // Group C2: cosign CLI (release workflows; action SHA is Dependabot-owned)
+    // ----------------------------------------------------------------------
+    {
+      description: 'Keep cosign CLI in sync across release workflows',
+      matchDepNames: [
+        'sigstore/cosign',
+      ],
+      groupName: 'cosign',
+      semanticCommits: 'enabled',
+      semanticCommitType: 'chore',
+      semanticCommitScope: 'deps',
+      automerge: false,
+    },
+    // ----------------------------------------------------------------------
     // Group C: goreleaser (Makefile + both release workflows in one PR)
     // ----------------------------------------------------------------------
     {
@@ -525,6 +539,22 @@
         'GORELEASER_VERSION\\s*\\??=\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)',
       ],
       depNameTemplate: 'goreleaser/goreleaser',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver',
+      extractVersionTemplate: '^v(?<version>.*)$',
+    },
+    // ===== cosign CLI (release workflows; installer action SHA is Dependabot-owned) =====
+    {
+      customType: 'regex',
+      description: 'Update cosign CLI version pinned in release workflows',
+      managerFilePatterns: [
+        '/^\\.github/workflows/release\\.yaml$/',
+        '/^\\.github/workflows/release-latest\\.yaml$/',
+      ],
+      matchStrings: [
+        'cosign-release:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)',
+      ],
+      depNameTemplate: 'sigstore/cosign',
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'semver',
       extractVersionTemplate: '^v(?<version>.*)$',


### PR DESCRIPTION
## Summary
- Add a Renovate regex manager for `cosign-release` in both release workflows
- Group cosign CLI updates so `release.yaml` and `release-latest.yaml` stay in sync
- Dependabot continues to own the `sigstore/cosign-installer` action SHA

## Test plan
- [ ] Verify Renovate config validates
- [ ] Confirm release workflows still parse correctly

Made with [Cursor](https://cursor.com)