### PR TITLE
 fix(test): prevent auto-promotion race in GitCommitStatus revert-detection spec

### DIFF
--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -745,6 +745,31 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 				}
 			}, constants.EventuallyTimeout).Should(Succeed())
 
+			By("Disabling auto-merge on development and staging so manual git operations are not overwritten")
+			stagingCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchStaging))
+			devCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchDevelopment))
+			Eventually(func(g Gomega) {
+				var ps promoterv1alpha1.PromotionStrategy
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &ps)).To(Succeed())
+				ps.Spec.Environments[0].AutoMerge = new(false) // development
+				ps.Spec.Environments[1].AutoMerge = new(false) // staging
+				g.Expect(k8sClient.Update(ctx, &ps)).To(Succeed())
+			}, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Waiting for in-flight promotions into staging to settle before manual git push")
+			Eventually(func(g Gomega) {
+				for _, ctpName := range []string{devCTPName, stagingCTPName} {
+					var ctp promoterv1alpha1.ChangeTransferPolicy
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ctpName, Namespace: "default"}, &ctp)).To(Succeed())
+					g.Expect(ctp.Spec.AutoMerge).NotTo(BeNil())
+					g.Expect(*ctp.Spec.AutoMerge).To(BeFalse(), "CTP %s should have auto-merge disabled", ctpName)
+					if ctp.Status.PullRequest != nil {
+						g.Expect(ctp.Status.PullRequest.State).NotTo(Equal(promoterv1alpha1.PullRequestOpen),
+							"CTP %s should have no open promotion PR", ctpName)
+					}
+				}
+			}, constants.EventuallyTimeout).Should(Succeed())
+
 			By("Simulating a revert on the staging active branch using git revert")
 			gitPath, err := os.MkdirTemp("", "*")
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -746,21 +746,20 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 			}, constants.EventuallyTimeout).Should(Succeed())
 
 			stagingCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchStaging))
-			// setPromotionStrategyGlobalProposedCommitStatusKey above can unblock a promotion that
-			// was pending from an earlier spec under a different gating key. Wait until staging
-			// has no in-flight promotion (no open PR, nothing left to merge) immediately before
-			// creating the revert merge commit, so a real "Promote ... to environment/staging"
-			// merge cannot race the manual push below.
-			By("Verifying staging has no open promotion PR and active dry sha matches proposed dry sha before the revert merge")
+			// This Ordered suite shares one PromotionStrategy. Prior specs may have left staging
+			// mid-promotion, and switching the proposed commit status key above can trigger another
+			// reconcile. Wait until staging is idle before we push a revert commit to its active
+			// branch so a controller-driven promotion PR does not race the manual push below.
+			By("Verifying staging is idle before pushing a revert commit to its active branch")
 			Eventually(func(g Gomega) {
 				var ctp promoterv1alpha1.ChangeTransferPolicy
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: stagingCTPName, Namespace: "default"}, &ctp)).To(Succeed())
 				if ctp.Status.PullRequest != nil {
 					g.Expect(ctp.Status.PullRequest.State).NotTo(Equal(promoterv1alpha1.PullRequestOpen),
-						"staging should have no open promotion PR before the revert merge")
+						"staging should have no open promotion PR before the revert commit push")
 				}
 				g.Expect(ctp.Status.Active.Dry.Sha).To(Equal(ctp.Status.Proposed.Dry.Sha),
-					"staging active dry sha should match proposed dry sha before the revert merge")
+					"staging active dry sha should match proposed dry sha before the revert commit push")
 			}, constants.EventuallyTimeout).Should(Succeed())
 
 			By("Simulating a revert on the staging active branch using git revert")

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -766,9 +766,6 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 			By("Waiting for in-flight promotions on development and staging to settle")
 			Eventually(noOpenPromotionPR, constants.EventuallyTimeout).Should(Succeed())
 
-			By("Confirming the promotion pipeline stays quiescent before the manual revert push")
-			Consistently(noOpenPromotionPR, 3*time.Second, 250*time.Millisecond).Should(Succeed())
-
 			By("Simulating a revert on the staging active branch using git revert")
 			gitPath, err := os.MkdirTemp("", "*")
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -746,25 +746,22 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 			}, constants.EventuallyTimeout).Should(Succeed())
 
 			stagingCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchStaging))
-			devCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchDevelopment))
-
 			// setPromotionStrategyGlobalProposedCommitStatusKey above can unblock a promotion that
