### PR TITLE
chore(ui): upgrade dashboard to React 19 and react-router v8

### DIFF
--- a/ui/dashboard/package-lock.json
+++ b/ui/dashboard/package-lock.json
@@ -8,10 +8,10 @@
       "name": "dashboard",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-icons": "^5.0.0",
-        "react-router-dom": "^6.30.4",
+        "react-router": "^8.3.0",
         "react-select": "^5.8.0",
         "sass": "^1.89.2",
         "zustand": "^5.0.0"
@@ -1667,15 +1667,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -3084,6 +3075,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -5714,28 +5711,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-icons": {
@@ -5764,35 +5757,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-select": {
@@ -6070,13 +6052,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -35,10 +35,10 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-icons": "^5.0.0",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^8.3.0",
     "react-select": "^5.8.0",
     "sass": "^1.89.2",
     "zustand": "^5.0.0"

--- a/ui/dashboard/src/App.tsx
+++ b/ui/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router';
 import DashboardPage from './pages/DashboardPage';
 import PromotionStrategyPage from './pages/PromotionStrategyPage';
 import HistoryPage from './pages/HistoryPage';

--- a/ui/dashboard/src/components/PromotionStrategyDetailsView.tsx
+++ b/ui/dashboard/src/components/PromotionStrategyDetailsView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Card from '@lib/components/Card';
 import { type PromotionStrategy } from '@shared/utils/PSData';
 

--- a/ui/dashboard/src/components/PromotionStrategySummary/PromotionStrategyTiles.tsx
+++ b/ui/dashboard/src/components/PromotionStrategySummary/PromotionStrategyTiles.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { PromotionStrategy } from '@shared/utils/PSData';
 import { PromotionStrategyTile } from '../PromotionStrategySummary/PromotionStrategyTile';
 import { getLastCommitTime, formatDate, getOverallPromotionStatus } from '@shared/utils/util';

--- a/ui/dashboard/src/components/TopBar.tsx
+++ b/ui/dashboard/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import logoSecondary from '../assets/logo-one-row-secondary.svg';
 import './TopBar.scss';
 

--- a/ui/dashboard/src/pages/HistoryPage.tsx
+++ b/ui/dashboard/src/pages/HistoryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import HistoryView from '@lib/components/HistoryView/HistoryView';
 import type { CellSelection } from '@lib/components/HistoryView/HistoryView';
 import { PromotionStrategyStore } from '../stores/PromotionStrategyStore';

--- a/ui/dashboard/src/pages/PromotionStrategyPage.tsx
+++ b/ui/dashboard/src/pages/PromotionStrategyPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { namespaceStore } from '../stores/NamespaceStore';
 import { viewStore } from '../stores/ViewStore';
 import { PromotionStrategyStore } from '../stores/PromotionStrategyStore';


### PR DESCRIPTION
Migrates the dashboard from `react-router-dom@6` to `react-router@8.3` (imports moved to the consolidated `react-router` package) and bumps `react`/`react-dom` to 19, which 8.3 requires.

This clears the `react-router` advisories flagged by `npm audit` — `8.3.0` is the first release outside every current advisory range. React 19 is scoped to the dashboard bundle only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the dashboard to use the latest React and routing packages.
  * Preserved existing navigation, page routing, links, and URL parameter behavior.
  * No visible changes to dashboard features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->