### PR TITLE
chore(ci): fix indirect gh client major bump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,11 +136,13 @@ jobs:
       - name: go mod tidy
         run: |
           go mod tidy
-          if ! diff=$(git diff --exit-code --unified=0 -- go.sum); then
-            line=$(echo "$diff" | sed -nr 's/@@ -([0-9]+),.*/\1/p' | head -n 1 | tr -d '\n')
-            echo "::error file=go.sum,line=$line::go.sum is out of date. Run 'go mod tidy' and commit the changes."
-            exit 1
-          fi
+          for file in go.mod go.sum; do
+            if ! diff=$(git diff --exit-code --unified=0 -- "$file"); then
+              line=$(echo "$diff" | sed -nr 's/@@ -([0-9]+),.*/\1/p' | head -n 1 | tr -d '\n')
+              echo "::error file=$file,line=$line::$file is out of date. Run 'go mod tidy' and commit the changes."
+              exit 1
+            fi
+          done
       - name: make mockery-gen
         run: |
           make mockery-gen

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
           go mod tidy
           for file in go.mod go.sum; do
             if ! diff=$(git diff --exit-code --unified=0 -- "$file"); then
-              line=$(echo "$diff" | sed -nr 's/@@ -([0-9]+),.*/\1/p' | head -n 1 | tr -d '\n')
+              line=$(echo "$diff" | sed -nr 's/^@@ -([0-9]+).*/\1/p' | head -n 1 | tr -d '\n')
               echo "::error file=$file,line=$line::$file is out of date. Run 'go mod tidy' and commit the changes."
               exit 1
             fi

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,7 +16,7 @@
   // Run `go mod tidy` natively as part of every gomod artifact update. This is the
   // reliable equivalent of the CI codegen `go mod tidy` check -- unlike a shell
   // postUpgradeTask it needs no allowedCommands entry and uses the go.mod toolchain,
-  // so go.sum is always tidy in the PR (no chicken-and-egg with the allowlist).
+  // so go.mod and go.sum are always tidy in the PR (no chicken-and-egg with the allowlist).
   postUpdateOptions: [
     'gomodTidy',
   ],
@@ -111,15 +111,19 @@
     // Group A2: GitHub API client (go-github major paths + ghinstallation)
     // go-github uses /vNN module paths; Renovate rewrites imports on major jumps.
     // Dependabot ignores these packages to avoid duplicate PRs.
+    // Direct requires only for go-github majors; indirect minors/patches are allowed
+    // but indirect majors are blocked (ghinstallation may lag on the old /vNN path).
     // ----------------------------------------------------------------------
     {
-      description: 'go-github and ghinstallation bump together; rewrite imports on major path changes',
+      description: 'Direct go-github require bumps; rewrite imports on major path changes',
       matchManagers: [
         'gomod',
       ],
       matchPackageNames: [
         'github.com/google/go-github/**',
-        'github.com/bradleyfalzon/ghinstallation/**',
+      ],
+      matchDepTypes: [
+        'require',
       ],
       enabled: true,
       groupName: 'GitHub API client',
@@ -131,6 +135,54 @@
         'gomodUpdateImportPaths',
         'gomodTidy',
       ],
+    },
+    {
+      description: 'ghinstallation bumps with go-github in one PR',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/bradleyfalzon/ghinstallation/**',
+      ],
+      enabled: true,
+      groupName: 'GitHub API client',
+      semanticCommits: 'enabled',
+      semanticCommitType: 'chore',
+      semanticCommitScope: 'deps',
+      automerge: false,
+    },
+    {
+      description: 'Allow patch/minor bumps on transitive go-github module paths',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/google/go-github/**',
+      ],
+      matchDepTypes: [
+        'indirect',
+      ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      enabled: true,
+    },
+    {
+      description: 'Block major/path-change bumps on transitive go-github (e.g. v88 indirect while direct is v89)',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/google/go-github/**',
+      ],
+      matchDepTypes: [
+        'indirect',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
     },
     // ----------------------------------------------------------------------
     // Group A3: E2E Kind node images (ci-e2e matrix; sliding window of minors)


### PR DESCRIPTION
Renovate doesn't handle major upgrades to indirect dependencies well. This breaks down version bumps into a direct/indirect, major/other matrix with appropriate settings for each.

It also has codegen CI check go.mod after `go mod tidy` so we don't miss go.mod-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated checks to verify that both `go.mod` and `go.sum` stay in sync after dependency tidying.
  * Updated dependency update rules so related Go client packages are aligned more consistently, including safer handling for minor updates and major path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->