### PR TITLE
fix: un-minimize RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,13 +41,10 @@ rules:
   - promoter.argoproj.io
   resources:
   - argocdcommitstatuses
-  - clusterscmproviders
   - controllerconfigurations
   - gitcommitstatuses
-  - gitrepositories
   - promotionstrategies
   - revertcommits
-  - scmproviders
   - timedcommitstatuses
   - webrequestcommitstatuses
   verbs:
@@ -92,8 +89,30 @@ rules:
   - promoter.argoproj.io
   resources:
   - changetransferpolicies
-  - commitstatuses
   - pullrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - clusterscmproviders
+  - gitrepositories
+  - scmproviders
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - commitstatuses
   verbs:
   - create
   - delete

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -8011,13 +8011,10 @@ rules:
   - promoter.argoproj.io
   resources:
   - argocdcommitstatuses
-  - clusterscmproviders
   - controllerconfigurations
   - gitcommitstatuses
-  - gitrepositories
   - promotionstrategies
   - revertcommits
-  - scmproviders
   - timedcommitstatuses
   - webrequestcommitstatuses
   verbs:
@@ -8062,8 +8059,30 @@ rules:
   - promoter.argoproj.io
   resources:
   - changetransferpolicies
-  - commitstatuses
   - pullrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - clusterscmproviders
+  - gitrepositories
+  - scmproviders
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - commitstatuses
   verbs:
   - create
   - delete

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -8011,13 +8011,10 @@ rules:
   - promoter.argoproj.io
   resources:
   - argocdcommitstatuses
-  - clusterscmproviders
   - controllerconfigurations
   - gitcommitstatuses
-  - gitrepositories
   - promotionstrategies
   - revertcommits
-  - scmproviders
   - timedcommitstatuses
   - webrequestcommitstatuses
   verbs:
@@ -8062,8 +8059,30 @@ rules:
   - promoter.argoproj.io
   resources:
   - changetransferpolicies
-  - commitstatuses
   - pullrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - clusterscmproviders
+  - gitrepositories
+  - scmproviders
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - commitstatuses
   verbs:
   - create
   - delete

--- a/dist/install-without-ui.yaml
+++ b/dist/install-without-ui.yaml
@@ -7964,13 +7964,10 @@ rules:
   - promoter.argoproj.io
   resources:
   - argocdcommitstatuses
-  - clusterscmproviders
   - controllerconfigurations
   - gitcommitstatuses
-  - gitrepositories
   - promotionstrategies
   - revertcommits
-  - scmproviders
   - timedcommitstatuses
   - webrequestcommitstatuses
   verbs:
@@ -8015,8 +8012,30 @@ rules:
   - promoter.argoproj.io
   resources:
   - changetransferpolicies
-  - commitstatuses
   - pullrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - clusterscmproviders
+  - gitrepositories
+  - scmproviders
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - promoter.argoproj.io
+  resources:
+  - commitstatuses
   verbs:
   - create
   - delete

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -86,7 +86,7 @@ func (r *ChangeTransferPolicyReconciler) GetEnqueueFunc() CTPEnqueueFunc {
 	return r.enqueueFunc
 }
 
-//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=changetransferpolicies,verbs=get;list;watch
+//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=changetransferpolicies,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=changetransferpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=changetransferpolicies/finalizers,verbs=update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests,verbs=get;list;watch;patch;create

--- a/internal/controller/clusterscmprovider_controller.go
+++ b/internal/controller/clusterscmprovider_controller.go
@@ -49,7 +49,7 @@ type ClusterScmProviderReconciler struct {
 	SettingsMgr *settings.Manager
 }
 
-// +kubebuilder:rbac:groups=promoter.argoproj.io,resources=clusterscmproviders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=promoter.argoproj.io,resources=clusterscmproviders,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=clusterscmproviders/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=clusterscmproviders/finalizers,verbs=update
 // +kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories,verbs=get;list;watch

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -47,7 +47,7 @@ type GitRepositoryReconciler struct {
 	Recorder events.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories,verbs=get;list;watch
+//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories/finalizers,verbs=update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests,verbs=get;list;watch

--- a/internal/controller/pullrequest_controller.go
+++ b/internal/controller/pullrequest_controller.go
@@ -78,7 +78,7 @@ func (r *PullRequestReconciler) GetEnqueueFunc() PREnqueueFunc {
 	return r.enqueueFunc
 }
 
-//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests,verbs=get;list;watch;delete;update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=pullrequests/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch

--- a/internal/controller/scmprovider_controller.go
+++ b/internal/controller/scmprovider_controller.go
@@ -47,7 +47,7 @@ type ScmProviderReconciler struct {
 	Recorder events.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=scmproviders,verbs=get;list;watch
+//+kubebuilder:rbac:groups=promoter.argoproj.io,resources=scmproviders,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=scmproviders/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=scmproviders/finalizers,verbs=update
 //+kubebuilder:rbac:groups=promoter.argoproj.io,resources=gitrepositories,verbs=get;list;watch


### PR DESCRIPTION
I trusted the LLMs too much. The `/finalizer` permission in RBAC does _not_ satisfy the requirements to make an `/update` call adding/removing a finalizer. You need full `update` for that on CRDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Permissions**
  * Updated access controls to support updating change transfer policies, cluster SCM providers, Git repositories, pull requests, and SCM providers.
  * Expanded access to related resource status, finalizer, and pull request data.
  * Retained existing permissions for commit status operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->