### PR TITLE
fix(ui): sort namespaces

### DIFF
--- a/ui/dashboard/src/stores/NamespaceStore.ts
+++ b/ui/dashboard/src/stores/NamespaceStore.ts
@@ -13,7 +13,8 @@ export const namespaceStore = create(
       namespace: '',
       namespaces: [],
       setNamespace: (ns) => set({ namespace: ns }),
-      setNamespaces: (nsList) => set({ namespaces: nsList }),
+      setNamespaces: (nsList) =>
+        set({ namespaces: [...nsList].sort((a, b) => a.localeCompare(b)) }),
     }),
     {
       name: 'namespace-storage',

--- a/ui/dashboard/test/NamespaceStore.test.ts
+++ b/ui/dashboard/test/NamespaceStore.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { namespaceStore } from '../src/stores/NamespaceStore';
+
+describe('namespaceStore', () => {
+  beforeEach(() => {
+    namespaceStore.setState({ namespace: '', namespaces: [] });
+  });
+
+  describe('setNamespaces', () => {
+    it('sorts namespaces alphabetically', () => {
+      namespaceStore.getState().setNamespaces(['zebra', 'alpha', 'middle']);
+
+      expect(namespaceStore.getState().namespaces).toEqual(['alpha', 'middle', 'zebra']);
+    });
+
+    it('does not mutate the input array', () => {
+      const input = ['zebra', 'alpha'];
+      namespaceStore.getState().setNamespaces(input);
+
+      expect(input).toEqual(['zebra', 'alpha']);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace lists are now kept in alphabetical order when saved, so the dashboard shows a consistent sorted view.
  * The original namespace list passed in is no longer altered when updates are applied.

* **Tests**
  * Added coverage to verify namespace sorting and confirm the input list remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->