### PR TITLE
fix(renovate): restore regex delimiters for golangci-lint managers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -469,11 +469,13 @@
       versioningTemplate: 'semver',
     },
     // ===== golangci-lint (Makefile + workflows, incl. SHA-pinned action) =====
+    // managerFilePatterns must be wrapped in /.../ to use regex; without delimiters Renovate
+    // treats the string as a glob (see docs.renovatebot.com/string-pattern-matching).
     {
       customType: 'regex',
       description: 'Update golangci-lint version in Makefile',
       managerFilePatterns: [
-        '^Makefile$',
+        '/^Makefile$/',
       ],
       matchStrings: [
         'GOLANGCI_LINT_VERSION\\s*\\??=\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)',
@@ -488,7 +490,7 @@
       customType: 'regex',
       description: 'Update golangci-lint version in GitHub Actions (handles SHA-pinned action)',
       managerFilePatterns: [
-        '^\\.github/workflows/.*\\.ya?ml$',
+        '/^\\.github/workflows/.*\\.ya?ml$/',
       ],
       matchStrings: [
         'golangci/golangci-lint-action@(?:[0-9a-f]{7,40}|v\\d+)[\\s\\S]*?version:\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)',


### PR DESCRIPTION
Copilot Autofix in #1712 removed /.../ wrappers from managerFilePatterns, which Renovate interprets as globs instead of regexes. That broke scanning of Makefile and workflow files for golangci-lint version bumps.

Hurray, the robots are sometimes just wrong.