### PR TITLE
chore(deps): refresh e2e Kind matrix and automate kindest/node bumps

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -23,7 +23,7 @@ jobs:
           - 1.34.8
           - 1.35.5
           - 1.36.1
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.kubernetes-minor-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,3 +45,17 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run E2E-Tests
         run: make test-e2e
+  e2e:
+    # Stable status check for branch protection; matrix jobs above may change names when
+    # kindest/node versions bump, but this job name stays constant.
+    name: E2E Tests
+    needs: ci
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All matrix jobs passed
+        run: |
+          if [[ "${{ needs.ci.result }}" != "success" ]]; then
+            echo "One or more E2E matrix jobs failed or were cancelled."
+            exit 1
+          fi

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -20,8 +20,8 @@ jobs:
         # kindest/node entries; when the newest minor advances, add the new version
         # and drop the oldest so the matrix stays at three consecutive minors.
         kubernetes-minor-version:
-          - 1.34.0
-          - 1.35.0
+          - 1.34.8
+          - 1.35.5
           - 1.36.1
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -16,10 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Three-minor sliding window for Kind e2e coverage. Renovate bumps individual
+        # kindest/node entries; when the newest minor advances, add the new version
+        # and drop the oldest so the matrix stays at three consecutive minors.
         kubernetes-minor-version:
-          - 1.29.0
-          - 1.30.0
-          - 1.31.0
+          - 1.34.0
+          - 1.35.0
+          - 1.36.1
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/renovate.json5
+++ b/renovate.json5
@@ -133,6 +133,20 @@
       ],
     },
     // ----------------------------------------------------------------------
+    // Group A3: E2E Kind node images (ci-e2e matrix; sliding window of minors)
+    // ----------------------------------------------------------------------
+    {
+      description: 'Group kindest/node bumps in the e2e Kind matrix',
+      matchDepNames: [
+        'kindest/node',
+      ],
+      groupName: 'E2E Kind Kubernetes matrix',
+      semanticCommits: 'enabled',
+      semanticCommitType: 'chore',
+      semanticCommitScope: 'deps',
+      automerge: false,
+    },
+    // ----------------------------------------------------------------------
     // Group B: Go toolchain + golangci-lint (+ golang base image)
     // ----------------------------------------------------------------------
     {
@@ -458,6 +472,20 @@
       datasourceTemplate: 'custom.envtest-k8s',
       versioningTemplate: 'semver',
       extractVersionTemplate: '^v(?<version>.*)$',
+    },
+    {
+      customType: 'regex',
+      description: 'Update kindest/node versions in the e2e Kind matrix',
+      managerFilePatterns: [
+        '/^\\.github/workflows/ci-e2e\\.yaml$/',
+      ],
+      matchStrings: [
+        '- (?<currentValue>1\\.\\d+\\.\\d+)\\s*$',
+      ],
+      depNameTemplate: 'kindest/node',
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'docker',
+      extractVersionTemplate: '^v?(?<version>.*)$',
     },
     // ===== Makefile tool versions =====
     {


### PR DESCRIPTION
## Summary
- Advance the ci-e2e Kind matrix from 1.29–1.31 to 1.34.0 / 1.35.0 / 1.36.1
- Add a Renovate regex manager and group rule for `kindest/node` matrix entries
- Document the three-minor sliding window maintenance expectation

## Test plan
- [ ] Run `make test-e2e` locally against a Kind cluster if possible
- [ ] Verify ci-e2e workflow passes on PR
- [ ] Verify Renovate config validates

Made with [Cursor](https://cursor.com)