### PR TITLE
fix(test): eliminate CTP integration test flake caused by webhook race

### DIFF
--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1624,8 +1624,6 @@ var _ = Describe("emitPromotionLifecycleEvents", func() {
 					proposedBranch = changeTransferPolicy.Spec.ProposedBranch
 					g.Expect(proposedBranch).To(Equal(path.Join(testBranchDevelopmentNext, activePathApp)))
 				}, constants.EventuallyTimeout).Should(Succeed())
-
-				waitForCTPSteadyState(ctx, ctpNamespacedName, &changeTransferPolicy)
 			})
 
 			AfterEach(func() {

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1624,6 +1624,8 @@ var _ = Describe("emitPromotionLifecycleEvents", func() {
 					proposedBranch = changeTransferPolicy.Spec.ProposedBranch
 					g.Expect(proposedBranch).To(Equal(path.Join(testBranchDevelopmentNext, activePathApp)))
 				}, constants.EventuallyTimeout).Should(Succeed())
+
+				waitForCTPSteadyState(ctx, ctpNamespacedName, &changeTransferPolicy)
 			})
 
 			AfterEach(func() {

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -92,6 +92,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				Expect(k8sClient.Create(ctx, changeTransferPolicy)).To(Succeed())
 
 				prName = utils.GetPullRequestName(gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name, changeTransferPolicy.Spec.ProposedBranch, changeTransferPolicy.Spec.ActiveBranch)
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -215,6 +217,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -326,6 +330,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -412,6 +418,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -483,17 +491,24 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 		})
 
 		Context("When setting mergeSha field", func() {
+			var name string
 			var scmSecret *v1.Secret
 			var scmProvider *promoterv1alpha1.ScmProvider
 			var gitRepo *promoterv1alpha1.GitRepository
 			var changeTransferPolicy *promoterv1alpha1.ChangeTransferPolicy
+			var typeNamespacedName types.NamespacedName
 			var gitPath string
 			var err error
 			var pr promoterv1alpha1.PullRequest
 			var prName string
 
 			BeforeEach(func() {
-				_, scmSecret, scmProvider, gitRepo, _, changeTransferPolicy = changeTransferPolicyResources(ctx, "ctp-merge-sha", "default")
+				name, scmSecret, scmProvider, gitRepo, _, changeTransferPolicy = changeTransferPolicyResources(ctx, "ctp-merge-sha", "default")
+
+				typeNamespacedName = types.NamespacedName{
+					Name:      name,
+					Namespace: "default",
+				}
 
 				changeTransferPolicy.Spec.ProposedBranch = testBranchDevelopmentNext
 				changeTransferPolicy.Spec.ActiveBranch = testBranchDevelopment
@@ -508,6 +523,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -594,6 +611,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -696,6 +715,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, typeNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -890,6 +911,8 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 
 				gitPath, err = os.MkdirTemp("", "*")
 				Expect(err).NotTo(HaveOccurred())
+
+				waitForCTPSteadyState(ctx, ctpKey, changeTransferPolicy)
 			})
 
 			AfterEach(func() {
@@ -1815,14 +1838,7 @@ var _ = Describe("emitPromotionLifecycleEvents", func() {
 				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
 				Expect(k8sClient.Create(ctx, changeTransferPolicy)).To(Succeed())
 
-				// Wait for the initial reconcile so status.proposed.hydrated.sha is set.
-				// Webhook matching uses that field as the push "before" SHA.
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(ctx, ctpNamespacedName, changeTransferPolicy)).To(Succeed())
-					g.Expect(changeTransferPolicy.Status.Proposed.Hydrated.Sha).NotTo(BeEmpty())
-					g.Expect(changeTransferPolicy.Status.Proposed.Hydrated.Sha).
-						To(Equal(changeTransferPolicy.Status.Active.Hydrated.Sha))
-				}, constants.EventuallyTimeout).Should(Succeed())
+				waitForCTPSteadyState(ctx, ctpNamespacedName, changeTransferPolicy)
 			})
 
 			AfterEach(func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -41,6 +41,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -827,40 +828,41 @@ func buildGitHubWebhookPayload(beforeSha, ref string) string {
 	return string(payloadBytes)
 }
 
-// sendWebhookForPush sends a webhook after a git push to simulate SCM provider behavior
+// waitForCTPSteadyState polls until the CTP's initial reconcile has populated
+// status.proposed.hydrated.sha (required for webhook field-index matching).
+func waitForCTPSteadyState(ctx context.Context, key types.NamespacedName, ctp *promoterv1alpha1.ChangeTransferPolicy) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, ctp)).To(Succeed())
+		g.Expect(ctp.Status.Proposed.Hydrated.Sha).NotTo(BeEmpty())
+		g.Expect(ctp.Status.Proposed.Hydrated.Sha).
+			To(Equal(ctp.Status.Active.Hydrated.Sha))
+	}, constants.EventuallyTimeout).Should(Succeed())
+}
+
+// sendWebhookForPush sends a webhook after a git push to simulate SCM provider behavior.
 func sendWebhookForPush(ctx context.Context, sha, branch string) {
-	// Build GitHub-style webhook payload
+	GinkgoHelper()
+
 	payload := buildGitHubWebhookPayload(sha, "refs/heads/"+branch)
 
-	// Send the webhook request
 	webhookURL := fmt.Sprintf("http://localhost:%d/", webhookReceiverPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewBufferString(payload))
-	if err != nil {
-		// Don't fail the test if webhook fails - log it instead
-		fmt.Printf("Failed to create webhook request: %v\n", err)
-		return
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to create webhook request")
 
-	// Set GitHub webhook headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Github-Event", "push")
 	req.Header.Set("X-Github-Delivery", fmt.Sprintf("test-delivery-%d", time.Now().Unix()))
 
-	// Send the request
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	resp, err := httpClient.Do(req)
-	if err != nil {
-		// Don't fail the test if webhook fails - log it instead
-		fmt.Printf("Failed to send webhook request: %v\n", err)
-		return
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to send webhook request")
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode != http.StatusNoContent {
-		fmt.Printf("Webhook receiver returned unexpected status code: %d\n", resp.StatusCode)
-	}
+	Expect(resp.StatusCode).To(Equal(http.StatusNoContent),
+		fmt.Sprintf("webhook receiver returned unexpected status %d for sha=%s branch=%s", resp.StatusCode, sha, branch))
 }
 
 // cloneTestRepo clones the test repo for gitRepo.Spec.Fake and configures git user. Returns the temp directory path.
@@ -1251,6 +1253,7 @@ func hydrateEnvironmentsBatchedTargets(ctx context.Context, repo *promoterv1alph
 	for i := range targets {
 		target := targets[i]
 		g.Go(func() error {
+			defer GinkgoRecover()
 			gp, err := cloneTestRepo(gctx, repo)
 			if err != nil {
 				return fmt.Errorf("failed to clone for branch %q: %w", target.Branch, err)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -830,6 +830,11 @@ func buildGitHubWebhookPayload(beforeSha, ref string) string {
 
 // waitForCTPSteadyState polls until the CTP's initial reconcile has populated
 // status.proposed.hydrated.sha (required for webhook field-index matching).
+//
+// Call this at the end of BeforeEach for tests that push changes and rely on a
+// webhook event to be picked up for the test to proceed quickly. If you don't
+// call this first, the webhook might send too early, and the `before` sha won't
+// match the CTP state.
 func waitForCTPSteadyState(ctx context.Context, key types.NamespacedName, ctp *promoterv1alpha1.ChangeTransferPolicy) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
## Summary

Fixes #1761

The CTP integration tests intermittently fail with `Timed out after 90.000s` waiting for `status.proposed.hydrated.sha` to update, because the webhook fires before the initial reconcile has populated the field index — causing a silent no-op (204) and leaving the test stuck waiting for a 5-min requeue that never arrives within the 90s timeout.

### Changes

- Extract `waitForCTPSteadyState` helper and call it in all 8 direct-CTP `BeforeEach` blocks so the initial reconcile populates `status.proposed.hydrated.sha` before any webhook fires
- The ActivePath CTP context is intentionally excluded — it uses orphan environment branches with no initial hydrated state, so the steady-state guard does not apply
- Make `sendWebhookForPush` strict (`Expect` assertions instead of `fmt.Printf` + silent return) — with the guards in place, webhook failures are real errors
- Add `defer GinkgoRecover()` to the `hydrateEnvironmentsBatchedTargets` errgroup goroutine that calls `sendWebhookForPush`

## Root cause

`makeChangeAndHydrateRepo` calls `sendWebhookForPush` which queries CTP by `status.proposed.hydrated.sha` field index. If the initial reconcile hasn't populated that field yet, the webhook silently no-ops (204), the test relies on a 5-min requeue but has a 90s timeout → flake.

## Test plan

- [x] `make test-parallel-repeat3` — all 10 suites pass across 3 iterations, 0 failures
- [x] `make build-installer fmt vet lint deadcode build` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved controller and end-to-end test stability by waiting for transfer policies to reach a steady state before assertions.
  * Standardized webhook response validation to require a successful `204 No Content` response.
  * Improved error and panic handling during concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->