### PR TITLE
feat(ui): history view cell improvements and detail-drawer deep-linking

### DIFF
--- a/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
+++ b/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
@@ -11,6 +11,7 @@ import {
 } from '@shared/utils/util';
 import type { CellState, CommitRow, EnvColumn, HealthKey } from '../types';
 import { DRAWER_MIN_WIDTH, DRAWER_MAX_WIDTH, HEALTH_LABELS, healthIcon } from '../presentation';
+import { isEmptyCellKind } from '../helpers';
 import Tooltip from '../Tooltip/Tooltip';
 
 const DetailDrawer: React.FC<{
@@ -119,6 +120,7 @@ const DetailDrawer: React.FC<{
               {cell.kind === 'failed' && 'FAILED'}
               {cell.kind === 'no-op' && 'NO-OP'}
               {cell.kind === 'no-changes' && 'NO CHANGES'}
+              {cell.kind === 'unknown-history' && 'HISTORY UNAVAILABLE'}
             </span>
             <span className="hp-drawer__branch">{branch}</span>
           </div>
@@ -299,7 +301,7 @@ const DetailDrawer: React.FC<{
             {envs.map((e) => {
               const c = row.cells[e.branch];
               const isHere = e.branch === branch;
-              const selectable = !isHere && c.kind !== 'no-changes';
+              const selectable = !isHere && !isEmptyCellKind(c.kind);
               const inner = (
                 <>
                   <span className="hp-drawer__presence-branch">{e.branch}</span>
@@ -318,6 +320,7 @@ const DetailDrawer: React.FC<{
                       </>
                     )}
                     {c.kind === 'no-changes' && '—'}
+                    {c.kind === 'unknown-history' && '?'}
                   </span>
                   {c.at && (
                     <Tooltip label={formatDate(c.at)}>

--- a/ui/components-lib/src/components/HistoryView/FlowCell/FlowCell.tsx
+++ b/ui/components-lib/src/components/HistoryView/FlowCell/FlowCell.tsx
@@ -23,6 +23,21 @@ const FlowCell: React.FC<{
     );
   }
 
+  if (cell.kind === 'unknown-history') {
+    return (
+      <Tooltip
+        label={`This commit predates ${branch}'s available history, so whether it ran here is no longer recorded.`}
+      >
+        <div
+          className="cell cell--unknown-history"
+          aria-label={`History unavailable for this commit in ${branch}`}
+        >
+          <span className="cell__unknown-label">History unavailable</span>
+        </div>
+      </Tooltip>
+    );
+  }
+
   const failingChecks = cell.commitStatuses
     .filter((s) => s.phase === 'failure')
     .map((s) => (s.description ? `${s.key}: ${s.description}` : s.key));

--- a/ui/components-lib/src/components/HistoryView/FlowCell/_FlowCell.scss
+++ b/ui/components-lib/src/components/HistoryView/FlowCell/_FlowCell.scss
@@ -92,6 +92,37 @@
   }
 }
 
+.cell--unknown-history {
+  border: 1px dashed $stroke-strong;
+  border-radius: $radius-md;
+  color: $text-muted;
+  font-size: 10.5px;
+  font-style: italic;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-height: 54px;
+  padding: 6px;
+  cursor: default;
+  background-color: $bg-soft;
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 5px,
+    rgba(15, 35, 60, 0.05) 5px,
+    rgba(15, 35, 60, 0.05) 10px
+  );
+  &::before {
+    background: transparent;
+  }
+}
+.cell__unknown-label {
+  line-height: 1.15;
+  text-align: center;
+}
+
 .cell__top {
   display: flex;
   align-items: center;
@@ -137,6 +168,11 @@
   }
   &--no-changes {
     background: transparent;
+    color: $text-muted;
+    border: 1px dashed $stroke-strong;
+  }
+  &--unknown-history {
+    background: $bg-soft;
     color: $text-muted;
     border: 1px dashed $stroke-strong;
   }

--- a/ui/components-lib/src/components/HistoryView/HistoryView.tsx
+++ b/ui/components-lib/src/components/HistoryView/HistoryView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { FaChevronLeft, FaFilter, FaSort, FaLayerGroup } from 'react-icons/fa';
 import { GoGitCommit } from 'react-icons/go';
 import { timeAgo, formatDate, getCommitUrl } from '@shared/utils/util';
@@ -13,11 +13,18 @@ import DetailDrawer from './DetailDrawer/DetailDrawer';
 import { useDrawerWidth } from './useDrawerWidth';
 import './index.scss';
 
+export interface CellSelection {
+  rowId: string;
+  branch: string;
+}
+
 export interface HistoryViewProps {
   strategy?: PromotionStrategy;
   name?: string;
   namespace?: string;
   onBack?: () => void;
+  initialSelection?: CellSelection | null;
+  onSelectionChange?: (_selection: CellSelection | null) => void;
   // By default the view fills its host container (`height: 100%`), which is
   // correct when mounted inside a sized ancestor like ArgoCD's
   // `application-details__tree`. Hosts with no sized ancestor (the dashboard)
@@ -31,6 +38,8 @@ const HistoryView: React.FC<HistoryViewProps> = ({
   namespace: namespaceProp,
   onBack,
   fillViewport = false,
+  initialSelection = null,
+  onSelectionChange,
 }) => {
   const rootClass = fillViewport ? 'hp--viewport' : '';
   const name = nameProp ?? strategy?.metadata?.name;
@@ -49,9 +58,26 @@ const HistoryView: React.FC<HistoryViewProps> = ({
   const [filter, setFilter] = useState<FilterId>('all');
   const [sort, setSort] = useState<SortId>('newest');
   const [envFilter, setEnvFilter] = useState<string[]>([]);
-  const [selected, setSelected] = useState<{ rowId: string; branch: string } | null>(null);
+  const [selected, setSelectedState] = useState<CellSelection | null>(initialSelection);
+
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+
+  const selectCell = useCallback((next: CellSelection | null) => {
+    setSelectedState(next);
+    onSelectionChangeRef.current?.(next);
+  }, []);
 
   const drawer = useDrawerWidth();
+
+  const validBranches = useMemo(() => new Set(envs.map((e) => e.branch)), [envs]);
+  useEffect(() => {
+    if (!selected || rows.length === 0) return;
+    if (!rowsById.has(selected.rowId) || !validBranches.has(selected.branch)) {
+      setSelectedState(null);
+      onSelectionChangeRef.current?.(null);
+    }
+  }, [selected, rows.length, rowsById, validBranches]);
 
   const handleToggleEnvFilter = useCallback((branch: string) => {
     setEnvFilter((prev) =>
@@ -106,14 +132,14 @@ const HistoryView: React.FC<HistoryViewProps> = ({
       const branches = envs.map((e) => e.branch);
       const liveBranch = branches.find((b) => row.cells[b].kind === 'live');
       const branch = liveBranch ?? branches.find((b) => !isEmptyCellKind(row.cells[b].kind));
-      if (branch) setSelected({ rowId, branch });
+      if (branch) selectCell({ rowId, branch });
       requestAnimationFrame(() => {
         document
           .getElementById(`row-${rowId}`)
           ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
       });
     },
-    [envs, rowsById],
+    [envs, rowsById, selectCell],
   );
 
   if (!strategy) return <div className={`hp-loading ${rootClass}`}>Loading promotion history…</div>;
@@ -403,7 +429,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({
                           cell={row.cells[env.branch]}
                           branch={env.branch}
                           isSelected={selected?.rowId === row.id && selected?.branch === env.branch}
-                          onSelect={() => setSelected({ rowId: row.id, branch: env.branch })}
+                          onSelect={() => selectCell({ rowId: row.id, branch: env.branch })}
                           rowsById={rowsById}
                           onJumpToRow={handleJumpToRow}
                         />
@@ -427,9 +453,9 @@ const HistoryView: React.FC<HistoryViewProps> = ({
           onResizeStart={drawer.onResizeStart}
           onResizeReset={drawer.onResizeReset}
           onResizeTo={drawer.onResizeTo}
-          onClose={() => setSelected(null)}
+          onClose={() => selectCell(null)}
           onJumpToRow={handleJumpToRow}
-          onSelectCell={(branch) => selected && setSelected({ rowId: selected.rowId, branch })}
+          onSelectCell={(branch) => selected && selectCell({ rowId: selected.rowId, branch })}
         />
       </div>
     </div>

--- a/ui/components-lib/src/components/HistoryView/HistoryView.tsx
+++ b/ui/components-lib/src/components/HistoryView/HistoryView.tsx
@@ -5,6 +5,7 @@ import { timeAgo, formatDate, getCommitUrl } from '@shared/utils/util';
 import type { PromotionStrategy } from '@shared/types/promotion';
 import type { CommitRow, FilterId, SortId } from './types';
 import { buildMatrix } from './buildMatrix';
+import { isEmptyCellKind } from './helpers';
 import { Dropdown, DropdownItem } from './Dropdown/Dropdown';
 import Tooltip from './Tooltip/Tooltip';
 import FlowCell from './FlowCell/FlowCell';
@@ -61,7 +62,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({
   const envScopedRows = useMemo(
     () =>
       envFilter.length
-        ? rows.filter((r) => envFilter.some((b) => r.cells[b]?.kind !== 'no-changes'))
+        ? rows.filter((r) => envFilter.some((b) => !isEmptyCellKind(r.cells[b]?.kind)))
         : rows,
     [rows, envFilter],
   );
@@ -104,7 +105,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({
       if (!row) return;
       const branches = envs.map((e) => e.branch);
       const liveBranch = branches.find((b) => row.cells[b].kind === 'live');
-      const branch = liveBranch ?? branches.find((b) => row.cells[b].kind !== 'no-changes');
+      const branch = liveBranch ?? branches.find((b) => !isEmptyCellKind(row.cells[b].kind));
       if (branch) setSelected({ rowId, branch });
       requestAnimationFrame(() => {
         document
@@ -227,7 +228,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({
                   </DropdownItem>
                   {envs.map((env) => {
                     const envCount = rows.filter(
-                      (r) => r.cells[env.branch]?.kind !== 'no-changes',
+                      (r) => !isEmptyCellKind(r.cells[env.branch]?.kind),
                     ).length;
                     return (
                       <DropdownItem

--- a/ui/components-lib/src/components/HistoryView/HistoryView.tsx
+++ b/ui/components-lib/src/components/HistoryView/HistoryView.tsx
@@ -73,7 +73,12 @@ const HistoryView: React.FC<HistoryViewProps> = ({
   const validBranches = useMemo(() => new Set(envs.map((e) => e.branch)), [envs]);
   useEffect(() => {
     if (!selected || rows.length === 0) return;
-    if (!rowsById.has(selected.rowId) || !validBranches.has(selected.branch)) {
+    const selectedCell = rowsById.get(selected.rowId)?.cells[selected.branch];
+    if (
+      !validBranches.has(selected.branch) ||
+      !selectedCell ||
+      isEmptyCellKind(selectedCell.kind)
+    ) {
       setSelectedState(null);
       onSelectionChangeRef.current?.(null);
     }

--- a/ui/components-lib/src/components/HistoryView/buildMatrix.ts
+++ b/ui/components-lib/src/components/HistoryView/buildMatrix.ts
@@ -105,6 +105,7 @@ const cellRank: Record<CellKind, number> = {
   failed: 4,
   'was-here': 3,
   'no-op': 2,
+  'unknown-history': 1,
   'no-changes': 1,
 };
 
@@ -171,7 +172,40 @@ function processHistory(rowsById: Map<string, CommitRow>, env: StatusEnvironment
   });
 }
 
-function finalizeRow(row: CommitRow, envs: StatusEnvironment[]): CommitRow {
+// The CRD caps per-environment history at 5 entries. A commit older than a capped
+// env's oldest surviving entry may have run there but its record was dropped, so such
+// cells render as 'unknown-history' rather than claiming 'no-changes'.
+const HISTORY_CAP = 5;
+
+interface EnvHorizon {
+  oldestKnownAt: number;
+  truncated: boolean;
+}
+
+function computeHorizons(envs: StatusEnvironment[]): Map<string, EnvHorizon> {
+  const horizons = new Map<string, EnvHorizon>();
+  for (const env of envs) {
+    const times: number[] = [];
+    const push = (raw?: string) => {
+      if (!raw) return;
+      const t = new Date(raw).getTime();
+      if (Number.isFinite(t)) times.push(t);
+    };
+    push(env.active?.dry?.commitTime);
+    for (const h of env.history ?? []) push(h.active?.dry?.commitTime);
+    horizons.set(env.branch, {
+      oldestKnownAt: times.length ? Math.min(...times) : Infinity,
+      truncated: (env.history?.length ?? 0) >= HISTORY_CAP,
+    });
+  }
+  return horizons;
+}
+
+function finalizeRow(
+  row: CommitRow,
+  envs: StatusEnvironment[],
+  horizons: Map<string, EnvHorizon>,
+): CommitRow {
   const times: number[] = [];
   for (const branch of envs.map((e) => e.branch)) {
     const c = row.cells[branch];
@@ -193,10 +227,19 @@ function finalizeRow(row: CommitRow, envs: StatusEnvironment[]): CommitRow {
     : 0;
   if (!Number.isFinite(row.earliestAt)) row.earliestAt = row.freshestAt;
 
+  const rowCommitAt = row.freshestAt;
+
   for (const e of envs) {
     if (!row.cells[e.branch]) {
+      const horizon = horizons.get(e.branch);
+      const agedOut =
+        !!horizon &&
+        horizon.truncated &&
+        rowCommitAt > 0 &&
+        Number.isFinite(horizon.oldestKnownAt) &&
+        rowCommitAt < horizon.oldestKnownAt;
       row.cells[e.branch] = {
-        kind: 'no-changes',
+        kind: agedOut ? 'unknown-history' : 'no-changes',
         commitStatuses: [],
         health: 'unknown',
       };
@@ -274,7 +317,8 @@ export function buildMatrix(strategy: PromotionStrategy): {
     processHistory(rowsById, env);
   });
 
-  const rows = Array.from(rowsById.values()).map((row) => finalizeRow(row, envs));
+  const horizons = computeHorizons(envs);
+  const rows = Array.from(rowsById.values()).map((row) => finalizeRow(row, envs, horizons));
 
   rows.sort((a, b) => b.freshestAt - a.freshestAt);
 

--- a/ui/components-lib/src/components/HistoryView/helpers.ts
+++ b/ui/components-lib/src/components/HistoryView/helpers.ts
@@ -1,5 +1,10 @@
 import type { Commit, CommitStatus } from '@shared/types/promotion';
-import type { HealthKey } from './types';
+import type { CellKind, HealthKey } from './types';
+
+// Cell kinds with no commit activity for the env: non-selectable, excluded from env-scoped rows.
+export function isEmptyCellKind(kind: CellKind | undefined): boolean {
+  return kind === 'no-changes' || kind === 'unknown-history';
+}
 
 export function healthFromStatuses(statuses: CommitStatus[] | undefined): HealthKey {
   if (!statuses || statuses.length === 0) return 'unknown';

--- a/ui/components-lib/src/components/HistoryView/presentation.tsx
+++ b/ui/components-lib/src/components/HistoryView/presentation.tsx
@@ -18,6 +18,7 @@ export const CELL_KIND_LABELS: Record<CellKind, string> = {
   failed: 'Failed',
   'no-op': 'No-op',
   'no-changes': 'No changes',
+  'unknown-history': 'History unavailable',
 };
 
 export const DRAWER_MIN_WIDTH = 320;
@@ -50,6 +51,8 @@ export function cellPillTooltip(cell: CellState, branch: string): string {
       return cell.noopNote || `No change in ${branch}`;
     case 'no-changes':
       return `Never reached ${branch}`;
+    case 'unknown-history':
+      return `Predates ${branch}'s available history — no longer recorded`;
     default:
       return '';
   }

--- a/ui/components-lib/src/components/HistoryView/types.ts
+++ b/ui/components-lib/src/components/HistoryView/types.ts
@@ -2,7 +2,14 @@ import type { Commit, CommitStatus, PullRequest, ReferenceCommit } from '@shared
 
 export type HealthKey = 'success' | 'failure' | 'pending' | 'unknown';
 
-export type CellKind = 'live' | 'in-flight' | 'was-here' | 'failed' | 'no-op' | 'no-changes';
+export type CellKind =
+  | 'live'
+  | 'in-flight'
+  | 'was-here'
+  | 'failed'
+  | 'no-op'
+  | 'no-changes'
+  | 'unknown-history';
 
 export interface CellState {
   kind: CellKind;

--- a/ui/dashboard/package-lock.json
+++ b/ui/dashboard/package-lock.json
@@ -4459,9 +4459,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {

--- a/ui/dashboard/src/pages/HistoryPage.tsx
+++ b/ui/dashboard/src/pages/HistoryPage.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useEffect, useCallback } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import HistoryView from '@lib/components/HistoryView/HistoryView';
+import type { CellSelection } from '@lib/components/HistoryView/HistoryView';
 import { PromotionStrategyStore } from '../stores/PromotionStrategyStore';
 
 const HistoryPage: React.FC = () => {
   const { namespace, name } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { items, fetchItems } = PromotionStrategyStore();
 
   useEffect(() => {
@@ -15,6 +17,30 @@ const HistoryPage: React.FC = () => {
 
   const strategy = items.find((ps) => ps.metadata.name === name);
 
+  const commit = searchParams.get('commit');
+  const env = searchParams.get('env');
+  const initialSelection = commit && env ? { rowId: commit, branch: env } : null;
+
+  const handleSelectionChange = useCallback(
+    (selection: CellSelection | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (selection) {
+            next.set('commit', selection.rowId);
+            next.set('env', selection.branch);
+          } else {
+            next.delete('commit');
+            next.delete('env');
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   return (
     <HistoryView
       strategy={strategy}
@@ -22,6 +48,8 @@ const HistoryPage: React.FC = () => {
       namespace={namespace}
       onBack={() => navigate(`/promotion-strategies/${namespace}/${name}`)}
       fillViewport
+      initialSelection={initialSelection}
+      onSelectionChange={handleSelectionChange}
     />
   );
 };

--- a/ui/extension/AppViewExtension.tsx
+++ b/ui/extension/AppViewExtension.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Select, { SingleValue } from 'react-select';
 import Card from '@components-lib/components/Card';
 import HistoryView from '@components-lib/components/HistoryView/HistoryView';
+import type { CellSelection } from '@components-lib/components/HistoryView/HistoryView';
 import { PromotionStrategy } from '@shared/types/promotion';
 import { AppViewComponentProps } from '@shared/types/extension';
 import { sortStrategyCommitStatuses } from '@shared/utils/util';
@@ -30,6 +31,28 @@ const setParam = (name: string) => {
     url.searchParams.set(PARAM, name);
   } else {
     url.searchParams.delete(PARAM);
+  }
+  window.history.replaceState(null, '', url.toString());
+};
+
+const COMMIT_PARAM = 'psCommit';
+const ENV_PARAM = 'psEnv';
+
+const getSelectionFromUrl = (): CellSelection | null => {
+  const params = new URLSearchParams(window.location.search);
+  const rowId = params.get(COMMIT_PARAM);
+  const branch = params.get(ENV_PARAM);
+  return rowId && branch ? { rowId, branch } : null;
+};
+
+const setSelectionInUrl = (selection: CellSelection | null) => {
+  const url = new URL(window.location.href);
+  if (selection) {
+    url.searchParams.set(COMMIT_PARAM, selection.rowId);
+    url.searchParams.set(ENV_PARAM, selection.branch);
+  } else {
+    url.searchParams.delete(COMMIT_PARAM);
+    url.searchParams.delete(ENV_PARAM);
   }
   window.history.replaceState(null, '', url.toString());
 };
@@ -66,7 +89,7 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
     () => getParam() || getStored(application.metadata.namespace, application.metadata.name),
   );
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [view, setView] = useState<ViewMode>('card');
+  const [view, setView] = useState<ViewMode>(() => (getSelectionFromUrl() ? 'history' : 'card'));
 
   useEffect(() => {
     const appName = application.metadata.name;
@@ -201,7 +224,11 @@ const AppViewExtension = ({ application, tree }: AppViewComponentProps) => {
       {selected && view === 'card' && <Card environments={selected.status?.environments || []} />}
       {selected && view === 'history' && (
         <div className="gp-history-wrapper">
-          <HistoryView strategy={selected} />
+          <HistoryView
+            strategy={selected}
+            initialSelection={getSelectionFromUrl()}
+            onSelectionChange={setSelectionInUrl}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Distinguish aged-out history cells from "no changes."** When a commit falls
  out of an environment's capped (5-entry) history, its cell now renders as
  "History unavailable" instead of the misleading "No changes."

- **Deep-link to a detail drawer cell.** A commit/environment cell can be linked
  and reopened via the URL — `?commit`/`?env` in the dashboard, `?psCommit`/`?psEnv`
  in the Argo CD extension.

## Results
example dropped off history:
<img width="1461" height="722" alt="image" src="https://github.com/user-attachments/assets/3d794ef8-a63d-45fd-9715-042b60338ba9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL-synchronized History view selections, allowing specific commits and environments to be shared and restored.
  * Added a new “History unavailable” presentation for cases where older history is no longer recorded, including badges, tooltips, and updated pill styling.
* **Bug Fixes**
  * Improved environment filtering, counts, and cell rendering to correctly recognize “empty/unavailable” states using consistent empty-state logic.  
  * Fixed selection behavior by validating selections against the current data and clearing/redirecting as needed when selections become invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->