### PR TITLE
feat(ctp): commit status description in history

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -277,6 +278,42 @@ func getFirstTrailerValue(trailers map[string][]string, key string) string {
 	return ""
 }
 
+func encodeTrailerDescription(description string) (string, error) {
+	encoded, err := json.Marshal(description)
+	if err != nil {
+		return "", fmt.Errorf("encode commit status description: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func decodeTrailerDescription(ctx context.Context, encoded string) string {
+	if encoded == "" {
+		return ""
+	}
+	var description string
+	if err := json.Unmarshal([]byte(encoded), &description); err != nil {
+		log.FromContext(ctx).Error(err, "failed to decode commit status description trailer", "encoded", encoded)
+		return ""
+	}
+	return description
+}
+
+func addCommitStatusTrailers(commitTrailers trailers, prefix string, statuses []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase) error {
+	for _, status := range statuses {
+		commitTrailers[prefix+status.Key+"-phase"] = status.Phase
+		commitTrailers[prefix+status.Key+"-url"] = status.Url
+		if status.Description == "" {
+			continue
+		}
+		encoded, err := encodeTrailerDescription(status.Description)
+		if err != nil {
+			return err
+		}
+		commitTrailers[prefix+status.Key+"-description"] = encoded
+	}
+	return nil
+}
+
 // populateActiveMetadata populates the active metadata for a history entry
 func (r *ChangeTransferPolicyReconciler) populateActiveMetadata(ctx context.Context, h *promoterv1alpha1.History, sha, activePath string, gitOperations *git.EnvironmentOperations) {
 	logger := log.FromContext(ctx)
@@ -364,9 +401,10 @@ func (r *ChangeTransferPolicyReconciler) populateCommitStatuses(ctx context.Cont
 			url = ""
 		}
 		h.Active.CommitStatuses = append(h.Active.CommitStatuses, promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{
-			Key:   key,
-			Phase: getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusActivePrefix+key+"-phase"),
-			Url:   url,
+			Key:         key,
+			Phase:       getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusActivePrefix+key+"-phase"),
+			Url:         url,
+			Description: decodeTrailerDescription(ctx, getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusActivePrefix+key+"-description")),
 		})
 	}
 
@@ -378,9 +416,10 @@ func (r *ChangeTransferPolicyReconciler) populateCommitStatuses(ctx context.Cont
 			url = ""
 		}
 		h.Proposed.CommitStatuses = append(h.Proposed.CommitStatuses, promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{
-			Key:   key,
-			Phase: getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusProposedPrefix+key+"-phase"),
-			Url:   url,
+			Key:         key,
+			Phase:       getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusProposedPrefix+key+"-phase"),
+			Url:         url,
+			Description: decodeTrailerDescription(ctx, getFirstTrailerValue(activeTrailers, constants.TrailerCommitStatusProposedPrefix+key+"-description")),
 		})
 	}
 }
