### PR TITLE
fix: reduce PR/CTP reconciles

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1241,11 +1241,6 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		prState = existingPR.Spec.State
 	}
 
-	if prExists && pullRequestManagedByCTPUnchanged(existingPR, title, description, commitMessage, ctp, prState) {
-		logger.V(4).Info("Pull request spec unchanged, skipping apply", "pullRequest", prName)
-		return existingPR, nil
-	}
-
 	// Build the apply configuration
 	prApply := acv1alpha1.PullRequest(prName, ctp.Namespace).
 		WithLabels(map[string]string{
@@ -1533,39 +1528,6 @@ func pullRequestUpdateEnqueuesChangeTransferPolicyPredicate() predicate.Predicat
 			return false
 		},
 	}
-}
-
-// pullRequestManagedByCTPUnchanged reports whether the PullRequest already matches the spec fields
-// createOrUpdatePullRequest would apply, so a Server-Side Apply patch can be skipped.
-func pullRequestManagedByCTPUnchanged(
-	existing *promoterv1alpha1.PullRequest,
-	title, description, commitMessage string,
-	ctp *promoterv1alpha1.ChangeTransferPolicy,
-	prState promoterv1alpha1.PullRequestState,
-) bool {
-	if existing.Spec.RepositoryReference.Name != ctp.Spec.RepositoryReference.Name ||
-		existing.Spec.Title != title ||
-		existing.Spec.Description != description ||
-		existing.Spec.TargetBranch != ctp.Spec.ActiveBranch ||
-		existing.Spec.SourceBranch != ctp.Spec.ProposedBranch ||
-		existing.Spec.MergeSha != ctp.Status.Proposed.Hydrated.Sha ||
-		existing.Spec.State != prState ||
-		existing.Spec.Commit.Message != commitMessage {
-		return false
-	}
-
-	expectedLabels := map[string]string{
-		promoterv1alpha1.PromotionStrategyLabel:    utils.KubeSafeLabel(ctp.Labels[promoterv1alpha1.PromotionStrategyLabel]),
-		promoterv1alpha1.ChangeTransferPolicyLabel: utils.KubeSafeLabel(ctp.Name),
-		promoterv1alpha1.EnvironmentLabel:          utils.KubeSafeLabel(ctp.Spec.ActiveBranch),
-	}
-	for key, want := range expectedLabels {
-		if existing.Labels[key] != want {
-			return false
-		}
-	}
-
-	return controllerutil.ContainsFinalizer(existing, promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer)
 }
 
 // boolPtrEqual compares two *bool pointers for equality.

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1486,7 +1486,7 @@ func TemplatePullRequest(prt promoterv1alpha1.PullRequestTemplate, data map[stri
 // Enqueues CTP on:
 //   - Create and Delete of the owned PullRequest
 //   - Update when metadata.generation changes (spec was patched — title, commit.message, state, etc.)
-//   - Update when finalizer count changes (CTP pull-request finalizer added or removed)
+//   - Update when the CTP pull-request finalizer is added or removed
 //   - Update when status.state changes (open, merged, closed, or cleared on external close)
 //   - Update when status.externallyMergedOrClosed changes
 //   - Update when status.id is first set ("" → non-empty; PR now exists on the SCM)
@@ -1513,7 +1513,9 @@ func pullRequestUpdateEnqueuesChangeTransferPolicyPredicate() predicate.Predicat
 			if oldPR.Generation != newPR.Generation {
 				return true
 			}
-			if len(oldPR.Finalizers) != len(newPR.Finalizers) {
+			oldHasCTPFinalizer := controllerutil.ContainsFinalizer(oldPR, promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer)
+			newHasCTPFinalizer := controllerutil.ContainsFinalizer(newPR, promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer)
+			if oldHasCTPFinalizer != newHasCTPFinalizer {
 				return true
 			}
 			if oldPR.Status.State != newPR.Status.State {

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -528,7 +528,7 @@ func (r *ChangeTransferPolicyReconciler) SetupWithManager(ctx context.Context, m
 		// This controller intentionally doesn't have a .Owns for CommitStatuses. Every reconcile of a CommitStatus
 		// checks whether it needs to update a related ChangeTransferPolicy by setting an annotation. Avoiding .Owns
 		// here avoids duplicate reconciliations.
-		Owns(&promoterv1alpha1.PullRequest{}).
+		Owns(&promoterv1alpha1.PullRequest{}, builder.WithPredicates(pullRequestUpdateEnqueuesChangeTransferPolicyPredicate())).
 		// Watch for external enqueue requests from other controllers (e.g., PromotionStrategy).
 		// The handler.EnqueueRequestForObject extracts the namespace/name from the GenericEvent.
 		WatchesRawSource(source.Channel(externalEnqueueChan, &handler.EnqueueRequestForObject{})).
@@ -1241,6 +1241,11 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		prState = existingPR.Spec.State
 	}
 
+	if prExists && pullRequestManagedByCTPUnchanged(existingPR, title, description, commitMessage, ctp, prState) {
+		logger.V(4).Info("Pull request spec unchanged, skipping apply", "pullRequest", prName)
+		return existingPR, nil
+	}
+
 	// Build the apply configuration
 	prApply := acv1alpha1.PullRequest(prName, ctp.Namespace).
 		WithLabels(map[string]string{
@@ -1477,6 +1482,75 @@ func TemplatePullRequest(prt promoterv1alpha1.PullRequestTemplate, data map[stri
 	}
 
 	return title, description, nil
+}
+
+// pullRequestUpdateEnqueuesChangeTransferPolicyPredicate limits CTP reconciles triggered by owned
+// PullRequests to spec changes and meaningful status transitions. Routine PR status writes (URL,
+// Ready, etc.) after SCM sync should not re-enqueue the CTP and drive a CTP→PR→CTP feedback loop.
+func pullRequestUpdateEnqueuesChangeTransferPolicyPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		DeleteFunc: func(event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPR, ok := e.ObjectOld.(*promoterv1alpha1.PullRequest)
+			if !ok || oldPR == nil {
+				return false
+			}
+			newPR, ok := e.ObjectNew.(*promoterv1alpha1.PullRequest)
+			if !ok || newPR == nil {
+				return false
+			}
+			if oldPR.Generation != newPR.Generation {
+				return true
+			}
+			if len(oldPR.Finalizers) != len(newPR.Finalizers) {
+				return true
+			}
+			if oldPR.Status.State != newPR.Status.State {
+				return true
+			}
+			if !boolPtrEqual(oldPR.Status.ExternallyMergedOrClosed, newPR.Status.ExternallyMergedOrClosed) {
+				return true
+			}
+			if oldPR.Status.ID == "" && newPR.Status.ID != "" {
+				return true
+			}
+			return false
+		},
+	}
+}
+
+// pullRequestManagedByCTPUnchanged reports whether the PullRequest already matches the spec fields
+// createOrUpdatePullRequest would apply, so a Server-Side Apply patch can be skipped.
+func pullRequestManagedByCTPUnchanged(
+	existing *promoterv1alpha1.PullRequest,
+	title, description, commitMessage string,
+	ctp *promoterv1alpha1.ChangeTransferPolicy,
+	prState promoterv1alpha1.PullRequestState,
+) bool {
+	if existing.Spec.RepositoryReference.Name != ctp.Spec.RepositoryReference.Name ||
+		existing.Spec.Title != title ||
+		existing.Spec.Description != description ||
+		existing.Spec.TargetBranch != ctp.Spec.ActiveBranch ||
+		existing.Spec.SourceBranch != ctp.Spec.ProposedBranch ||
+		existing.Spec.MergeSha != ctp.Status.Proposed.Hydrated.Sha ||
+		existing.Spec.State != prState ||
+		existing.Spec.Commit.Message != commitMessage {
+		return false
+	}
+
+	expectedLabels := map[string]string{
+		promoterv1alpha1.PromotionStrategyLabel:    utils.KubeSafeLabel(ctp.Labels[promoterv1alpha1.PromotionStrategyLabel]),
+		promoterv1alpha1.ChangeTransferPolicyLabel: utils.KubeSafeLabel(ctp.Name),
+		promoterv1alpha1.EnvironmentLabel:          utils.KubeSafeLabel(ctp.Spec.ActiveBranch),
+	}
+	for key, want := range expectedLabels {
+		if existing.Labels[key] != want {
+			return false
+		}
+	}
+
+	return controllerutil.ContainsFinalizer(existing, promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer)
 }
 
 // boolPtrEqual compares two *bool pointers for equality.

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1485,8 +1485,23 @@ func TemplatePullRequest(prt promoterv1alpha1.PullRequestTemplate, data map[stri
 }
 
 // pullRequestUpdateEnqueuesChangeTransferPolicyPredicate limits CTP reconciles triggered by owned
-// PullRequests to spec changes and meaningful status transitions. Routine PR status writes (URL,
-// Ready, etc.) after SCM sync should not re-enqueue the CTP and drive a CTP→PR→CTP feedback loop.
+// PullRequests. Without it, bare Owns(PullRequest) re-enqueues CTP on every PR status write and can
+// drive a CTP→PR→CTP feedback loop (PR SCM sync → status churn → CTP SSA → PR generation bump → repeat).
+//
+// Enqueues CTP on:
+//   - Create and Delete of the owned PullRequest
+//   - Update when metadata.generation changes (spec was patched — title, commit.message, state, etc.)
+//   - Update when finalizer count changes (CTP pull-request finalizer added or removed)
+//   - Update when status.state changes (open, merged, closed, or cleared on external close)
+//   - Update when status.externallyMergedOrClosed changes
+//   - Update when status.id is first set ("" → non-empty; PR now exists on the SCM)
+//
+// Does not enqueue CTP on status-only updates, including:
+//   - status.url (stable or changed)
+//   - status.prCreationTime (e.g. fake FindOpen returns time.Now() each sync)
+//   - status.conditions (Ready message, reason, lastTransitionTime)
+//   - status.observedGeneration
+//   - status.id changes after the ID is already populated
 func pullRequestUpdateEnqueuesChangeTransferPolicyPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(event.CreateEvent) bool { return true },

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1318,69 +1318,6 @@ var _ = Describe("TemplatePullRequest", func() {
 	})
 })
 
-var _ = Describe("pullRequestManagedByCTPUnchanged", func() {
-	var (
-		ctp      *promoterv1alpha1.ChangeTransferPolicy
-		existing *promoterv1alpha1.PullRequest
-	)
-
-	BeforeEach(func() {
-		ctp = &promoterv1alpha1.ChangeTransferPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ctp-prod",
-				Labels: map[string]string{
-					promoterv1alpha1.PromotionStrategyLabel: "my-ps",
-				},
-			},
-			Spec: promoterv1alpha1.ChangeTransferPolicySpec{
-				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "repo"},
-				ProposedBranch:      "environment/staging-next",
-				ActiveBranch:        "environment/staging",
-			},
-			Status: promoterv1alpha1.ChangeTransferPolicyStatus{
-				Proposed: promoterv1alpha1.CommitBranchState{
-					Hydrated: promoterv1alpha1.CommitShaState{Sha: "hydrated-sha"},
-				},
-			},
-		}
-		existing = &promoterv1alpha1.PullRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pr-1",
-				Labels: map[string]string{
-					promoterv1alpha1.PromotionStrategyLabel:    utils.KubeSafeLabel("my-ps"),
-					promoterv1alpha1.ChangeTransferPolicyLabel: utils.KubeSafeLabel("ctp-prod"),
-					promoterv1alpha1.EnvironmentLabel:          utils.KubeSafeLabel("environment/staging"),
-				},
-				Finalizers: []string{promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer},
-			},
-			Spec: promoterv1alpha1.PullRequestSpec{
-				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "repo"},
-				Title:               "title",
-				Description:         "description",
-				TargetBranch:        "environment/staging",
-				SourceBranch:        "environment/staging-next",
-				MergeSha:            "hydrated-sha",
-				State:               promoterv1alpha1.PullRequestOpen,
-				Commit:              promoterv1alpha1.CommitConfiguration{Message: "commit message"},
-			},
-		}
-	})
-
-	It("returns true when all managed fields match", func() {
-		Expect(pullRequestManagedByCTPUnchanged(existing, "title", "description", "commit message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeTrue())
-	})
-
-	It("returns false when commit message differs", func() {
-		Expect(pullRequestManagedByCTPUnchanged(existing, "title", "description", "different message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeFalse())
-	})
-
-	It("returns false when the CTP finalizer is missing", func() {
-		withoutFinalizer := existing.DeepCopy()
-		withoutFinalizer.Finalizers = nil
-		Expect(pullRequestManagedByCTPUnchanged(withoutFinalizer, "title", "description", "commit message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeFalse())
-	})
-})
-
 var _ = Describe("pullRequestUpdateEnqueuesChangeTransferPolicyPredicate", func() {
 	pred := pullRequestUpdateEnqueuesChangeTransferPolicyPredicate()
 

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -38,7 +38,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 //go:embed testdata/ChangeTransferPolicy.yaml
@@ -1194,6 +1196,120 @@ var _ = Describe("TemplatePullRequest", func() {
 			Expect(description).To(ContainSubstring("Strategy: " + psName))
 			Expect(description).To(ContainSubstring("Promote to " + testBranchDevelopment))
 		})
+	})
+})
+
+var _ = Describe("pullRequestManagedByCTPUnchanged", func() {
+	var (
+		ctp      *promoterv1alpha1.ChangeTransferPolicy
+		existing *promoterv1alpha1.PullRequest
+	)
+
+	BeforeEach(func() {
+		ctp = &promoterv1alpha1.ChangeTransferPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ctp-prod",
+				Labels: map[string]string{
+					promoterv1alpha1.PromotionStrategyLabel: "my-ps",
+				},
+			},
+			Spec: promoterv1alpha1.ChangeTransferPolicySpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "repo"},
+				ProposedBranch:      "environment/staging-next",
+				ActiveBranch:        "environment/staging",
+			},
+			Status: promoterv1alpha1.ChangeTransferPolicyStatus{
+				Proposed: promoterv1alpha1.CommitBranchState{
+					Hydrated: promoterv1alpha1.CommitShaState{Sha: "hydrated-sha"},
+				},
+			},
+		}
+		existing = &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pr-1",
+				Labels: map[string]string{
+					promoterv1alpha1.PromotionStrategyLabel:    utils.KubeSafeLabel("my-ps"),
+					promoterv1alpha1.ChangeTransferPolicyLabel: utils.KubeSafeLabel("ctp-prod"),
+					promoterv1alpha1.EnvironmentLabel:          utils.KubeSafeLabel("environment/staging"),
+				},
+				Finalizers: []string{promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer},
+			},
+			Spec: promoterv1alpha1.PullRequestSpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "repo"},
+				Title:               "title",
+				Description:         "description",
+				TargetBranch:        "environment/staging",
+				SourceBranch:        "environment/staging-next",
+				MergeSha:            "hydrated-sha",
+				State:               promoterv1alpha1.PullRequestOpen,
+				Commit:              promoterv1alpha1.CommitConfiguration{Message: "commit message"},
+			},
+		}
+	})
+
+	It("returns true when all managed fields match", func() {
+		Expect(pullRequestManagedByCTPUnchanged(existing, "title", "description", "commit message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeTrue())
+	})
+
+	It("returns false when commit message differs", func() {
+		Expect(pullRequestManagedByCTPUnchanged(existing, "title", "description", "different message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeFalse())
+	})
+
+	It("returns false when the CTP finalizer is missing", func() {
+		withoutFinalizer := existing.DeepCopy()
+		withoutFinalizer.Finalizers = nil
+		Expect(pullRequestManagedByCTPUnchanged(withoutFinalizer, "title", "description", "commit message", ctp, promoterv1alpha1.PullRequestOpen)).To(BeFalse())
+	})
+})
+
+var _ = Describe("pullRequestUpdateEnqueuesChangeTransferPolicyPredicate", func() {
+	var pred = pullRequestUpdateEnqueuesChangeTransferPolicyPredicate()
+
+	It("ignores status-only URL updates", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     promoterv1alpha1.PullRequestStatus{State: promoterv1alpha1.PullRequestOpen, ID: "1"},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Status.Url = "https://example/pr/1"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeFalse())
+	})
+
+	It("enqueues on spec generation change", func() {
+		oldPR := &promoterv1alpha1.PullRequest{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
+		newPR := oldPR.DeepCopy()
+		newPR.Generation = 2
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
+	})
+
+	It("enqueues when the PR ID is first set", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     promoterv1alpha1.PullRequestStatus{State: promoterv1alpha1.PullRequestOpen},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Status.ID = "42"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
+	})
+
+	It("enqueues on terminal state change", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     promoterv1alpha1.PullRequestStatus{State: promoterv1alpha1.PullRequestOpen, ID: "1"},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Status.State = promoterv1alpha1.PullRequestMerged
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
+	})
+
+	It("enqueues when externally merged flag changes", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     promoterv1alpha1.PullRequestStatus{State: promoterv1alpha1.PullRequestOpen, ID: "1"},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Status.ExternallyMergedOrClosed = ptr.To(true)
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
 	})
 })
 

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -881,7 +881,6 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				By("Simulating routine PR controller status-only writes that used to re-enqueue CTP")
 				for poke := 0; poke < 3; poke++ {
-					poke := poke
 					Eventually(func(g Gomega) {
 						g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
 						pr.Status.Url = fmt.Sprintf("https://fake.example/pr/%s?poke=%d", pr.Status.ID, poke)

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -895,17 +895,13 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					g.Expect(pr.Status.Url).To(Equal(fmt.Sprintf("https://fake.example/pr/%s?poke=2", pr.Status.ID)))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
-				findOpenSnapshot := fake.FindOpenCallCount()
-				updateSnapshot := fake.UpdateCallCount()
-				scmSnapshot := fake.PullRequestSCMCallCount()
-				Expect(scmSnapshot).To(BeNumerically("<", 10),
-					"a regression reproduces dozens of SCM calls from status-only churn")
-
 				By("Verifying status churn does not drive SCM polling in a tight loop")
+				// With the fix, three status-only pokes produce 0 SCM calls after reset.
+				// Without it, the loop reaches 1+ FindOpen/Update pairs within ~0.5s.
 				Consistently(func(g Gomega) {
-					g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", findOpenSnapshot+1))
-					g.Expect(fake.UpdateCallCount()).To(BeNumerically("<=", updateSnapshot+1))
-					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
+					g.Expect(fake.FindOpenCallCount()).To(BeZero())
+					g.Expect(fake.UpdateCallCount()).To(BeZero())
+					g.Expect(fake.PullRequestSCMCallCount()).To(BeZero())
 				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 
 				var afterPR promoterv1alpha1.PullRequest

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -919,19 +919,18 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					g.Expect(k8sClient.Patch(ctx, changeTransferPolicy, ctrlclient.MergeFrom(base))).To(Succeed())
 				}, constants.EventuallyTimeout).Should(Succeed())
 
-				By("Waiting for the nudge reconcile to settle")
-				time.Sleep(1 * time.Second)
-				findOpenSnapshot := fake.FindOpenCallCount()
-				updateSnapshot := fake.UpdateCallCount()
-				scmSnapshot := fake.PullRequestSCMCallCount()
-				Expect(scmSnapshot).To(BeNumerically("<", 25),
-					"a regression reproduces dozens of SCM calls per nudge")
+				By("Waiting for CTP to finish reconciling the nudge")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, ctpKey, changeTransferPolicy)).To(Succeed())
+					g.Expect(changeTransferPolicy.Status.ObservedGeneration).To(Equal(changeTransferPolicy.Generation))
+				}, constants.EventuallyTimeout).Should(Succeed())
 