-			// was pending from an earlier spec under a different gating key, racing the manual
-			// revert push below with a real "Promote ... to environment/staging" merge (the CI
-			// flake this guards against). Wait for that to fully drain, then require it to stay
-			// drained for a few seconds before doing any git operations.
-			noOpenPromotionPR := func(g Gomega) {
-				for _, ctpName := range []string{devCTPName, stagingCTPName} {
-					var ctp promoterv1alpha1.ChangeTransferPolicy
-					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ctpName, Namespace: "default"}, &ctp)).To(Succeed())
-					if ctp.Status.PullRequest != nil {
-						g.Expect(ctp.Status.PullRequest.State).NotTo(Equal(promoterv1alpha1.PullRequestOpen),
-							"CTP %s should have no open promotion PR", ctpName)
-					}
+			// was pending from an earlier spec under a different gating key. Wait until staging
+			// has no in-flight promotion (no open PR, nothing left to merge) immediately before
+			// creating the revert merge commit, so a real "Promote ... to environment/staging"
+			// merge cannot race the manual push below.
+			By("Verifying staging has no open promotion PR and active dry sha matches proposed dry sha before the revert merge")
+			Eventually(func(g Gomega) {
+				var ctp promoterv1alpha1.ChangeTransferPolicy
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: stagingCTPName, Namespace: "default"}, &ctp)).To(Succeed())
+				if ctp.Status.PullRequest != nil {
+					g.Expect(ctp.Status.PullRequest.State).NotTo(Equal(promoterv1alpha1.PullRequestOpen),
+						"staging should have no open promotion PR before the revert merge")
 				}
-			}
-			By("Waiting for in-flight promotions on development and staging to settle")
-			Eventually(noOpenPromotionPR, constants.EventuallyTimeout).Should(Succeed())
+				g.Expect(ctp.Status.Active.Dry.Sha).To(Equal(ctp.Status.Proposed.Dry.Sha),
+					"staging active dry sha should match proposed dry sha before the revert merge")
+			}, constants.EventuallyTimeout).Should(Succeed())
 
 			By("Simulating a revert on the staging active branch using git revert")
 			gitPath, err := os.MkdirTemp("", "*")

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -745,30 +745,29 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 				}
 			}, constants.EventuallyTimeout).Should(Succeed())
 
-			By("Disabling auto-merge on development and staging so manual git operations are not overwritten")
 			stagingCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchStaging))
 			devCTPName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchDevelopment))
-			Eventually(func(g Gomega) {
-				var ps promoterv1alpha1.PromotionStrategy
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &ps)).To(Succeed())
-				ps.Spec.Environments[0].AutoMerge = new(false) // development
-				ps.Spec.Environments[1].AutoMerge = new(false) // staging
-				g.Expect(k8sClient.Update(ctx, &ps)).To(Succeed())
-			}, constants.EventuallyTimeout).Should(Succeed())
 
-			By("Waiting for in-flight promotions into staging to settle before manual git push")
-			Eventually(func(g Gomega) {
+			// setPromotionStrategyGlobalProposedCommitStatusKey above can unblock a promotion that
+			// was pending from an earlier spec under a different gating key, racing the manual
+			// revert push below with a real "Promote ... to environment/staging" merge (the CI
+			// flake this guards against). Wait for that to fully drain, then require it to stay
+			// drained for a few seconds before doing any git operations.
+			noOpenPromotionPR := func(g Gomega) {
 				for _, ctpName := range []string{devCTPName, stagingCTPName} {
 					var ctp promoterv1alpha1.ChangeTransferPolicy
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ctpName, Namespace: "default"}, &ctp)).To(Succeed())
-					g.Expect(ctp.Spec.AutoMerge).NotTo(BeNil())
-					g.Expect(*ctp.Spec.AutoMerge).To(BeFalse(), "CTP %s should have auto-merge disabled", ctpName)
 					if ctp.Status.PullRequest != nil {
 						g.Expect(ctp.Status.PullRequest.State).NotTo(Equal(promoterv1alpha1.PullRequestOpen),
 							"CTP %s should have no open promotion PR", ctpName)
 					}
 				}
-			}, constants.EventuallyTimeout).Should(Succeed())
+			}
+			By("Waiting for in-flight promotions on development and staging to settle")
+			Eventually(noOpenPromotionPR, constants.EventuallyTimeout).Should(Succeed())
+
+			By("Confirming the promotion pipeline stays quiescent before the manual revert push")
+			Consistently(noOpenPromotionPR, 3*time.Second, 250*time.Millisecond).Should(Succeed())
 
 			By("Simulating a revert on the staging active branch using git revert")
 			gitPath, err := os.MkdirTemp("", "*")


### PR DESCRIPTION
* CI intermittently failed GitCommitStatus Controller > Revert Detection Flow > should detect reverts on staging when a real promotion merge (Promote … to environment/staging) landed on top of the manually-pushed revert commit before assertions ran, making the active tip look like a passing "Promote" commit instead of the revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Strengthened the “revert detection” test to ensure staging promotion state is stable before simulating a staging revert, reducing race-related flakiness.
  * Added assertions that there is no open promotion pull request and that the staging and proposed dry SHAs match prior to pushing the revert commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->