### PR TITLE
feat: link previous environment commit status to merge commit

### DIFF
--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -580,7 +580,7 @@ func (r *PromotionStrategyReconciler) handleRateLimitedEnqueue(
 	}
 }
 
-func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitStatus(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, phase promoterv1alpha1.CommitStatusPhase, pendingReason string, previousEnvironmentBranch string, previousCRPCSPhases []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase) (*promoterv1alpha1.CommitStatus, error) {
+func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitStatus(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, phase promoterv1alpha1.CommitStatusPhase, pendingReason string, previousEnvironmentBranch string, previousCRPCSPhases []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase, previousEnvironmentCommitURL string) (*promoterv1alpha1.CommitStatus, error) {
 	logger := log.FromContext(ctx)
 
 	// TODO: do we like this name proposed-<name>?
@@ -589,11 +589,7 @@ func (r *PromotionStrategyReconciler) createOrUpdatePreviousEnvironmentCommitSta
 	kind := reflect.TypeFor[promoterv1alpha1.ChangeTransferPolicy]().Name()
 	gvk := promoterv1alpha1.GroupVersion.WithKind(kind)
 
-	// If there is only one commit status, use the URL from that commit status.
-	var url string
-	if len(previousCRPCSPhases) == 1 {
-		url = previousCRPCSPhases[0].Url
-	}
+	url := previousEnvironmentCommitURL
 
 	statusMap := make(map[string]string)
 	for _, status := range previousCRPCSPhases {
@@ -723,9 +719,12 @@ func (r *PromotionStrategyReconciler) updatePreviousEnvironmentCommitStatus(ctx 
 			"previousEnvironmentProposedNoteSha", getNoteDrySha(previousEnvironmentStatus.Proposed.Note),
 			"previousEnvironmentActiveBranch", previousEnvironmentStatus.Branch)
 
-		// Since there is at least one configured active check, and since this is not the first environment,
-		// we should not create a commit status for the previous environment.
-		cs, err := r.createOrUpdatePreviousEnvironmentCommitStatus(ctx, ctp, commitStatusPhase, pendingReason, previousEnvironmentStatus.Branch, ctps[i-1].Status.Active.CommitStatuses)
+		var previousEnvCommitURL string
+		if repoURL := previousEnvironmentStatus.Active.Dry.RepoURL; repoURL != "" && previousEnvironmentStatus.Active.Hydrated.Sha != "" {
+			previousEnvCommitURL = repoURL + "/commit/" + previousEnvironmentStatus.Active.Hydrated.Sha
+		}
+
+		cs, err := r.createOrUpdatePreviousEnvironmentCommitStatus(ctx, ctp, commitStatusPhase, pendingReason, previousEnvironmentStatus.Branch, ctps[i-1].Status.Active.CommitStatuses, previousEnvCommitURL)
 		if err != nil {
 			return fmt.Errorf("failed to create or update previous environment commit status for branch %s: %w", ctp.Spec.ActiveBranch, err)
 		}

--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -720,8 +720,14 @@ func (r *PromotionStrategyReconciler) updatePreviousEnvironmentCommitStatus(ctx 
 			"previousEnvironmentActiveBranch", previousEnvironmentStatus.Branch)
 
 		var previousEnvCommitURL string
-		if repoURL := previousEnvironmentStatus.Active.Dry.RepoURL; repoURL != "" && previousEnvironmentStatus.Active.Hydrated.Sha != "" {
-			previousEnvCommitURL = repoURL + "/commit/" + previousEnvironmentStatus.Active.Hydrated.Sha
+		if sha := previousEnvironmentStatus.Active.Hydrated.Sha; sha != "" {
+			repoURL := previousEnvironmentStatus.Active.Hydrated.RepoURL
+			if repoURL == "" {
+				repoURL = previousEnvironmentStatus.Active.Dry.RepoURL
+			}
+			if repoURL != "" {
+				previousEnvCommitURL = repoURL + "/commit/" + sha
+			}
 		}
 
 		cs, err := r.createOrUpdatePreviousEnvironmentCommitStatus(ctx, ctp, commitStatusPhase, pendingReason, previousEnvironmentStatus.Branch, ctps[i-1].Status.Active.CommitStatuses, previousEnvCommitURL)


### PR DESCRIPTION
## Summary

- Always link the `promoter-previous-environment` commit status to the previous environment's merge commit (`{repoURL}/commit/{sha}`)
- Replaces previous behavior: single active status → that status's URL, multiple → no URL
- When `RepoURL` or hydrated SHA is unavailable, no link is set (graceful fallback)

## Behavior change

This changes the URL target of the previous environment commit status. Previously it pointed to a single active commit status's detail page (e.g. ArgoCD app). Now it always points to the merge commit, which shows **all** check runs in one place. Looking for agreement from core maintainers.

Closes #1745

## Test plan

- [x] `make generate-all` — no changes
- [x] `make manifests` — no changes
- [x] `make fmt` / `make vet` — pass
- [x] `make lint` — 0 issues
- [x] `make test-parallel` — all 10 suites pass
- [x] `make deadcode` — pass
- [x] `make build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how previous environment commit status links are populated, so the displayed commit URL is now more reliable.
  * Fixed cases where the status link could be missing unless only one prior phase was available, helping users consistently navigate to the correct commit details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->