@@ -391,7 +430,7 @@ func getCommitStatusKeysFromTrailers(ctx context.Context, trailers map[string][]
 
 	// This function extracts commit status keys from trailers with the given prefix.
 	// It looks for keys that start with the prefix, trims the prefix, splits by "-", and joins all but the last part to form the commit status key.
-	// This is under the assumption that the last part is always "-phase" or "-url" today and that it does not go over multiple "-" aka the ending can not be
+	// This is under the assumption that the last part is always "-phase", "-url", or "-description" and that it does not go over multiple "-" aka the ending can not be
 	// -what-am-i-doing. This would return a bad key because it would contain -what-am-i.
 	extractKeys := func(prefix string) []string {
 		keys := []string{}
@@ -1224,13 +1263,11 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		commitTrailers[constants.TrailerPullRequestCreationTime] = existingPR.Status.PRCreationTime.Format(time.RFC3339)
 		commitTrailers[constants.TrailerPullRequestUrl] = existingPR.Status.Url
 
-		for _, status := range ctp.Status.Active.CommitStatuses {
-			commitTrailers[constants.TrailerCommitStatusActivePrefix+status.Key+"-phase"] = status.Phase
-			commitTrailers[constants.TrailerCommitStatusActivePrefix+status.Key+"-url"] = status.Url
+		if err := addCommitStatusTrailers(commitTrailers, constants.TrailerCommitStatusActivePrefix, ctp.Status.Active.CommitStatuses); err != nil {
+			return nil, err
 		}
-		for _, status := range ctp.Status.Proposed.CommitStatuses {
-			commitTrailers[constants.TrailerCommitStatusProposedPrefix+status.Key+"-phase"] = status.Phase
-			commitTrailers[constants.TrailerCommitStatusProposedPrefix+status.Key+"-url"] = status.Url
+		if err := addCommitStatusTrailers(commitTrailers, constants.TrailerCommitStatusProposedPrefix, ctp.Status.Proposed.CommitStatuses); err != nil {
+			return nil, err
 		}
 		commitTrailers[constants.TrailerShaHydratedActive] = ctp.Status.Active.Hydrated.Sha
 		commitTrailers[constants.TrailerShaHydratedProposed] = ctp.Status.Proposed.Hydrated.Sha

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1998,3 +1998,65 @@ func changeTransferPolicyResources(ctx context.Context, name, namespace string) 
 
 	return name, scmSecret, scmProvider, gitRepo, commitStatus, changeTransferPolicy
 }
+
+var _ = Describe("commit status description trailers", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("round-trips plain text, newlines, and embedded quotes", func() {
+		for _, original := range []string{
+			"Waiting for approval",
+			"line1\nline2",
+			`say "hello"`,
+		} {
+			encoded, err := encodeTrailerDescription(original)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decodeTrailerDescription(ctx, encoded)).To(Equal(original))
+		}
+	})
+
+	It("returns empty string for empty or malformed encoded values", func() {
+		Expect(decodeTrailerDescription(ctx, "")).To(Equal(""))
+		Expect(decodeTrailerDescription(ctx, "not-json")).To(Equal(""))
+	})
+
+	It("extracts commit status keys from phase, url, and description trailers", func() {
+		trailers := map[string][]string{
+			constants.TrailerCommitStatusActivePrefix + "argocd-health-phase":            {"success"},
+			constants.TrailerCommitStatusActivePrefix + "argocd-health-url":              {"https://example.com"},
+			constants.TrailerCommitStatusActivePrefix + "argocd-health-description":      {`"healthy"`},
+			constants.TrailerCommitStatusProposedPrefix + "no-deployments-allowed-phase": {"pending"},
+		}
+		activeKeys, proposedKeys := getCommitStatusKeysFromTrailers(ctx, trailers)
+		Expect(activeKeys).To(ConsistOf("argocd-health"))
+		Expect(proposedKeys).To(ConsistOf("no-deployments-allowed"))
+	})
+
+	It("populates history commit status descriptions from JSON-encoded trailers", func() {
+		description := "Waiting for hydrator\nsecond line"
+		encoded, err := encodeTrailerDescription(description)
+		Expect(err).NotTo(HaveOccurred())
+
+		trailers := map[string][]string{
+			constants.TrailerCommitStatusActivePrefix + healthCheckCSKey + "-phase":       {"success"},
+			constants.TrailerCommitStatusActivePrefix + healthCheckCSKey + "-url":         {"https://example.com/check"},
+			constants.TrailerCommitStatusActivePrefix + healthCheckCSKey + "-description": {encoded},
+			constants.TrailerCommitStatusProposedPrefix + "gate-phase":                    {"pending"},
+			constants.TrailerCommitStatusProposedPrefix + "gate-description":              {`"proposed description"`},
+		}
+
+		history := promoterv1alpha1.History{}
+		(&ChangeTransferPolicyReconciler{}).populateCommitStatuses(ctx, &history, trailers)
+
+		Expect(history.Active.CommitStatuses).To(HaveLen(1))
+		Expect(history.Active.CommitStatuses[0].Key).To(Equal(healthCheckCSKey))
+		Expect(history.Active.CommitStatuses[0].Description).To(Equal(description))
+
+		Expect(history.Proposed.CommitStatuses).To(HaveLen(1))
+		Expect(history.Proposed.CommitStatuses[0].Key).To(Equal("gate"))
+		Expect(history.Proposed.CommitStatuses[0].Description).To(Equal("proposed description"))
+	})
+})


### PR DESCRIPTION
Reviewing the new history UI PR, I realized it would be really nice to have the CommitStatus description in history. Helps give the user confidence that they're really looking at the state at merge time.

I've opened a separate PR that will ensure this change doesn't introduce any additional PR reconciles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit status information in commit trailers now includes structured descriptions, alongside phase and URL details.
  * Existing pull request commit messages are updated with richer status trailers for both active and proposed environments.

* **Bug Fixes**
  * Commit history reconstruction now correctly restores commit status descriptions from trailers.
  * Improved handling for empty or malformed description trailer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->