### PR TITLE
feat(SCS): add SCS to view and add tests

### DIFF
--- a/api/view/v1alpha1/types.go
+++ b/api/view/v1alpha1/types.go
@@ -63,6 +63,9 @@ type PromotionStrategyDetails struct {
 	// WebRequestCommitStatuses are the WebRequestCommitStatus managers that reference the PromotionStrategy.
 	WebRequestCommitStatuses []promoterv1alpha1.WebRequestCommitStatus `json:"webRequestCommitStatuses,omitempty"`
 
+	// ScheduledCommitStatuses are the ScheduledCommitStatus managers that reference the PromotionStrategy.
+	ScheduledCommitStatuses []promoterv1alpha1.ScheduledCommitStatus `json:"scheduledCommitStatuses,omitempty"`
+
 	// GitRepository is the GitRepository referenced by the PromotionStrategy, if resolvable.
 	GitRepository *promoterv1alpha1.GitRepository `json:"gitRepository,omitempty"`
 

--- a/api/view/v1alpha1/zz_generated.deepcopy.go
+++ b/api/view/v1alpha1/zz_generated.deepcopy.go
@@ -80,6 +80,13 @@ func (in *PromotionStrategyDetails) DeepCopyInto(out *PromotionStrategyDetails) 
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ScheduledCommitStatuses != nil {
+		in, out := &in.ScheduledCommitStatuses, &out.ScheduledCommitStatuses
+		*out = make([]apiv1alpha1.ScheduledCommitStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.GitRepository != nil {
 		in, out := &in.GitRepository, &out.GitRepository
 		*out = new(apiv1alpha1.GitRepository)

--- a/api/view/v1alpha1/zz_generated.openapi.go
+++ b/api/view/v1alpha1/zz_generated.openapi.go
@@ -6289,6 +6289,19 @@ func schema_gitops_promoter_api_view_v1alpha1_PromotionStrategyDetails(ref commo
 							},
 						},
 					},
+					"scheduledCommitStatuses": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScheduledCommitStatuses are the ScheduledCommitStatus managers that reference the PromotionStrategy.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref(apiv1alpha1.ScheduledCommitStatus{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
 					"gitRepository": {
 						SchemaProps: spec.SchemaProps{
 							Description: "GitRepository is the GitRepository referenced by the PromotionStrategy, if resolvable.",
@@ -6312,7 +6325,7 @@ func schema_gitops_promoter_api_view_v1alpha1_PromotionStrategyDetails(ref commo
 			},
 		},
 		Dependencies: []string{
-			apiv1alpha1.ArgoCDCommitStatus{}.OpenAPIModelName(), apiv1alpha1.ChangeTransferPolicy{}.OpenAPIModelName(), apiv1alpha1.ClusterScmProvider{}.OpenAPIModelName(), apiv1alpha1.CommitStatus{}.OpenAPIModelName(), apiv1alpha1.GitCommitStatus{}.OpenAPIModelName(), apiv1alpha1.GitRepository{}.OpenAPIModelName(), apiv1alpha1.PromotionStrategy{}.OpenAPIModelName(), apiv1alpha1.PullRequest{}.OpenAPIModelName(), apiv1alpha1.ScmProvider{}.OpenAPIModelName(), apiv1alpha1.TimedCommitStatus{}.OpenAPIModelName(), apiv1alpha1.WebRequestCommitStatus{}.OpenAPIModelName(), metav1.ObjectMeta{}.OpenAPIModelName()},
+			apiv1alpha1.ArgoCDCommitStatus{}.OpenAPIModelName(), apiv1alpha1.ChangeTransferPolicy{}.OpenAPIModelName(), apiv1alpha1.ClusterScmProvider{}.OpenAPIModelName(), apiv1alpha1.CommitStatus{}.OpenAPIModelName(), apiv1alpha1.GitCommitStatus{}.OpenAPIModelName(), apiv1alpha1.GitRepository{}.OpenAPIModelName(), apiv1alpha1.PromotionStrategy{}.OpenAPIModelName(), apiv1alpha1.PullRequest{}.OpenAPIModelName(), apiv1alpha1.ScheduledCommitStatus{}.OpenAPIModelName(), apiv1alpha1.ScmProvider{}.OpenAPIModelName(), apiv1alpha1.TimedCommitStatus{}.OpenAPIModelName(), apiv1alpha1.WebRequestCommitStatus{}.OpenAPIModelName(), metav1.ObjectMeta{}.OpenAPIModelName()},
 	}
 }
 

--- a/config/apiserver/base/rbac.yaml
+++ b/config/apiserver/base/rbac.yaml
@@ -20,6 +20,7 @@ rules:
       - gitcommitstatuses
       - timedcommitstatuses
       - webrequestcommitstatuses
+      - scheduledcommitstatuses
       - gitrepositories
       - scmproviders
       - clusterscmproviders

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -8538,6 +8538,7 @@ rules:
   - gitcommitstatuses
   - timedcommitstatuses
   - webrequestcommitstatuses
+  - scheduledcommitstatuses
   - gitrepositories
   - scmproviders
   - clusterscmproviders

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -8538,6 +8538,7 @@ rules:
   - gitcommitstatuses
   - timedcommitstatuses
   - webrequestcommitstatuses
+  - scheduledcommitstatuses
   - gitrepositories
   - scmproviders
   - clusterscmproviders

--- a/internal/apiserver/builder.go
+++ b/internal/apiserver/builder.go
@@ -129,6 +129,12 @@ func buildBundle(ctx context.Context, reader client.Reader, namespace, name, res
 	}
 	bundle.WebRequestCommitStatuses = nilIfEmpty(webReqCSList.Items)
 
+	scheduledCSList := &promoterv1alpha1.ScheduledCommitStatusList{}
+	if err := reader.List(ctx, scheduledCSList, client.InNamespace(namespace), client.MatchingFields{controller.PromotionStrategyRefField: name}); err != nil {
+		return nil, fmt.Errorf("failed to list ScheduledCommitStatuses: %w", err)
+	}
+	bundle.ScheduledCommitStatuses = nilIfEmpty(scheduledCSList.Items)
+
 	// Git config: GitRepository -> ScmProvider / ClusterScmProvider.
 	// The credentials Secret referenced by the provider is intentionally never read.
 	if err := attachGitConfig(ctx, reader, namespace, ps, bundle); err != nil {

--- a/internal/apiserver/builder_test.go
+++ b/internal/apiserver/builder_test.go
@@ -54,12 +54,7 @@ func psLabeledMeta(name string) metav1.ObjectMeta {
 // newFakeClientBuilder returns a fake client builder with gate promotionStrategyRef field indexes.
 func newFakeClientBuilder() *fake.ClientBuilder {
 	b := fake.NewClientBuilder().WithScheme(utils.GetScheme())
-	for _, obj := range []client.Object{
-		&promoterv1alpha1.ArgoCDCommitStatus{},
-		&promoterv1alpha1.GitCommitStatus{},
-		&promoterv1alpha1.TimedCommitStatus{},
-		&promoterv1alpha1.WebRequestCommitStatus{},
-	} {
+	for _, obj := range controller.GateCommitStatusKinds() {
 		b = b.WithIndex(obj, controller.PromotionStrategyRefField, controller.PromotionStrategyRefIndexValues)
 	}
 	return b
@@ -131,6 +126,10 @@ func seedObjects() []client.Object {
 			ObjectMeta: objectMeta("web-1"),
 			Spec:       promoterv1alpha1.WebRequestCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: testPSName}},
 		},
+		&promoterv1alpha1.ScheduledCommitStatus{
+			ObjectMeta: objectMeta("scheduled-1"),
+			Spec:       promoterv1alpha1.ScheduledCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: testPSName}},
+		},
 		&promoterv1alpha1.GitRepository{
 			ObjectMeta: objectMeta("my-repo"),
 			Spec: promoterv1alpha1.GitRepositorySpec{
@@ -186,6 +185,8 @@ var _ = Describe("BuildBundle", func() {
 		Expect(bundle.GitCommitStatuses).To(HaveLen(1))
 		Expect(bundle.TimedCommitStatuses).To(HaveLen(1))
 		Expect(bundle.WebRequestCommitStatuses).To(HaveLen(1))
+		Expect(bundle.ScheduledCommitStatuses).To(HaveLen(1))
+		Expect(bundle.ScheduledCommitStatuses[0].Name).To(Equal("scheduled-1"))
 
 		By("resolving git config but never the Secret")
 		Expect(bundle.GitRepository).NotTo(BeNil())

--- a/internal/apiserver/index.go
+++ b/internal/apiserver/index.go
@@ -110,18 +110,15 @@ func (p *BundleProvider) currentResourceVersion() string {
 
 // childKinds are all resource kinds whose changes can affect a bundle.
 func (p *BundleProvider) childKinds() []client.Object {
-	kinds := []client.Object{
+	return append([]client.Object{
 		&promoterv1alpha1.PromotionStrategy{},
 		&promoterv1alpha1.ChangeTransferPolicy{},
 		&promoterv1alpha1.PullRequest{},
 		&promoterv1alpha1.CommitStatus{},
-	}
-	kinds = append(kinds, controller.GateCommitStatusKinds()...)
-	return append(kinds,
 		&promoterv1alpha1.GitRepository{},
 		&promoterv1alpha1.ScmProvider{},
 		&promoterv1alpha1.ClusterScmProvider{},
-	)
+	}, controller.GateCommitStatusKinds()...)
 }
 
 // SetupInformers registers event handlers for all child kinds so that any change

--- a/internal/apiserver/index.go
+++ b/internal/apiserver/index.go
@@ -37,6 +37,7 @@ import (
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	viewv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/view/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/controller"
 )
 
 var log = ctrl.Log.WithName("dashboard-apiserver")
@@ -109,19 +110,18 @@ func (p *BundleProvider) currentResourceVersion() string {
 
 // childKinds are all resource kinds whose changes can affect a bundle.
 func (p *BundleProvider) childKinds() []client.Object {
-	return []client.Object{
+	kinds := []client.Object{
 		&promoterv1alpha1.PromotionStrategy{},
 		&promoterv1alpha1.ChangeTransferPolicy{},
 		&promoterv1alpha1.PullRequest{},
 		&promoterv1alpha1.CommitStatus{},
-		&promoterv1alpha1.ArgoCDCommitStatus{},
-		&promoterv1alpha1.GitCommitStatus{},
-		&promoterv1alpha1.TimedCommitStatus{},
-		&promoterv1alpha1.WebRequestCommitStatus{},
+	}
+	kinds = append(kinds, controller.GateCommitStatusKinds()...)
+	return append(kinds,
 		&promoterv1alpha1.GitRepository{},
 		&promoterv1alpha1.ScmProvider{},
 		&promoterv1alpha1.ClusterScmProvider{},
-	}
+	)
 }
 
 // SetupInformers registers event handlers for all child kinds so that any change
@@ -248,14 +248,6 @@ func (p *BundleProvider) mapObjectToPromotionStrategies(ctx context.Context, obj
 		return keyFromLabel(o.Namespace, o.Labels)
 	case *promoterv1alpha1.CommitStatus:
 		return keyFromLabel(o.Namespace, o.Labels)
-	case *promoterv1alpha1.ArgoCDCommitStatus:
-		return keyFromRef(o.Namespace, o.Spec.PromotionStrategyRef.Name)
-	case *promoterv1alpha1.GitCommitStatus:
-		return keyFromRef(o.Namespace, o.Spec.PromotionStrategyRef.Name)
-	case *promoterv1alpha1.TimedCommitStatus:
-		return keyFromRef(o.Namespace, o.Spec.PromotionStrategyRef.Name)
-	case *promoterv1alpha1.WebRequestCommitStatus:
-		return keyFromRef(o.Namespace, o.Spec.PromotionStrategyRef.Name)
 	case *promoterv1alpha1.GitRepository:
 		return p.keysReferencingGitRepository(ctx, o.Namespace, o.Name)
 	case *promoterv1alpha1.ScmProvider:
@@ -263,6 +255,11 @@ func (p *BundleProvider) mapObjectToPromotionStrategies(ctx context.Context, obj
 	case *promoterv1alpha1.ClusterScmProvider:
 		return p.keysReferencingScmProvider(ctx, "ClusterScmProvider", "", o.Name)
 	default:
+		// PromotionStrategyRef gate managers (ArgoCD/Git/Timed/WebRequest/Scheduled
+		// CommitStatus, and any future gate with Spec.PromotionStrategyRef).
+		if name := controller.PromotionStrategyRefName(obj); name != "" {
+			return keyFromRef(obj.GetNamespace(), name)
+		}
 		return nil
 	}
 }

--- a/internal/apiserver/index_test.go
+++ b/internal/apiserver/index_test.go
@@ -125,6 +125,12 @@ var _ = Describe("mapObjectToPromotionStrategies", func() {
 				Spec:       promoterv1alpha1.WebRequestCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: testPSName}},
 			},
 			[]types.NamespacedName{psKey}),
+		Entry("ScheduledCommitStatus by ref",
+			&promoterv1alpha1.ScheduledCommitStatus{
+				ObjectMeta: objectMeta("scheduled"),
+				Spec:       promoterv1alpha1.ScheduledCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: testPSName}},
+			},
+			[]types.NamespacedName{psKey}),
 		Entry("GitRepository reverse lookup",
 			&promoterv1alpha1.GitRepository{ObjectMeta: objectMeta("my-repo")},
 			[]types.NamespacedName{psKey}),

--- a/internal/apiserver/view_added_test.go
+++ b/internal/apiserver/view_added_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	viewv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/view/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/controller"
+)
+
+// GateCommitStatusKinds is discovered from the promoter scheme (any type with
+// Spec.PromotionStrategyRef). These specs assert the view aggregate still wires
+// each discovered gate into PromotionStrategyDetails / buildBundle / watches /
+// PS mapping — the parts that cannot be inferred automatically.
+//
+// When you add a new gate CRD with Spec.PromotionStrategyRef:
+//  1. Register it with SchemeBuilder (discovery picks it up automatically)
+//  2. Add a []T field on PromotionStrategyDetails
+//  3. List it in buildBundle
+var _ = Describe("Gate commit-status managers stay in sync with the view aggregate", func() {
+	It("discovers at least the known PromotionStrategyRef gate kinds", func() {
+		got := map[string]struct{}{}
+		for _, gate := range controller.GateCommitStatusKinds() {
+			got[reflect.TypeOf(gate).Elem().Name()] = struct{}{}
+		}
+		for _, want := range []string{
+			"ArgoCDCommitStatus",
+			"GitCommitStatus",
+			"TimedCommitStatus",
+			"WebRequestCommitStatus",
+			"ScheduledCommitStatus",
+		} {
+			Expect(got).To(HaveKey(want),
+				"scheme discovery should find %s (does the type have Spec.PromotionStrategyRef and SchemeBuilder.Register?)", want)
+		}
+	})
+
+	It("exposes every discovered gate kind on PromotionStrategyDetails", func() {
+		viewFields := promotionStrategyDetailsGateSliceFields()
+		for _, gate := range controller.GateCommitStatusKinds() {
+			elemType := reflect.TypeOf(gate).Elem()
+			_, ok := viewFields[elemType]
+			Expect(ok).To(BeTrue(),
+				"PromotionStrategyDetails is missing a []%s field for gate %T; add it to api/view/v1alpha1/types.go and regenerate the view OpenAPI",
+				elemType.Name(), gate)
+		}
+	})
+
+	It("watches every discovered gate kind as a child kind", func() {
+		watched := map[reflect.Type]struct{}{}
+		for _, kind := range newProviderWithReader(newFakeReader()).childKinds() {
+			watched[reflect.TypeOf(kind)] = struct{}{}
+		}
+		for _, gate := range controller.GateCommitStatusKinds() {
+			Expect(watched).To(HaveKey(reflect.TypeOf(gate)),
+				"childKinds() is missing gate %T; include controller.GateCommitStatusKinds() in BundleProvider.childKinds", gate)
+		}
+	})
+
+	It("maps every discovered gate kind back to its PromotionStrategy", func() {
+		provider := newProviderWithReader(newFakeReader(mappingSeed()...))
+		psKey := types.NamespacedName{Namespace: testNamespace, Name: testPSName}
+
+		for _, proto := range controller.GateCommitStatusKinds() {
+			gate := proto.DeepCopyObject().(client.Object)
+			gate.SetName(fmt.Sprintf("gate-%s", reflect.TypeOf(gate).Elem().Name()))
+			gate.SetNamespace(testNamespace)
+			setPromotionStrategyRefName(gate, testPSName)
+
+			Expect(controller.PromotionStrategyRefIndexValues(gate)).To(Equal([]string{testPSName}),
+				"PromotionStrategyRefIndexValues must handle %T", gate)
+			Expect(provider.mapObjectToPromotionStrategies(context.Background(), gate)).To(Equal([]types.NamespacedName{psKey}),
+				"mapObjectToPromotionStrategies must handle %T", gate)
+		}
+	})
+
+	It("includes every discovered gate kind when building a bundle", func() {
+		objs := []client.Object{
+			&promoterv1alpha1.PromotionStrategy{
+				ObjectMeta: metav1.ObjectMeta{Name: testPSName, Namespace: testNamespace, UID: testPSUID},
+				Spec: promoterv1alpha1.PromotionStrategySpec{
+					Environments: []promoterv1alpha1.Environment{{Branch: "environment/dev"}},
+				},
+			},
+		}
+		for _, proto := range controller.GateCommitStatusKinds() {
+			gate := proto.DeepCopyObject().(client.Object)
+			gate.SetName(fmt.Sprintf("gate-%s", reflect.TypeOf(gate).Elem().Name()))
+			gate.SetNamespace(testNamespace)
+			setPromotionStrategyRefName(gate, testPSName)
+			objs = append(objs, gate)
+		}
+
+		bundle, err := buildBundle(context.Background(), newFakeReader(objs...), testNamespace, testPSName, "1")
+		Expect(err).NotTo(HaveOccurred())
+
+		viewFields := promotionStrategyDetailsGateSliceFields()
+		bundleVal := reflect.ValueOf(bundle).Elem()
+		for _, proto := range controller.GateCommitStatusKinds() {
+			elemType := reflect.TypeOf(proto).Elem()
+			fieldName := viewFields[elemType]
+			Expect(fieldName).NotTo(BeEmpty())
+			slice := bundleVal.FieldByName(fieldName)
+			Expect(slice.IsValid()).To(BeTrue())
+			Expect(slice.Len()).To(Equal(1),
+				"buildBundle did not include %s (field %s); list the gate kind in internal/apiserver/builder.go",
+				elemType.Name(), fieldName)
+		}
+	})
+})
+
+// promotionStrategyDetailsGateSliceFields maps gate element types (e.g.
+// promoterv1alpha1.TimedCommitStatus) to the PromotionStrategyDetails field name
+// that holds []T for that gate.
+func promotionStrategyDetailsGateSliceFields() map[reflect.Type]string {
+	detailsType := reflect.TypeOf(viewv1alpha1.PromotionStrategyDetails{})
+	out := make(map[reflect.Type]string)
+	for i := 0; i < detailsType.NumField(); i++ {
+		field := detailsType.Field(i)
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		out[field.Type.Elem()] = field.Name
+	}
+	return out
+}
+
+// setPromotionStrategyRefName sets spec.promotionStrategyRef.name on a gate object.
+func setPromotionStrategyRefName(obj client.Object, name string) {
+	spec := reflect.ValueOf(obj).Elem().FieldByName("Spec")
+	Expect(spec.IsValid()).To(BeTrue(), "%T has no Spec field", obj)
+	ref := spec.FieldByName("PromotionStrategyRef")
+	Expect(ref.IsValid()).To(BeTrue(), "%T.Spec has no PromotionStrategyRef field", obj)
+	nameField := ref.FieldByName("Name")
+	Expect(nameField.CanSet()).To(BeTrue(), "%T.Spec.PromotionStrategyRef.Name is not settable", obj)
+	nameField.SetString(name)
+}

--- a/internal/apiserver/view_added_test.go
+++ b/internal/apiserver/view_added_test.go
@@ -18,18 +18,29 @@ package apiserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
+	goruntime "runtime"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	viewv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/view/v1alpha1"
 	"github.com/argoproj-labs/gitops-promoter/internal/controller"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
 // GateCommitStatusKinds is discovered from the promoter scheme (any type with
@@ -41,6 +52,7 @@ import (
 //  1. Register it with SchemeBuilder (discovery picks it up automatically)
 //  2. Add a []T field on PromotionStrategyDetails
 //  3. List it in buildBundle
+//  4. Add the resource plural to config/apiserver/base/rbac.yaml (promoter-apiserver)
 var _ = Describe("Gate commit-status managers stay in sync with the view aggregate", func() {
 	It("discovers at least the known PromotionStrategyRef gate kinds", func() {
 		got := map[string]struct{}{}
@@ -131,6 +143,18 @@ var _ = Describe("Gate commit-status managers stay in sync with the view aggrega
 				elemType.Name(), fieldName)
 		}
 	})
+
+	It("grants the apiserver ClusterRole read access to every discovered gate kind", func() {
+		scheme := utils.GetScheme()
+		resources := apiserverClusterRoleResources()
+		for _, proto := range controller.GateCommitStatusKinds() {
+			gvk, err := apiutil.GVKForObject(proto, scheme)
+			Expect(err).NotTo(HaveOccurred())
+			plural := gateResourcePlural(gvk)
+			Expect(resources).To(ContainElement(plural),
+				"%s: add %q to promoter-apiserver ClusterRole resources (config/apiserver/base/rbac.yaml)", gvk.Kind, plural)
+		}
+	})
 })
 
 // promotionStrategyDetailsGateSliceFields maps gate element types (e.g.
@@ -158,4 +182,47 @@ func setPromotionStrategyRefName(obj client.Object, name string) {
 	nameField := ref.FieldByName("Name")
 	Expect(nameField.CanSet()).To(BeTrue(), "%T.Spec.PromotionStrategyRef.Name is not settable", obj)
 	nameField.SetString(name)
+}
+
+// gateResourcePlural returns the CRD plural for a gate kind (…Status → …statuses).
+func gateResourcePlural(gvk schema.GroupVersionKind) string {
+	return strings.ToLower(gvk.Kind) + "es"
+}
+
+// apiserverClusterRoleResources returns the promoter.argoproj.io resources listed
+// on the promoter-apiserver ClusterRole in config/apiserver/base/rbac.yaml.
+//
+// TODO: automatically generate this RBAC instead of relying on the user to update it.
+func apiserverClusterRoleResources() []string {
+	_, thisFile, _, ok := goruntime.Caller(0)
+	Expect(ok).To(BeTrue())
+	path := filepath.Join(filepath.Dir(thisFile), "..", "..", "config", "apiserver", "base", "rbac.yaml")
+
+	raw, err := os.ReadFile(path)
+	Expect(err).NotTo(HaveOccurred(), "read %s", path)
+
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(string(raw)), 4096)
+	for {
+		var role rbacv1.ClusterRole
+		err := decoder.Decode(&role)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		Expect(err).NotTo(HaveOccurred(), "decode %s", path)
+		if role.Name != "promoter-apiserver" {
+			continue
+		}
+		var resources []string
+		for _, rule := range role.Rules {
+			for _, group := range rule.APIGroups {
+				if group != "promoter.argoproj.io" {
+					continue
+				}
+				resources = append(resources, rule.Resources...)
+			}
+		}
+		return resources
+	}
+	Fail(fmt.Sprintf("ClusterRole promoter-apiserver not found in %s", path))
+	return nil
 }

--- a/internal/apiserver/view_added_test.go
+++ b/internal/apiserver/view_added_test.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -221,6 +220,6 @@ func apiserverClusterRoleResources() []string {
 		}
 		return resources
 	}
-	Fail(fmt.Sprintf("ClusterRole promoter-apiserver not found in %s", path))
+	Fail("ClusterRole promoter-apiserver not found in " + path)
 	return nil
 }