-				By("Verifying SCM is not polled in a tight loop after settle")
+				By("Verifying the nudge did not drive PR SCM sync")
+				Expect(fake.FindOpenCallCount()).To(BeZero())
+				Expect(fake.UpdateCallCount()).To(BeZero())
+
 				Consistently(func(g Gomega) {
-					g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", findOpenSnapshot+1))
-					g.Expect(fake.UpdateCallCount()).To(BeNumerically("<=", updateSnapshot+1))
-					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
+					g.Expect(fake.PullRequestSCMCallCount()).To(BeZero())
 				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 			})
 

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1367,6 +1367,31 @@ var _ = Describe("pullRequestUpdateEnqueuesChangeTransferPolicyPredicate", func(
 		newPR.Status.ExternallyMergedOrClosed = ptr.To(true)
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
 	})
+
+	It("enqueues when the CTP finalizer is removed even if another finalizer is added", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+				Finalizers: []string{promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer},
+			},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Finalizers = []string{promoterv1alpha1.PullRequestFinalizer}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeTrue())
+	})
+
+	It("ignores unrelated finalizer changes when the CTP finalizer is unchanged", func() {
+		oldPR := &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+				Finalizers: []string{promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer},
+			},
+			Status: promoterv1alpha1.PullRequestStatus{State: promoterv1alpha1.PullRequestOpen, ID: "1"},
+		}
+		newPR := oldPR.DeepCopy()
+		newPR.Finalizers = append(slices.Clone(newPR.Finalizers), promoterv1alpha1.PullRequestFinalizer)
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPR, ObjectNew: newPR})).To(BeFalse())
+	})
 })
 
 var _ = Describe("tooManyPRsError", func() {

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -883,10 +884,14 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				time.Sleep(500 * time.Millisecond)
+				findOpenSnapshot := fake.FindOpenCallCount()
+				updateSnapshot := fake.UpdateCallCount()
 				scmSnapshot := fake.PullRequestSCMCallCount()
 
 				By("Verifying status-only churn does not drive SCM polling")
 				Consistently(func(g Gomega) {
+					g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", findOpenSnapshot+1))
+					g.Expect(fake.UpdateCallCount()).To(BeNumerically("<=", updateSnapshot+1))
 					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
 				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 
@@ -909,18 +914,22 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					if changeTransferPolicy.Annotations == nil {
 						changeTransferPolicy.Annotations = map[string]string{}
 					}
-					changeTransferPolicy.Annotations["promoter.argoproj.io/test-nudge"] = fmt.Sprintf("%d", time.Now().UnixNano())
+					changeTransferPolicy.Annotations["promoter.argoproj.io/test-nudge"] = strconv.FormatInt(time.Now().UnixNano(), 10)
 					g.Expect(k8sClient.Patch(ctx, changeTransferPolicy, ctrlclient.MergeFrom(base))).To(Succeed())
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Waiting for the nudge reconcile to settle")
 				time.Sleep(1 * time.Second)
+				findOpenSnapshot := fake.FindOpenCallCount()
+				updateSnapshot := fake.UpdateCallCount()
 				scmSnapshot := fake.PullRequestSCMCallCount()
 				Expect(scmSnapshot).To(BeNumerically("<", 25),
 					"a regression reproduces dozens of SCM calls per nudge")
 
 				By("Verifying SCM is not polled in a tight loop after settle")
 				Consistently(func(g Gomega) {
+					g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", findOpenSnapshot+1))
+					g.Expect(fake.UpdateCallCount()).To(BeNumerically("<=", updateSnapshot+1))
 					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
 				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 			})
@@ -931,7 +940,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				pr, _ := waitForOpenPRWithID()
 
 				fake.ResetPullRequestSCMCallCounts()
-				baseline := fake.PullRequestSCMCallCount()
+				baselineFindOpen := fake.FindOpenCallCount()
+				baselineUpdate := fake.UpdateCallCount()
 
 				By("Changing PR spec so the PR controller must sync to SCM")
 				Eventually(func(g Gomega) {
@@ -941,7 +951,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Eventually(func(g Gomega) {
-					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically(">", baseline))
+					g.Expect(fake.FindOpenCallCount()).To(BeNumerically(">", baselineFindOpen))
+					g.Expect(fake.UpdateCallCount()).To(BeNumerically(">", baselineUpdate))
 				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -889,7 +889,12 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					}, constants.EventuallyTimeout).Should(Succeed())
 				}
 
-				time.Sleep(500 * time.Millisecond)
+				By("Waiting for the last status poke to land on the PR")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
+					g.Expect(pr.Status.Url).To(Equal(fmt.Sprintf("https://fake.example/pr/%s?poke=2", pr.Status.ID)))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
 				findOpenSnapshot := fake.FindOpenCallCount()
 				updateSnapshot := fake.UpdateCallCount()
 				scmSnapshot := fake.PullRequestSCMCallCount()

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -870,26 +869,34 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				return pr, pr.Generation
 			}
 
-			It("should not poll SCM after status-only PR updates", func() {
+			// Regression for open-PR steady state with blocked promotion: routine PR status
+			// writes used to Owns(PullRequest)-enqueue CTP, which SSA-reapplied the PR and
+			// retriggered PR controller SCM sync in a CTP→PR→CTP feedback loop.
+			It("should not enter a CTP→PR SCM feedback loop when PR status churns in steady state", func() {
 				By("Creating a pending promotion with an open PR")
 				_, _ = makeChangeAndHydrateRepo(gitPath, gitRepo, "", "")
 				pr, stableGeneration := waitForOpenPRWithID()
 
 				fake.ResetPullRequestSCMCallCounts()
 
-				By("Simulating PR controller status-only writes (URL) that used to re-enqueue CTP")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
-					pr.Status.Url = "https://fake.example/pr/" + pr.Status.ID
-					g.Expect(k8sClient.Status().Update(ctx, &pr)).To(Succeed())
-				}, constants.EventuallyTimeout).Should(Succeed())
+				By("Simulating routine PR controller status-only writes that used to re-enqueue CTP")
+				for poke := 0; poke < 3; poke++ {
+					poke := poke
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
+						pr.Status.Url = fmt.Sprintf("https://fake.example/pr/%s?poke=%d", pr.Status.ID, poke)
+						g.Expect(k8sClient.Status().Update(ctx, &pr)).To(Succeed())
+					}, constants.EventuallyTimeout).Should(Succeed())
+				}
 
 				time.Sleep(500 * time.Millisecond)
 				findOpenSnapshot := fake.FindOpenCallCount()
 				updateSnapshot := fake.UpdateCallCount()
 				scmSnapshot := fake.PullRequestSCMCallCount()
+				Expect(scmSnapshot).To(BeNumerically("<", 10),
+					"a regression reproduces dozens of SCM calls from status-only churn")
 
-				By("Verifying status-only churn does not drive SCM polling")
+				By("Verifying status churn does not drive SCM polling in a tight loop")
 				Consistently(func(g Gomega) {
 					g.Expect(fake.FindOpenCallCount()).To(BeNumerically("<=", findOpenSnapshot+1))
 					g.Expect(fake.UpdateCallCount()).To(BeNumerically("<=", updateSnapshot+1))
@@ -899,39 +906,6 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				var afterPR promoterv1alpha1.PullRequest
 				Expect(k8sClient.Get(ctx, prKey, &afterPR)).To(Succeed())
 				Expect(afterPR.Generation).To(Equal(stableGeneration))
-			})
-
-			It("should not poll SCM in a loop after CTP nudges", func() {
-				By("Creating a pending promotion with an open PR")
-				_, _ = makeChangeAndHydrateRepo(gitPath, gitRepo, "", "")
-				waitForOpenPRWithID()
-
-				fake.ResetPullRequestSCMCallCounts()
-
-				By("Nudging CTP via annotation change without changing PR spec")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, ctpKey, changeTransferPolicy)).To(Succeed())
-					base := changeTransferPolicy.DeepCopy()
-					if changeTransferPolicy.Annotations == nil {
-						changeTransferPolicy.Annotations = map[string]string{}
-					}
-					changeTransferPolicy.Annotations["promoter.argoproj.io/test-nudge"] = strconv.FormatInt(time.Now().UnixNano(), 10)
-					g.Expect(k8sClient.Patch(ctx, changeTransferPolicy, ctrlclient.MergeFrom(base))).To(Succeed())
-				}, constants.EventuallyTimeout).Should(Succeed())
-
-				By("Waiting for CTP to finish reconciling the nudge")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, ctpKey, changeTransferPolicy)).To(Succeed())
-					g.Expect(changeTransferPolicy.Status.ObservedGeneration).To(Equal(changeTransferPolicy.Generation))
-				}, constants.EventuallyTimeout).Should(Succeed())
-
-				By("Verifying the nudge did not drive PR SCM sync")
-				Expect(fake.FindOpenCallCount()).To(BeZero())
-				Expect(fake.UpdateCallCount()).To(BeZero())
-
-				Consistently(func(g Gomega) {
-					g.Expect(fake.PullRequestSCMCallCount()).To(BeZero())
-				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 			})
 
 			It("should still hit SCM when the PR spec changes", func() {

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1263,7 +1263,7 @@ var _ = Describe("pullRequestManagedByCTPUnchanged", func() {
 })
 
 var _ = Describe("pullRequestUpdateEnqueuesChangeTransferPolicyPredicate", func() {
-	var pred = pullRequestUpdateEnqueuesChangeTransferPolicyPredicate()
+	pred := pullRequestUpdateEnqueuesChangeTransferPolicyPredicate()
 
 	It("ignores status-only URL updates", func() {
 		oldPR := &promoterv1alpha1.PullRequest{

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -854,6 +854,7 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, scmSecret)).To(Succeed())
+				_ = os.RemoveAll(gitPath)
 			})
 
 			waitForOpenPRWithID := func() (promoterv1alpha1.PullRequest, int64) {
@@ -941,6 +942,7 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				fake.ResetPullRequestSCMCallCounts()
 				baselineFindOpen := fake.FindOpenCallCount()
+
 				baselineUpdate := fake.UpdateCallCount()
 
 				By("Changing PR spec so the PR controller must sync to SCM")

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	"github.com/argoproj-labs/gitops-promoter/internal/scms/fake"
@@ -809,6 +810,138 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					}, &createdPR)
 					// PR should be deleted (not found)
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
+			})
+		})
+
+		Context("When an open PR is in steady state", func() {
+			var (
+				name                 string
+				scmSecret            *v1.Secret
+				scmProvider          *promoterv1alpha1.ScmProvider
+				gitRepo              *promoterv1alpha1.GitRepository
+				changeTransferPolicy *promoterv1alpha1.ChangeTransferPolicy
+				ctpKey               types.NamespacedName
+				prKey                types.NamespacedName
+				gitPath              string
+				prName               string
+			)
+
+			BeforeEach(func() {
+				var err error
+				name, scmSecret, scmProvider, gitRepo, _, changeTransferPolicy = changeTransferPolicyResources(ctx, "ctp-open-pr-steady", "default")
+
+				ctpKey = types.NamespacedName{Name: name, Namespace: "default"}
+				changeTransferPolicy.Spec.ProposedBranch = testBranchDevelopmentNext
+				changeTransferPolicy.Spec.ActiveBranch = testBranchDevelopment
+				changeTransferPolicy.Spec.AutoMerge = new(false)
+
+				Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
+				Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Create(ctx, changeTransferPolicy)).To(Succeed())
+
+				prName = utils.GetPullRequestName(gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name, changeTransferPolicy.Spec.ProposedBranch, changeTransferPolicy.Spec.ActiveBranch)
+				prKey = types.NamespacedName{Name: utils.KubeSafeUniqueName(prName), Namespace: "default"}
+
+				gitPath, err = os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(ctrlclient.IgnoreNotFound(k8sClient.Delete(ctx, changeTransferPolicy))).To(Succeed())
+				Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, scmSecret)).To(Succeed())
+			})
+
+			waitForOpenPRWithID := func() (promoterv1alpha1.PullRequest, int64) {
+				var pr promoterv1alpha1.PullRequest
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
+					g.Expect(pr.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+					g.Expect(pr.Status.ID).NotTo(BeEmpty())
+					g.Expect(k8sClient.Get(ctx, ctpKey, changeTransferPolicy)).To(Succeed())
+					g.Expect(changeTransferPolicy.Status.PullRequest).NotTo(BeNil())
+					g.Expect(changeTransferPolicy.Status.PullRequest.ID).To(Equal(pr.Status.ID))
+				}, constants.EventuallyTimeout).Should(Succeed())
+				return pr, pr.Generation
+			}
+
+			It("should not poll SCM after status-only PR updates", func() {
+				By("Creating a pending promotion with an open PR")
+				_, _ = makeChangeAndHydrateRepo(gitPath, gitRepo, "", "")
+				pr, stableGeneration := waitForOpenPRWithID()
+
+				fake.ResetPullRequestSCMCallCounts()
+
+				By("Simulating PR controller status-only writes (URL) that used to re-enqueue CTP")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
+					pr.Status.Url = "https://fake.example/pr/" + pr.Status.ID
+					g.Expect(k8sClient.Status().Update(ctx, &pr)).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				time.Sleep(500 * time.Millisecond)
+				scmSnapshot := fake.PullRequestSCMCallCount()
+
+				By("Verifying status-only churn does not drive SCM polling")
+				Consistently(func(g Gomega) {
+					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
+				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
+
+				var afterPR promoterv1alpha1.PullRequest
+				Expect(k8sClient.Get(ctx, prKey, &afterPR)).To(Succeed())
+				Expect(afterPR.Generation).To(Equal(stableGeneration))
+			})
+
+			It("should not poll SCM in a loop after CTP nudges", func() {
+				By("Creating a pending promotion with an open PR")
+				_, _ = makeChangeAndHydrateRepo(gitPath, gitRepo, "", "")
+				waitForOpenPRWithID()
+
+				fake.ResetPullRequestSCMCallCounts()
+
+				By("Nudging CTP via annotation change without changing PR spec")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, ctpKey, changeTransferPolicy)).To(Succeed())
+					base := changeTransferPolicy.DeepCopy()
+					if changeTransferPolicy.Annotations == nil {
+						changeTransferPolicy.Annotations = map[string]string{}
+					}
+					changeTransferPolicy.Annotations["promoter.argoproj.io/test-nudge"] = fmt.Sprintf("%d", time.Now().UnixNano())
+					g.Expect(k8sClient.Patch(ctx, changeTransferPolicy, ctrlclient.MergeFrom(base))).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				By("Waiting for the nudge reconcile to settle")
+				time.Sleep(1 * time.Second)
+				scmSnapshot := fake.PullRequestSCMCallCount()
+				Expect(scmSnapshot).To(BeNumerically("<", 25),
+					"a regression reproduces dozens of SCM calls per nudge")
+
+				By("Verifying SCM is not polled in a tight loop after settle")
+				Consistently(func(g Gomega) {
+					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically("<=", scmSnapshot+1))
+				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
+			})
+
+			It("should still hit SCM when the PR spec changes", func() {
+				By("Creating a pending promotion with an open PR")
+				_, _ = makeChangeAndHydrateRepo(gitPath, gitRepo, "", "")
+				pr, _ := waitForOpenPRWithID()
+
+				fake.ResetPullRequestSCMCallCounts()
+				baseline := fake.PullRequestSCMCallCount()
+
+				By("Changing PR spec so the PR controller must sync to SCM")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, prKey, &pr)).To(Succeed())
+					pr.Spec.Title = pr.Spec.Title + "-updated"
+					g.Expect(k8sClient.Update(ctx, &pr)).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(fake.PullRequestSCMCallCount()).To(BeNumerically(">", baseline))
 				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -40,8 +40,9 @@ var (
 )
 
 type pullRequestProviderState struct {
-	id    string
-	state v1alpha1.PullRequestState
+	createdAt time.Time
+	id        string
+	state     v1alpha1.PullRequestState
 }
 
 // PullRequest implements the scms.PullRequestProvider interface for testing purposes.
@@ -83,8 +84,9 @@ func (pr *PullRequest) Create(ctx context.Context, title, head, base, descriptio
 
 	id = strconv.Itoa(len(pullRequests) + 1)
 	pullRequests[pr.getMapKey(*pullRequestCopy, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name)] = pullRequestProviderState{
-		id:    id,
-		state: v1alpha1.PullRequestOpen,
+		id:        id,
+		state:     v1alpha1.PullRequestOpen,
+		createdAt: time.Now(),
 	}
 
 	return id, nil
@@ -114,9 +116,11 @@ func (pr *PullRequest) Close(ctx context.Context, pullRequest v1alpha1.PullReque
 	if _, ok := pullRequests[prKey]; !ok {
 		return errors.New("pull request not found")
 	}
+	prev := pullRequests[prKey]
 	pullRequests[prKey] = pullRequestProviderState{
-		id:    pullRequests[prKey].id,
-		state: v1alpha1.PullRequestClosed,
+		id:        prev.id,
+		state:     v1alpha1.PullRequestClosed,
+		createdAt: prev.createdAt,
 	}
 	return nil
 }
@@ -214,9 +218,11 @@ func (pr *PullRequest) Merge(ctx context.Context, pullRequest v1alpha1.PullReque
 	if _, ok := pullRequests[prKey]; !ok {
 		return errors.New("pull request not found")
 	}
+	prev := pullRequests[prKey]
 	pullRequests[prKey] = pullRequestProviderState{
-		id:    pullRequests[prKey].id,
-		state: v1alpha1.PullRequestMerged,
+		id:        prev.id,
+		state:     v1alpha1.PullRequestMerged,
+		createdAt: prev.createdAt,
 	}
 	return nil
 }
@@ -292,26 +298,29 @@ func (pr *PullRequest) FindOpen(ctx context.Context, pullRequest v1alpha1.PullRe
 	findOpenCallCount.Add(1)
 
 	mutexPR.RLock()
-	found, id := pr.findOpen(ctx, pullRequest)
+	found, id, createdAt := pr.findOpen(ctx, pullRequest)
 	mutexPR.RUnlock()
 
-	return found, id, time.Now(), nil
+	return found, id, createdAt, nil
 }
 
-func (pr *PullRequest) findOpen(ctx context.Context, pullRequest v1alpha1.PullRequest) (bool, string) {
+func (pr *PullRequest) findOpen(ctx context.Context, pullRequest v1alpha1.PullRequest) (bool, string, time.Time) {
 	log.FromContext(ctx).Info("Finding open pull request", "pullRequest", pullRequest)
 	if pullRequests == nil {
-		return false, ""
+		return false, "", time.Time{}
 	}
 
 	gitRepo, err := utils.GetGitRepositoryFromObjectKey(ctx, pr.k8sClient, client.ObjectKey{Namespace: pullRequest.Namespace, Name: pullRequest.Spec.RepositoryReference.Name})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to get GitRepository")
-		return false, ""
+		return false, "", time.Time{}
 	}
 
 	pullRequestState, ok := pullRequests[pr.getMapKey(pullRequest, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name)]
-	return ok && pullRequestState.state == v1alpha1.PullRequestOpen, pullRequestState.id
+	if !ok || pullRequestState.state != v1alpha1.PullRequestOpen {
+		return false, "", time.Time{}
+	}
+	return true, pullRequestState.id, pullRequestState.createdAt
 }
 
 func (pr *PullRequest) getMapKey(pullRequest v1alpha1.PullRequest, owner, name string) string {

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -32,6 +32,8 @@ var (
 
 	// findOpenCallCount is incremented on every FindOpen call (for tests).
 	findOpenCallCount atomic.Uint64
+	// updateCallCount is incremented on every Update call (for tests).
+	updateCallCount atomic.Uint64
 	// mergeShaMismatchCount is incremented every time Merge is called with a PR
 	// whose Spec.MergeSha does not match origin/<sourceBranch> (for tests).
 	mergeShaMismatchCount atomic.Uint64
@@ -90,6 +92,7 @@ func (pr *PullRequest) Create(ctx context.Context, title, head, base, descriptio
 
 // Update updates an existing pull request with the specified title and description.
 func (pr *PullRequest) Update(ctx context.Context, title, description string, pullRequest v1alpha1.PullRequest) error {
+	updateCallCount.Add(1)
 	return nil
 }
 
@@ -223,9 +226,30 @@ func ResetFindOpenCallCount() {
 	findOpenCallCount.Store(0)
 }
 
+// ResetUpdateCallCount resets the test-only counter of Update invocations.
+func ResetUpdateCallCount() {
+	updateCallCount.Store(0)
+}
+
+// ResetPullRequestSCMCallCounts resets both FindOpen and Update test counters.
+func ResetPullRequestSCMCallCounts() {
+	findOpenCallCount.Store(0)
+	updateCallCount.Store(0)
+}
+
 // FindOpenCallCount returns how many times FindOpen has been invoked since the last reset.
 func FindOpenCallCount() uint64 {
 	return findOpenCallCount.Load()
+}
+
+// UpdateCallCount returns how many times Update has been invoked since the last reset.
+func UpdateCallCount() uint64 {
+	return updateCallCount.Load()
+}
+
+// PullRequestSCMCallCount returns FindOpen plus Update invocations since the last reset.
+func PullRequestSCMCallCount() uint64 {
+	return findOpenCallCount.Load() + updateCallCount.Load()
 }
 
 // ResetMergeShaMismatchCount resets the test-only counter of Merge calls that hit the

--- a/internal/scms/fake/pullrequest.go
+++ b/internal/scms/fake/pullrequest.go
@@ -233,8 +233,8 @@ func ResetUpdateCallCount() {
 
 // ResetPullRequestSCMCallCounts resets both FindOpen and Update test counters.
 func ResetPullRequestSCMCallCounts() {
-	findOpenCallCount.Store(0)
-	updateCallCount.Store(0)
+	ResetFindOpenCallCount()
+	ResetUpdateCallCount()
 }
 
 // FindOpenCallCount returns how many times FindOpen has been invoked since the last reset.
@@ -249,7 +249,7 @@ func UpdateCallCount() uint64 {
 
 // PullRequestSCMCallCount returns FindOpen plus Update invocations since the last reset.
 func PullRequestSCMCallCount() uint64 {
-	return findOpenCallCount.Load() + updateCallCount.Load()
+	return FindOpenCallCount() + UpdateCallCount()
 }
 
 // ResetMergeShaMismatchCount resets the test-only counter of Merge calls that hit the


### PR DESCRIPTION
### Summary
Stops a CTP → PullRequest → CTP loop that caused steady SCM PullRequest/list + update traffic while promotion is blocked on open PRs, even with a 60m requeue.

### Changes
 * Skip no-op PR applies: CTP compares the computed PR spec to the live object before SSA; unchanged specs are not patched.
 * Narrow Owns(PullRequest): CTP re-enqueues only on spec generation changes, finalizer changes, first PR ID, or terminal/externally-closed state — not routine status updates (URL, Ready, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced ChangeTransferPolicy reconciliations by narrowing Pull Request event handling to relevant create/delete events and specific meaningful updates.
  * Prevents reconciliations from triggering on status-only changes (e.g., URL-only churn).
* **Bug Fixes**
  * Improves synchronization by enqueueing only when key finalizer/status fields change meaningfully, including initial `status.id` population and CTP finalizer removal.
* **Tests**
  * Added steady-state coverage to confirm no unnecessary SCM polling/update calls during status-only churn.
  * Enhanced fake SCM metrics and timing behavior to support stronger call-count and state assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->