--- a/internal/apiserver/view_added_test.go
+++ b/internal/apiserver/view_added_test.go
@@ -18,7 +18,6 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -85,9 +84,8 @@ var _ = Describe("Gate commit-status managers stay in sync with the view aggrega
 		provider := newProviderWithReader(newFakeReader(mappingSeed()...))
 		psKey := types.NamespacedName{Namespace: testNamespace, Name: testPSName}
 
-		for _, proto := range controller.GateCommitStatusKinds() {
-			gate := proto.DeepCopyObject().(client.Object)
-			gate.SetName(fmt.Sprintf("gate-%s", reflect.TypeOf(gate).Elem().Name()))
+		for _, gate := range controller.GateCommitStatusKinds() {
+			gate.SetName("gate-" + reflect.TypeOf(gate).Elem().Name())
 			gate.SetNamespace(testNamespace)
 			setPromotionStrategyRefName(gate, testPSName)
 
@@ -99,17 +97,16 @@ var _ = Describe("Gate commit-status managers stay in sync with the view aggrega
 	})
 
 	It("includes every discovered gate kind when building a bundle", func() {
-		objs := []client.Object{
-			&promoterv1alpha1.PromotionStrategy{
-				ObjectMeta: metav1.ObjectMeta{Name: testPSName, Namespace: testNamespace, UID: testPSUID},
-				Spec: promoterv1alpha1.PromotionStrategySpec{
-					Environments: []promoterv1alpha1.Environment{{Branch: "environment/dev"}},
-				},
+		gates := controller.GateCommitStatusKinds()
+		objs := make([]client.Object, 0, 1+len(gates))
+		objs = append(objs, &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: testPSName, Namespace: testNamespace, UID: testPSUID},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				Environments: []promoterv1alpha1.Environment{{Branch: "environment/dev"}},
 			},
-		}
-		for _, proto := range controller.GateCommitStatusKinds() {
-			gate := proto.DeepCopyObject().(client.Object)
-			gate.SetName(fmt.Sprintf("gate-%s", reflect.TypeOf(gate).Elem().Name()))
+		})
+		for _, gate := range gates {
+			gate.SetName("gate-" + reflect.TypeOf(gate).Elem().Name())
 			gate.SetNamespace(testNamespace)
 			setPromotionStrategyRefName(gate, testPSName)
 			objs = append(objs, gate)
@@ -120,7 +117,7 @@ var _ = Describe("Gate commit-status managers stay in sync with the view aggrega
 
 		viewFields := promotionStrategyDetailsGateSliceFields()
 		bundleVal := reflect.ValueOf(bundle).Elem()
-		for _, proto := range controller.GateCommitStatusKinds() {
+		for _, proto := range gates {
 			elemType := reflect.TypeOf(proto).Elem()
 			fieldName := viewFields[elemType]
 			Expect(fieldName).NotTo(BeEmpty())

--- a/internal/controller/fieldindex.go
+++ b/internal/controller/fieldindex.go
@@ -19,45 +19,136 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // PromotionStrategyRefField is the cache field index path for gate CRDs that
 // reference a PromotionStrategy via spec.promotionStrategyRef.name.
 const PromotionStrategyRefField = ".spec.promotionStrategyRef.name"
 
+var (
+	gateCommitStatusKindsOnce sync.Once
+	gateCommitStatusKinds     []client.Object
+)
+
+// GateCommitStatusKinds returns the commit-status gate CRD kinds that reference a
+// PromotionStrategy via spec.promotionStrategyRef.name.
+//
+// Kinds are discovered from the promoter scheme (any non-List type whose Spec has
+// a PromotionStrategyRef field), so adding a new gate CRD automatically includes
+// it here once it is registered with SchemeBuilder. The view aggregation layer
+// still needs a []T field and a buildBundle list; see the view added tests in
+// internal/apiserver/view_added_test.go.
+func GateCommitStatusKinds() []client.Object {
+	gateCommitStatusKindsOnce.Do(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(promoterv1alpha1.AddToScheme(scheme))
+		gateCommitStatusKinds = discoverPromotionStrategyRefGateKinds(scheme)
+	})
+	// Return copies of the prototype objects so callers cannot mutate the cache.
+	out := make([]client.Object, len(gateCommitStatusKinds))
+	for i, obj := range gateCommitStatusKinds {
+		out[i] = obj.DeepCopyObject().(client.Object)
+	}
+	return out
+}
+
+// discoverPromotionStrategyRefGateKinds returns one empty instance per promoter
+// kind whose Spec embeds PromotionStrategyRef (excluding *List types).
+func discoverPromotionStrategyRefGateKinds(scheme *runtime.Scheme) []client.Object {
+	known := scheme.KnownTypes(promoterv1alpha1.SchemeGroupVersion)
+	var kindNames []string
+	for kind, t := range known {
+		if strings.HasSuffix(kind, "List") {
+			continue
+		}
+		if !typeHasPromotionStrategyRef(t) {
+			continue
+		}
+		kindNames = append(kindNames, kind)
+	}
+	sort.Strings(kindNames)
+
+	out := make([]client.Object, 0, len(kindNames))
+	for _, kind := range kindNames {
+		obj, ok := reflect.New(known[kind]).Interface().(client.Object)
+		if !ok {
+			panic(fmt.Sprintf("promoter kind %s is registered but does not implement client.Object", kind))
+		}
+		out = append(out, obj)
+	}
+	return out
+}
+
+// typeHasPromotionStrategyRef reports whether t (a non-pointer struct type) has
+// Spec.PromotionStrategyRef.
+func typeHasPromotionStrategyRef(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+	spec, ok := t.FieldByName("Spec")
+	if !ok {
+		return false
+	}
+	specType := spec.Type
+	if specType.Kind() == reflect.Ptr {
+		specType = specType.Elem()
+	}
+	if specType.Kind() != reflect.Struct {
+		return false
+	}
+	_, ok = specType.FieldByName("PromotionStrategyRef")
+	return ok
+}
+
+// PromotionStrategyRefName returns spec.promotionStrategyRef.name for gate CRDs,
+// or "" when the object is not a PromotionStrategyRef gate.
+func PromotionStrategyRefName(obj client.Object) string {
+	if obj == nil {
+		return ""
+	}
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	if !typeHasPromotionStrategyRef(v.Type()) {
+		return ""
+	}
+	name := v.FieldByName("Spec").FieldByName("PromotionStrategyRef").FieldByName("Name")
+	if !name.IsValid() || name.Kind() != reflect.String {
+		return ""
+	}
+	return name.String()
+}
+
 // PromotionStrategyRefIndexValues returns the PromotionStrategy name referenced
 // by a gate CRD for field-indexed list/watch queries.
 func PromotionStrategyRefIndexValues(rawObj client.Object) []string {
-	switch o := rawObj.(type) {
-	case *promoterv1alpha1.ArgoCDCommitStatus:
-		return []string{o.Spec.PromotionStrategyRef.Name}
-	case *promoterv1alpha1.GitCommitStatus:
-		return []string{o.Spec.PromotionStrategyRef.Name}
-	case *promoterv1alpha1.TimedCommitStatus:
-		return []string{o.Spec.PromotionStrategyRef.Name}
-	case *promoterv1alpha1.WebRequestCommitStatus:
-		return []string{o.Spec.PromotionStrategyRef.Name}
-	case *promoterv1alpha1.ScheduledCommitStatus:
-		return []string{o.Spec.PromotionStrategyRef.Name}
-	default:
-		return nil
+	if name := PromotionStrategyRefName(rawObj); name != "" {
+		return []string{name}
 	}
+	return nil
 }
 
 // RegisterGatePromotionStrategyRefFieldIndexes registers PromotionStrategyRefField
 // on all commit-status gate CRD kinds.
 func RegisterGatePromotionStrategyRefFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error {
-	gateKinds := []client.Object{
-		&promoterv1alpha1.ArgoCDCommitStatus{},
-		&promoterv1alpha1.GitCommitStatus{},
-		&promoterv1alpha1.TimedCommitStatus{},
-		&promoterv1alpha1.WebRequestCommitStatus{},
-		&promoterv1alpha1.ScheduledCommitStatus{},
-	}
-	for _, obj := range gateKinds {
+	for _, obj := range GateCommitStatusKinds() {
 		if err := indexer.IndexField(ctx, obj, PromotionStrategyRefField, PromotionStrategyRefIndexValues); err != nil {
 			return fmt.Errorf("failed to set field index %s for %T: %w", PromotionStrategyRefField, obj, err)
 		}

--- a/internal/controller/fieldindex.go
+++ b/internal/controller/fieldindex.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -57,7 +57,11 @@ func GateCommitStatusKinds() []client.Object {
 	// Return copies of the prototype objects so callers cannot mutate the cache.
 	out := make([]client.Object, len(gateCommitStatusKinds))
 	for i, obj := range gateCommitStatusKinds {
-		out[i] = obj.DeepCopyObject().(client.Object)
+		copied, ok := obj.DeepCopyObject().(client.Object)
+		if !ok {
+			panic(fmt.Sprintf("DeepCopyObject for %T did not return client.Object", obj))
+		}
+		out[i] = copied
 	}
 	return out
 }
@@ -76,7 +80,7 @@ func discoverPromotionStrategyRefGateKinds(scheme *runtime.Scheme) []client.Obje
 		}
 		kindNames = append(kindNames, kind)
 	}
-	sort.Strings(kindNames)
+	slices.Sort(kindNames)
 
 	out := make([]client.Object, 0, len(kindNames))
 	for _, kind := range kindNames {
@@ -92,7 +96,7 @@ func discoverPromotionStrategyRefGateKinds(scheme *runtime.Scheme) []client.Obje
 // typeHasPromotionStrategyRef reports whether t (a non-pointer struct type) has
 // Spec.PromotionStrategyRef.
 func typeHasPromotionStrategyRef(t reflect.Type) bool {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {
@@ -103,7 +107,7 @@ func typeHasPromotionStrategyRef(t reflect.Type) bool {
 		return false
 	}
 	specType := spec.Type
-	if specType.Kind() == reflect.Ptr {
+	if specType.Kind() == reflect.Pointer {
 		specType = specType.Elem()
 	}
 	if specType.Kind() != reflect.Struct {
@@ -120,7 +124,7 @@ func PromotionStrategyRefName(obj client.Object) string {
 		return ""
 	}
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}

--- a/internal/controller/fieldindex_test.go
+++ b/internal/controller/fieldindex_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+)
+
+var _ = Describe("GateCommitStatusKinds", func() {
+	It("discovers PromotionStrategyRef gate types from the scheme", func() {
+		got := map[string]struct{}{}
+		for _, obj := range GateCommitStatusKinds() {
+			got[reflect.TypeOf(obj).Elem().Name()] = struct{}{}
+		}
+
+		for _, want := range []string{
+			"ArgoCDCommitStatus",
+			"GitCommitStatus",
+			"TimedCommitStatus",
+			"WebRequestCommitStatus",
+			"ScheduledCommitStatus",
+		} {
+			Expect(got).To(HaveKey(want))
+		}
+
+		for _, notWant := range []string{
+			"PromotionStrategy",
+			"ChangeTransferPolicy",
+			"CommitStatus",
+			"PullRequest",
+			"GitRepository",
+		} {
+			Expect(got).NotTo(HaveKey(notWant))
+		}
+	})
+})
+
+var _ = Describe("PromotionStrategyRefName", func() {
+	It("returns the referenced PromotionStrategy name for a gate", func() {
+		scs := &promoterv1alpha1.ScheduledCommitStatus{}
+		scs.Spec.PromotionStrategyRef.Name = "my-ps"
+		Expect(PromotionStrategyRefName(scs)).To(Equal("my-ps"))
+	})
+
+	It("returns empty for non-gate types", func() {
+		Expect(PromotionStrategyRefName(&promoterv1alpha1.PromotionStrategy{})).To(BeEmpty())
+	})
+})

--- a/ui/shared/src/types/generated/view.gen.ts
+++ b/ui/shared/src/types/generated/view.gen.ts
@@ -412,6 +412,20 @@ export type components = {
              */
             type: string;
         };
+        /** @description CronWindow defines a recurring time window using a cron expression and a duration. */
+        CronWindow: {
+            /**
+             * @description Cron is a standard 5-field cron expression defining the start of the window (minute hour day-of-month month day-of-week). For example "0 9 * * 1-5" means Monday–Friday at 09:00 in the configured timezone.
+             * @default
+             */
+            cron: string;
+            /** @description Description is an optional human-readable explanation of this window (e.g. "US East business hours", "Holiday deployment freeze"). */
+            description?: string;
+            /** @description Duration is how long the window remains open after the cron trigger. The duration should be in a format accepted by Go's time.ParseDuration function, e.g., "8h", "30m", "2h30m". */
+            duration: components["schemas"]["Duration"];
+            /** @description Timezone overrides the spec-level default timezone for this specific window. If not set, the spec-level timezone (or UTC if that is also not set) is used. */
+            timezone?: string;
+        };
         /** @description Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json. */
         Duration: string;
         /** @description Environment defines a single environment in the promotion sequence. */
@@ -1187,6 +1201,8 @@ export type components = {
             promotionStrategy: components["schemas"]["PromotionStrategy"];
             /** @description PullRequests are the PullRequests associated with the PromotionStrategy (selected by the promoter.argoproj.io/promotion-strategy label). */
             pullRequests?: components["schemas"]["PullRequest"][];
+            /** @description ScheduledCommitStatuses are the ScheduledCommitStatus managers that reference the PromotionStrategy. */
+            scheduledCommitStatuses?: components["schemas"]["ScheduledCommitStatus"][];
             /** @description ScmProvider is the namespaced ScmProvider referenced by the GitRepository, if applicable. The credentials Secret referenced by the provider is never resolved or included. */
             scmProvider?: components["schemas"]["ScmProvider"];
             /** @description TimedCommitStatuses are the TimedCommitStatus managers that reference the PromotionStrategy. */
@@ -1346,6 +1362,97 @@ export type components = {
         RevisionReference: {
             /** @description Commit contains metadata about the commit that is related in some way to another commit. */
             commit?: components["schemas"]["CommitMetadata"];
+        };
+        /** @description ScheduledCommitStatus is the Schema for the scheduledcommitstatuses API. */
+        ScheduledCommitStatus: {
+            /** @description APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+            apiVersion?: string;
+            /** @description Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+            kind?: string;
+            /**
+             * @description metadata is a standard object metadata
+             * @default {}
+             */
+            metadata?: components["schemas"]["ObjectMeta"];
+            /**
+             * @description spec defines the desired state of ScheduledCommitStatus
+             * @default {}
+             */
+            spec: components["schemas"]["ScheduledCommitStatusSpec"];
+            /**
+             * @description status defines the observed state of ScheduledCommitStatus
+             * @default {}
+             */
+            status?: components["schemas"]["ScheduledCommitStatusStatus"];
+        };
+        /** @description ScheduledCommitStatusSpec defines the desired state of ScheduledCommitStatus. */
+        ScheduledCommitStatusSpec: {
+            /** @description Allow defines global allow windows applied to all listed environments in addition to per-environment allow windows (OR semantics across all). */
+            allow?: components["schemas"]["CronWindow"][];
+            /** @description Environments defines the list of environments to gate. Only listed environments are gated; unlisted environments default to success (24/7 open). Each environment inherits global allow/exclude windows and may add its own. An environment with no per-environment windows is valid when global windows are defined. */
+            environments: components["schemas"]["ScheduledEnvironment"][];
+            /** @description Exclude defines global exclusion windows applied to all listed environments in addition to per-environment exclusions. Exclusions take precedence over allow windows. */
+            exclude?: components["schemas"]["CronWindow"][];
+            /**
+             * @description Key is the gate name referenced in the PromotionStrategy's proposedCommitStatuses. Must be lowercase alphanumeric with hyphens, 1–63 characters (pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$).
+             * @default
+             */
+            key: string;
+            /**
+             * @description PromotionStrategyRef is a reference to the promotion strategy that this scheduled commit status applies to.
+             * @default {}
+             */
+            promotionStrategyRef: components["schemas"]["io_argoproj_promoter_v1alpha1_ObjectReference"];
+            /** @description Timezone is the default IANA timezone name used for evaluating cron expressions across all windows. Individual windows may override this with their own timezone field. Defaults to UTC. */
+            timezone?: string;
+        };
+        /** @description ScheduledCommitStatusStatus defines the observed state of ScheduledCommitStatus. */
+        ScheduledCommitStatusStatus: {
+            /** @description Conditions represent the latest available observations of an object's state */
+            conditions?: components["schemas"]["Condition"][];
+            /** @description Environments holds the status of each environment being tracked. */
+            environments?: components["schemas"]["ScheduledEnvironmentStatus"][];
+            /** @description InstanceID mirrors metadata.labels[promoter.argoproj.io/instance-id] stamped on each reconcile attempt by this install's controller, including when Ready=False; omitted when the resource has no instance-id label (default install). */
+            instanceID?: string;
+            /**
+             * Format: int64
+             * @description ObservedGeneration is the .metadata.generation that this status was reconciled from. Because status is written via Server-Side Apply with ForceOwnership (which has no optimistic-concurrency check), this field is the canonical way to detect stale status writes: compare status.observedGeneration with metadata.generation.
+             */
+            observedGeneration?: number;
+        };
+        /** @description ScheduledEnvironment defines the window configuration for a single environment. */
+        ScheduledEnvironment: {
+            /** @description Allow defines the allowed promotion windows. Promotions are allowed when the current time falls inside any of these windows (OR semantics). These are combined with any global spec.allow windows. If no allow windows are defined (neither here nor globally), the environment operates in exclusion-only mode. */
+            allow?: components["schemas"]["CronWindow"][];
+            /**
+             * @description Branch is the name of the branch/environment you want to gate with time windows. Must not start with '-', contain ':', or contain '..'.
+             * @default
+             */
+            branch: string;
+            /** @description Exclude defines blackout periods during which promotions are blocked. Exclusions take precedence over allow windows — if the current time falls inside any exclusion, promotions are blocked regardless of allow windows. These are combined with any global spec.exclude windows. If empty, no blackout periods are applied. */
+            exclude?: components["schemas"]["CronWindow"][];
+        };
+        /** @description ScheduledEnvironmentStatus defines the observed window state for a specific environment. */
+        ScheduledEnvironmentStatus: {
+            /** @description Active holds details of the currently active window driving the phase. Nil when no specific window is active (e.g. exclusion-only mode with no active exclusion). */
+            active?: components["schemas"]["WindowStatus"];
+            /**
+             * @description Branch is the name of the branch/environment.
+             * @default
+             */
+            branch: string;
+            /** @description Next holds details of the next expected window transition. Used by UIs for countdown timers and by the controller for precise requeuing. */
+            next?: components["schemas"]["WindowStatus"];
+            /**
+             * @description Phase represents the current phase of the scheduled gate.
+             * @default
+             */
+            phase: string;
+            /**
+             * @description Sha is the proposed commit SHA being tracked for this environment. Supports both SHA-1 (40 chars) and SHA-256 (64 chars) Git hash formats.
+             * @default
+             */
+            sha: string;
         };
         /**
          * @description Scm specifies authentication using SCM provider credentials.
@@ -1824,6 +1931,15 @@ export type components = {
              *       - success.when.variables result → {{ index .SuccessVariables "key" }}
              */
             variables?: components["schemas"]["OutputSpec"];
+        };
+        /** @description WindowStatus holds details about a specific window state (active or upcoming). */
+        WindowStatus: {
+            /** @description Allow is the cron expression of the allow window, if applicable. */
+            allow?: string;
+            /** @description Exclude is the cron expression of the exclusion window, if applicable. */
+            exclude?: string;
+            /** @description Transition is when this window state is expected to change (e.g. window closing for active, window opening for next). */
+            transition?: components["schemas"]["Time"];
         };
         /** @description ObjectReference is a reference to an object by name. It is used to refer to objects in the same namespace. */
         io_argoproj_promoter_v1alpha1_ObjectReference: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promotion strategy details now expose `scheduledCommitStatuses`, listing scheduled commit status managers associated with each strategy.
  * The API omits `scheduledCommitStatuses` when empty and populates it for all supported gate types.
  * Updated server permissions to allow reading `scheduledcommitstatuses`.

* **Tests**
  * Added/updated coverage to verify dynamic discovery of gate types, correct mapping back to owning promotion strategies, and accurate API representation of `scheduledCommitStatuses`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->