### PR TITLE
feat(webrequestcommitstatus): allow failure phase from success expression in environments context

### DIFF
--- a/api/v1alpha1/webrequestcommitstatus_types.go
+++ b/api/v1alpha1/webrequestcommitstatus_types.go
@@ -118,9 +118,9 @@ type WebRequestCommitStatusSpec struct {
 //
 // Context (the context field below) controls request fan-out and what data is available in templates and trigger expressions:
 //
-//   - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and must return a boolean (true → success, false → pending; failure is not expressible).
+//   - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and returns the phase for that one environment — see SuccessSpec for the boolean and object return shapes.
 //
-//   - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see WhenWithOutputSpec.Expression for boolean vs per-branch object return shapes.
+//   - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see SuccessSpec for boolean vs per-branch object return shapes.
 //
 // When context is "promotionstrategy", Branch is empty for the shared HTTP request and trigger expressions. Use PromotionStrategy (e.g. status environments) for branch-specific values. For description and url templates, {{ .Branch }} and {{ .Phase }} are set per environment when rendering that environment's CommitStatus.
 //
@@ -152,9 +152,31 @@ type PollingModeSpec struct {
 	Interval metav1.Duration `json:"interval,omitempty"`
 }
 
-// SuccessSpec defines when the commit status phase is success.
+// SuccessSpec defines the phase reported on the CommitStatus.
+//
+// When.Expression is evaluated every reconcile (whether or not an HTTP request was made). Its variables are
+// documented on WhenWithOutputSpec.Expression, plus Response (nil when no request was made this reconcile).
+// The accepted return values depend on spec.mode.context:
+//
+//   - "environments" (default): a boolean (true → success, false → pending), or an object { phase } where phase
+//     is "success", "pending", or "failure". An omitted or empty phase means "pending". Each evaluation is
+//     already scoped to one environment, so the per-branch keys below are rejected in this context.
+//
+//   - "promotionstrategy": a boolean (all applicable environments get success or pending), or an object
+//     { defaultPhase?, environments? } where environments is a list of { branch, phase }. Branches not listed
+//     (or all of them, when environments is omitted or empty) get defaultPhase, which is "pending" when omitted.
+//
+// Any other return type, or an unrecognized phase string, fails the reconcile.
+//
+// Examples:
+//
+//	# environments context: fail fast on a 5xx instead of waiting for a timeout
+//	- "Response == nil ? Phase == 'success' : (Response.StatusCode >= 500 ? {phase: 'failure'} : Response.StatusCode == 200)"
+//
+//	# promotionstrategy context: map a batch payload to per-branch phases
+//	- "{ defaultPhase: 'pending', environments: map(Response.Body.results, {{branch: .env, phase: .state}}) }"
 type SuccessSpec struct {
-	// When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+	// When is evaluated every reconcile. See SuccessSpec for return values and WhenWithOutputSpec.Expression for variables.
 	// +required
 	When WhenWithOutputSpec `json:"when"`
 }
@@ -522,7 +544,8 @@ type WebRequestCommitStatusEnvironmentStatus struct {
 	LastSuccessfulSha string `json:"lastSuccessfulSha,omitempty"`
 
 	// Phase represents the current phase of the validation.
-	// This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+	// A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+	// return form documented on SuccessSpec.
 	// +kubebuilder:validation:Enum=pending;success;failure
 	// +required
 	Phase CommitStatusPhase `json:"phase"`

--- a/api/view/v1alpha1/zz_generated.openapi.go
+++ b/api/view/v1alpha1/zz_generated.openapi.go
@@ -3450,7 +3450,7 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_ModeSpec(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ModeSpec defines how the WebRequestCommitStatus controller issues HTTP requests.\n\nExactly one of Polling or Trigger must be set.\n\nContext (the context field below) controls request fan-out and what data is available in templates and trigger expressions:\n\n  - \"environments\" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and must return a boolean (true → success, false → pending; failure is not expressible).\n\n  - \"promotionstrategy\": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see WhenWithOutputSpec.Expression for boolean vs per-branch object return shapes.\n\nWhen context is \"promotionstrategy\", Branch is empty for the shared HTTP request and trigger expressions. Use PromotionStrategy (e.g. status environments) for branch-specific values. For description and url templates, {{ .Branch }} and {{ .Phase }} are set per environment when rendering that environment's CommitStatus.",
+				Description: "ModeSpec defines how the WebRequestCommitStatus controller issues HTTP requests.\n\nExactly one of Polling or Trigger must be set.\n\nContext (the context field below) controls request fan-out and what data is available in templates and trigger expressions:\n\n  - \"environments\" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and returns the phase for that one environment — see SuccessSpec for the boolean and object return shapes.\n\n  - \"promotionstrategy\": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see SuccessSpec for boolean vs per-branch object return shapes.\n\nWhen context is \"promotionstrategy\", Branch is empty for the shared HTTP request and trigger expressions. Use PromotionStrategy (e.g. status environments) for branch-specific values. For description and url templates, {{ .Branch }} and {{ .Phase }} are set per environment when rendering that environment's CommitStatus.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"polling": {
@@ -5222,12 +5222,12 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_SuccessSpec(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SuccessSpec defines when the commit status phase is success.",
+				Description: "SuccessSpec defines the phase reported on the CommitStatus.\n\nWhen.Expression is evaluated every reconcile (whether or not an HTTP request was made). Its variables are documented on WhenWithOutputSpec.Expression, plus Response (nil when no request was made this reconcile). The accepted return values depend on spec.mode.context:\n\n  - \"environments\" (default): a boolean (true → success, false → pending), or an object { phase } where phase\n    is \"success\", \"pending\", or \"failure\". An omitted or empty phase means \"pending\". Each evaluation is\n    already scoped to one environment, so the per-branch keys below are rejected in this context.\n\n  - \"promotionstrategy\": a boolean (all applicable environments get success or pending), or an object\n    { defaultPhase?, environments? } where environments is a list of { branch, phase }. Branches not listed\n    (or all of them, when environments is omitted or empty) get defaultPhase, which is \"pending\" when omitted.\n\nAny other return type, or an unrecognized phase string, fails the reconcile.\n\nExamples:\n\n\t# environments context: fail fast on a 5xx instead of waiting for a timeout\n\t- \"Response == nil ? Phase == 'success' : (Response.StatusCode >= 500 ? {phase: 'failure'} : Response.StatusCode == 200)\"\n\n\t# promotionstrategy context: map a batch payload to per-branch phases\n\t- \"{ defaultPhase: 'pending', environments: map(Response.Body.results, {{branch: .env, phase: .state}}) }\"",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"when": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When is evaluated every reconcile. See WhenWithOutputSpec.Expression.",
+							Description: "When is evaluated every reconcile. See SuccessSpec for return values and WhenWithOutputSpec.Expression for variables.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(apiv1alpha1.WhenWithOutputSpec{}.OpenAPIModelName()),
 						},
@@ -5760,7 +5760,7 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_WebRequestCommitStatusEnv
 					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Phase represents the current phase of the validation. This controller sets only \"pending\" or \"success\"; it never sets \"failure\" (failure is allowed by the enum for API consistency).",
+							Description: "Phase represents the current phase of the validation. A boolean success expression yields only \"pending\" or \"success\"; \"failure\" requires the { phase } object return form documented on SuccessSpec.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/applyconfiguration/api/v1alpha1/modespec.go
+++ b/applyconfiguration/api/v1alpha1/modespec.go
@@ -30,9 +30,9 @@ import (
 //
 // Context (the context field below) controls request fan-out and what data is available in templates and trigger expressions:
 //
-// - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and must return a boolean (true → success, false → pending; failure is not expressible).
+// - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and returns the phase for that one environment — see SuccessSpec for the boolean and object return shapes.
 //
-// - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see WhenWithOutputSpec.Expression for boolean vs per-branch object return shapes.
+// - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see SuccessSpec for boolean vs per-branch object return shapes.
 //
 // When context is "promotionstrategy", Branch is empty for the shared HTTP request and trigger expressions. Use PromotionStrategy (e.g. status environments) for branch-specific values. For description and url templates, {{ .Branch }} and {{ .Phase }} are set per environment when rendering that environment's CommitStatus.
 type ModeSpecApplyConfiguration struct {

--- a/applyconfiguration/api/v1alpha1/successspec.go
+++ b/applyconfiguration/api/v1alpha1/successspec.go
@@ -20,9 +20,31 @@ package v1alpha1
 // SuccessSpecApplyConfiguration represents a declarative configuration of the SuccessSpec type for use
 // with apply.
 //
-// SuccessSpec defines when the commit status phase is success.
+// SuccessSpec defines the phase reported on the CommitStatus.
+//
+// When.Expression is evaluated every reconcile (whether or not an HTTP request was made). Its variables are
+// documented on WhenWithOutputSpec.Expression, plus Response (nil when no request was made this reconcile).
+// The accepted return values depend on spec.mode.context:
+//
+// - "environments" (default): a boolean (true → success, false → pending), or an object { phase } where phase
+// is "success", "pending", or "failure". An omitted or empty phase means "pending". Each evaluation is
+// already scoped to one environment, so the per-branch keys below are rejected in this context.
+//
+// - "promotionstrategy": a boolean (all applicable environments get success or pending), or an object
+// { defaultPhase?, environments? } where environments is a list of { branch, phase }. Branches not listed
+// (or all of them, when environments is omitted or empty) get defaultPhase, which is "pending" when omitted.
+//
+// Any other return type, or an unrecognized phase string, fails the reconcile.
+//
+// Examples:
+//
+// # environments context: fail fast on a 5xx instead of waiting for a timeout
+// - "Response == nil ? Phase == 'success' : (Response.StatusCode >= 500 ? {phase: 'failure'} : Response.StatusCode == 200)"
+//
+// # promotionstrategy context: map a batch payload to per-branch phases
+// - "{ defaultPhase: 'pending', environments: map(Response.Body.results, {{branch: .env, phase: .state}}) }"
 type SuccessSpecApplyConfiguration struct {
-	// When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+	// When is evaluated every reconcile. See SuccessSpec for return values and WhenWithOutputSpec.Expression for variables.
 	When *WhenWithOutputSpecApplyConfiguration `json:"when,omitempty"`
 }
 

--- a/applyconfiguration/api/v1alpha1/webrequestcommitstatusenvironmentstatus.go
+++ b/applyconfiguration/api/v1alpha1/webrequestcommitstatusenvironmentstatus.go
@@ -41,7 +41,8 @@ type WebRequestCommitStatusEnvironmentStatusApplyConfiguration struct {
 	// Supports both SHA-1 (40 chars) and SHA-256 (64 chars) Git hash formats.
 	LastSuccessfulSha *string `json:"lastSuccessfulSha,omitempty"`
 	// Phase represents the current phase of the validation.
-	// This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+	// A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+	// return form documented on SuccessSpec.
 	Phase *apiv1alpha1.CommitStatusPhase `json:"phase,omitempty"`
 	// LastRequestTime is when the last HTTP request was made.
 	LastRequestTime *v1.Time `json:"lastRequestTime,omitempty"`

--- a/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
@@ -501,7 +501,8 @@ spec:
                   Evaluated every reconcile. See SuccessSpec.
                 properties:
                   when:
-                    description: When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+                    description: When is evaluated every reconcile. See SuccessSpec
+                      for return values and WhenWithOutputSpec.Expression for variables.
                     properties:
                       expression:
                         description: |-
@@ -704,7 +705,8 @@ spec:
                     phase:
                       description: |-
                         Phase represents the current phase of the validation.
-                        This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+                        A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+                        return form documented on SuccessSpec.
                       enum:
                       - pending
                       - success

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -8177,7 +8177,8 @@ spec:
                   Evaluated every reconcile. See SuccessSpec.
                 properties:
                   when:
-                    description: When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+                    description: When is evaluated every reconcile. See SuccessSpec
+                      for return values and WhenWithOutputSpec.Expression for variables.
                     properties:
                       expression:
                         description: |-
@@ -8380,7 +8381,8 @@ spec:
                     phase:
                       description: |-
                         Phase represents the current phase of the validation.
-                        This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+                        A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+                        return form documented on SuccessSpec.
                       enum:
                       - pending
                       - success

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -8177,7 +8177,8 @@ spec:
                   Evaluated every reconcile. See SuccessSpec.
                 properties:
                   when:
-                    description: When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+                    description: When is evaluated every reconcile. See SuccessSpec
+                      for return values and WhenWithOutputSpec.Expression for variables.
                     properties:
                       expression:
                         description: |-
@@ -8380,7 +8381,8 @@ spec:
                     phase:
                       description: |-
                         Phase represents the current phase of the validation.
-                        This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+                        A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+                        return form documented on SuccessSpec.
                       enum:
                       - pending
                       - success

--- a/dist/install-without-ui.yaml
+++ b/dist/install-without-ui.yaml
@@ -8177,7 +8177,8 @@ spec:
                   Evaluated every reconcile. See SuccessSpec.
                 properties:
                   when:
-                    description: When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+                    description: When is evaluated every reconcile. See SuccessSpec
+                      for return values and WhenWithOutputSpec.Expression for variables.
                     properties:
                       expression:
                         description: |-
@@ -8380,7 +8381,8 @@ spec:
                     phase:
                       description: |-
                         Phase represents the current phase of the validation.
-                        This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+                        A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object
+                        return form documented on SuccessSpec.
                       enum:
                       - pending
                       - success

--- a/docs/gating-promotions/built-in-gates/web-request-commit-status/index.md
+++ b/docs/gating-promotions/built-in-gates/web-request-commit-status/index.md
@@ -101,7 +101,7 @@ The controller reconciles when the `WebRequestCommitStatus` or the referenced **
 Use it when a **single** external API call represents validation for the whole PromotionStrategy (or a subset of environments that share one backend), and you do not want N identical HTTP calls for N environments. Examples:
 
 - One “release train” or “deployment pipeline” status API keyed by application or repo, not by individual environment branch
-- A batch endpoint that returns status for multiple environments in one JSON payload (pair with a success expression that returns [per-branch phases](#success-expression-return-types-promotionstrategy-context))
+- A batch endpoint that returns status for multiple environments in one JSON payload (pair with a success expression that returns [per-branch phases](#promotionstrategy-context))
 
 ### Template and trigger variables (`promotionstrategy` context)
 
@@ -136,9 +136,28 @@ Response != nil ? Response.StatusCode == 200 : Phase == "success"
 
 This is the **carry-forward pattern**: when an HTTP response is available, evaluate it (`Response.StatusCode == 200`). When no request was made this reconcile (`Response` is `nil`), fall back to `Phase` -- which holds the phase from the previous reconcile. If the previous reconcile already determined `"success"`, the expression preserves it without needing another HTTP call. On the very first reconcile `Phase` is `""` (empty), so the fallback returns `false` and the phase starts as `pending`.
 
-### Success expression return types (`promotionstrategy` context)
+### Success expression return types
 
-**Return types:**
+Both contexts accept a **boolean** or an **object**. The object shape differs because of what each context resolves: one environment per evaluation, or every environment from a single shared evaluation. Any other return type — or a `phase` string outside `success` / `pending` / `failure` — fails the reconcile and surfaces on the `Ready` condition.
+
+#### `environments` context
+
+1. **Boolean** — `true`: phase **success** for the environment being processed; `false`: **pending**.
+2. **Object** — shape: `{ "phase"?: "success" \| "pending" \| "failure" }`. An omitted or empty `phase` means **`pending`**, so the object form is what you use to report **failure** and fail the gate fast instead of staying pending until a timeout.
+
+Each evaluation is already scoped to one branch, so the per-branch keys below (`defaultPhase`, `environments`) are **rejected** in this context.
+
+```yaml
+success:
+  when:
+    # 5xx is a hard rejection; anything else is the usual success/pending ladder
+    expression: |
+      Response == nil ? { phase: Phase } :
+      Response.StatusCode >= 500 ? { phase: "failure" } :
+      { phase: Response.StatusCode == 200 && Response.Body.approved ? "success" : "pending" }
+```
+
+#### `promotionstrategy` context
 
 1. **Boolean** — `true`: all applicable environments get phase **success**; `false`: all get **pending** (not failure).
 2. **Object** — shape: `{ "defaultPhase"?: "success" \| "pending" \| "failure", "environments"?: [ { "branch": "<branch>", "phase": "..." }, ... ] }`  

--- a/internal/controller/webrequestcommitstatus_controller_test.go
+++ b/internal/controller/webrequestcommitstatus_controller_test.go
@@ -540,6 +540,96 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})
+	Describe("Polling Mode - Failure Phase (environments context)", func() {
+		var webRequestCommitStatus *promoterv1alpha1.WebRequestCommitStatus
+
+		BeforeEach(func() {
+			By("Creating a test HTTP server that returns 503")
+			testServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "rejected",
+				})
+			}))
+
+			By("Creating a WebRequestCommitStatus whose success expression returns a { phase } object")
+			webRequestCommitStatus = &promoterv1alpha1.WebRequestCommitStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-polling-phase-failure",
+					Namespace: "default",
+				},
+				Spec: promoterv1alpha1.WebRequestCommitStatusSpec{
+					PromotionStrategyRef: promoterv1alpha1.ObjectReference{
+						Name: name,
+					},
+					Key:      "external-approval",
+					ReportOn: constants.CommitRefProposed,
+					HTTPRequest: promoterv1alpha1.HTTPRequestSpec{
+						URLTemplate:    testServer.URL + "/validate",
+						MethodTemplate: "GET",
+						Timeout:        metav1.Duration{Duration: 10 * time.Second},
+					},
+					Success: promoterv1alpha1.SuccessSpec{
+						When: promoterv1alpha1.WhenWithOutputSpec{
+							Expression: `Response == nil ? { phase: Phase } : (Response.StatusCode >= 500 ? { phase: "failure" } : { phase: Response.StatusCode == 200 ? "success" : "pending" })`,
+						},
+					},
+					Mode: promoterv1alpha1.ModeSpec{
+						Polling: &promoterv1alpha1.PollingModeSpec{
+							Interval: metav1.Duration{Duration: 30 * time.Second},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, webRequestCommitStatus)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Cleaning up WebRequestCommitStatus")
+			if testServer != nil {
+				testServer.Close()
+			}
+			_ = k8sClient.Delete(ctx, webRequestCommitStatus)
+		})
+
+		It("should report failure phase when the success expression returns { phase: failure }", func() {
+			By("Waiting for WebRequestCommitStatus to process environments")
+			Eventually(func(g Gomega) {
+				var wrcs promoterv1alpha1.WebRequestCommitStatus
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      name + "-polling-phase-failure",
+					Namespace: "default",
+				}, &wrcs)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+
+				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
+				for i := range wrcs.Status.Environments {
+					if wrcs.Status.Environments[i].Branch == testBranchDevelopment {
+						devEnvStatus = &wrcs.Status.Environments[i]
+						break
+					}
+				}
+				g.Expect(devEnvStatus).ToNot(BeNil(), "Dev environment status should exist")
+				g.Expect(devEnvStatus.Phase).To(Equal(promoterv1alpha1.CommitPhaseFailure))
+				g.Expect(devEnvStatus.LastSuccessfulSha).To(BeEmpty(), "a failed environment must not record a successful SHA")
+				g.Expect(devEnvStatus.LastResponseStatusCode).ToNot(BeNil())
+				g.Expect(*devEnvStatus.LastResponseStatusCode).To(Equal(503))
+
+				By("Verifying the CommitStatus carries the failure phase")
+				commitStatusName := utils.CommitStatusResourceName(ctx, &wrcs, testBranchDevelopment)
+				var cs promoterv1alpha1.CommitStatus
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      commitStatusName,
+					Namespace: "default",
+				}, &cs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhaseFailure))
+			}, constants.EventuallyTimeout).Should(Succeed())
+		})
+	})
 
 	Describe("Polling Mode - Interval Short-Circuit", func() {
 		var (

--- a/internal/webrequest/environments.go
+++ b/internal/webrequest/environments.go
@@ -113,6 +113,27 @@ func parsePerBranchPhases(obj map[string]any) (promoterv1alpha1.CommitStatusPhas
 	return defaultPhase, m, nil
 }
 
+// parseSinglePhase extracts the phase from an expression result object of the form { phase } used by
+// context=environments, where each evaluation is already scoped to one branch. A missing or empty phase
+// yields pending. The per-branch keys accepted in promotionstrategy context (defaultPhase, environments)
+// are rejected here so a promotionstrategy-shaped expression is not silently reduced to pending.
+func parseSinglePhase(obj map[string]any) (promoterv1alpha1.CommitStatusPhase, error) {
+	for _, key := range []string{"defaultPhase", "environments"} {
+		if _, ok := obj[key]; ok {
+			return promoterv1alpha1.CommitPhasePending, fmt.Errorf("validation expression object must be { phase } in environments context, got key %q, which is only supported with mode.context: promotionstrategy", key)
+		}
+	}
+	phaseStr, err := getString(obj, "phase")
+	if err != nil {
+		return promoterv1alpha1.CommitPhasePending, fmt.Errorf("validation expression phase: %w", err)
+	}
+	phase, err := parsePhaseString(phaseStr, promoterv1alpha1.CommitPhasePending)
+	if err != nil {
+		return promoterv1alpha1.CommitPhasePending, fmt.Errorf("validation expression phase: %w", err)
+	}
+	return phase, nil
+}
+
 // getString reads an optional string field from an expression object. Missing or nil key yields ("", nil).
 // A present value with non-string type returns an error.
 func getString(m map[string]any, key string) (string, error) {

--- a/internal/webrequest/evaluator.go
+++ b/internal/webrequest/evaluator.go
@@ -86,16 +86,13 @@ func (e *ExpressionEvaluator) getCompiledTriggerDataExpression(expression string
 	return e.getCompiledExpression(expressionCacheKey{Prefix: "triggerdata", Expression: expression})
 }
 
-// getCompiledValidationExpression returns a cached or newly compiled validation expression program.
-// Used by evaluateValidationExpression. Compiled with expr.AsBool() so the expression must return a boolean.
+// getCompiledValidationExpression returns a cached or newly compiled success.when expression program.
+// Compiled without a result type constraint: the expression may return a bool or, depending on
+// spec.mode.context, an object ({ phase } for environments, { defaultPhase?, environments? } for
+// promotionstrategy). The return type is checked when the program runs, so both contexts share one
+// cache entry per expression.
 func (e *ExpressionEvaluator) getCompiledValidationExpression(expression string) (*vm.Program, error) {
-	return e.getCompiledExpression(expressionCacheKey{Prefix: "validation", Expression: expression}, expr.AsBool())
-}
-
-// getCompiledValidationExpressionForPromotionStrategy returns a cached or newly compiled validation expression without AsBool.
-// Used by evaluateValidationExpressionForPromotionStrategy when context is promotionstrategy: expression may return bool or object { defaultPhase?, environments? }.
-func (e *ExpressionEvaluator) getCompiledValidationExpressionForPromotionStrategy(expression string) (*vm.Program, error) {
-	return e.getCompiledExpression(expressionCacheKey{Prefix: "validation_promotionstrategy", Expression: expression})
+	return e.getCompiledExpression(expressionCacheKey{Prefix: "validation", Expression: expression})
 }
 
 // getCompiledResponseDataExpression returns a cached or newly compiled response output expression program.
@@ -206,30 +203,48 @@ func (e *ExpressionEvaluator) evaluateTriggerDataExpression(ctx context.Context,
 	return result, nil
 }
 
-// evaluateValidationExpression runs the success.when expression to determine the commit status phase.
+// evaluateValidationExpressionForEnvironments runs the success.when expression when mode.context is environments,
+// to determine the commit status phase for the branch currently being processed.
 // The exprData map is built by successWhenExprData and includes Response (nil when no request was made),
 // Branch, Phase, PromotionStrategy, WebRequestCommitStatus, and output variables.
-// Its boolean return is used directly: true → Success, false → Pending.
-func (e *ExpressionEvaluator) evaluateValidationExpression(ctx context.Context, expression string, exprData map[string]any) (bool, error) {
+// The expression may return: a boolean (true → success, false → pending); or an object { phase } where phase is
+// "success", "pending", or "failure" (defaults to "pending" when omitted or empty).
+// The per-branch object form accepted in promotionstrategy context is not accepted here: each evaluation is
+// already scoped to a single branch.
+func (e *ExpressionEvaluator) evaluateValidationExpressionForEnvironments(ctx context.Context, expression string, exprData map[string]any) (promoterv1alpha1.CommitStatusPhase, error) {
 	logger := log.FromContext(ctx)
 
 	program, err := e.getCompiledValidationExpression(expression)
 	if err != nil {
-		return false, fmt.Errorf("failed to compile validation expression: %w", err)
+		return promoterv1alpha1.CommitPhasePending, fmt.Errorf("failed to compile validation expression: %w", err)
 	}
 
 	output, err := expr.Run(program, exprData)
 	if err != nil {
-		return false, fmt.Errorf("failed to evaluate validation expression: %w", err)
+		return promoterv1alpha1.CommitPhasePending, fmt.Errorf("failed to evaluate validation expression: %w", err)
 	}
 
-	result, ok := output.(bool)
-	if !ok {
-		return false, fmt.Errorf("validation expression must return boolean, got %T", output)
+	// Boolean: true → success, false → pending
+	if b, ok := output.(bool); ok {
+		phase := promoterv1alpha1.CommitPhasePending
+		if b {
+			phase = promoterv1alpha1.CommitPhaseSuccess
+		}
+		logger.V(4).Info("Validation expression evaluated", "passed", b, "phase", phase)
+		return phase, nil
 	}
 
-	logger.V(4).Info("Validation expression evaluated", "passed", result)
-	return result, nil
+	// Object: { phase } — phase defaults to "pending" when omitted
+	if obj, ok := output.(map[string]any); ok {
+		phase, parseErr := parseSinglePhase(obj)
+		if parseErr != nil {
+			return promoterv1alpha1.CommitPhasePending, parseErr
+		}
+		logger.V(4).Info("Validation expression evaluated (phase object)", "phase", phase)
+		return phase, nil
+	}
+
+	return promoterv1alpha1.CommitPhasePending, fmt.Errorf("validation expression must return bool or object { phase }, got %T", output)
 }
 
 // evaluateValidationExpressionForPromotionStrategy runs the success.when expression when mode.context is promotionstrategy.
@@ -241,7 +256,7 @@ func (e *ExpressionEvaluator) evaluateValidationExpression(ctx context.Context, 
 func (e *ExpressionEvaluator) evaluateValidationExpressionForPromotionStrategy(ctx context.Context, expression string, exprData map[string]any) (phase promoterv1alpha1.CommitStatusPhase, phasePerBranch map[string]promoterv1alpha1.CommitStatusPhase, err error) {
 	logger := log.FromContext(ctx)
 
-	program, err := e.getCompiledValidationExpressionForPromotionStrategy(expression)
+	program, err := e.getCompiledValidationExpression(expression)
 	if err != nil {
 		return promoterv1alpha1.CommitPhasePending, nil, fmt.Errorf("failed to compile validation expression: %w", err)
 	}

--- a/internal/webrequest/evaluator_test.go
+++ b/internal/webrequest/evaluator_test.go
@@ -74,21 +74,72 @@ var _ = Describe("ExpressionEvaluator", func() {
 		})
 	})
 
-	Describe("evaluateValidationExpression", func() {
-		It("returns true for a boolean expression that evaluates to true", func() {
-			passed, err := e.evaluateValidationExpression(ctx, "Response.StatusCode == 200", map[string]any{
+	Describe("evaluateValidationExpressionForEnvironments", func() {
+		It("returns CommitPhaseSuccess for a boolean expression that evaluates to true", func() {
+			phase, err := e.evaluateValidationExpressionForEnvironments(ctx, "Response.StatusCode == 200", map[string]any{
 				"Response": map[string]any{"StatusCode": 200},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(passed).To(BeTrue())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
 		})
 
-		It("returns false when the boolean expression is false", func() {
-			passed, err := e.evaluateValidationExpression(ctx, "Response.StatusCode == 200", map[string]any{
+		It("returns CommitPhasePending when the boolean expression is false", func() {
+			phase, err := e.evaluateValidationExpressionForEnvironments(ctx, "Response.StatusCode == 200", map[string]any{
 				"Response": map[string]any{"StatusCode": 500},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(passed).To(BeFalse())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhasePending))
+		})
+
+		It("returns the phase from a { phase } object", func() {
+			expression := `Response.StatusCode >= 500 ? {"phase": "failure"} : {"phase": "success"}`
+
+			phase, err := e.evaluateValidationExpressionForEnvironments(ctx, expression, map[string]any{
+				"Response": map[string]any{"StatusCode": 503},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhaseFailure))
+
+			phase, err = e.evaluateValidationExpressionForEnvironments(ctx, expression, map[string]any{
+				"Response": map[string]any{"StatusCode": 200},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+		})
+
+		It("returns CommitPhasePending for an explicit pending phase", func() {
+			phase, err := e.evaluateValidationExpressionForEnvironments(ctx, `{"phase": "pending"}`, map[string]any{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhasePending))
+		})
+
+		It("defaults phase to pending when the object omits it", func() {
+			phase, err := e.evaluateValidationExpressionForEnvironments(ctx, `{"other": "value"}`, map[string]any{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(phase).To(Equal(promoterv1alpha1.CommitPhasePending))
+		})
+
+		It("errors on an unrecognized phase", func() {
+			_, err := e.evaluateValidationExpressionForEnvironments(ctx, `{"phase": "bogus"}`, map[string]any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unrecognized phase"))
+		})
+
+		It("errors when the object uses promotionstrategy-only keys", func() {
+			for _, expression := range []string{
+				`{"defaultPhase": "success"}`,
+				`{"environments": [{"branch": "env/dev", "phase": "success"}]}`,
+			} {
+				_, err := e.evaluateValidationExpressionForEnvironments(ctx, expression, map[string]any{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("promotionstrategy"))
+			}
+		})
+
+		It("errors when the expression returns a non-bool, non-object value", func() {
+			_, err := e.evaluateValidationExpressionForEnvironments(ctx, `"success"`, map[string]any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must return bool or object { phase }"))
 		})
 	})
 

--- a/internal/webrequest/reconcile.go
+++ b/internal/webrequest/reconcile.go
@@ -242,6 +242,10 @@ func applyHTTPExecutionDecision(
 	return reconcileOutcomeFromHTTPResponse(ctx, evaluator, wrcs, td, resp)
 }
 
+// resolvePhaseFromSuccessWhen evaluates spec.success.when.expression for the current mode.context.
+// In environments context the expression returns a bool or { phase } and resolves to a single phase for the
+// branch being processed (phasePerBranch is always nil). In promotionstrategy context it returns a bool or
+// { defaultPhase?, environments? } and may additionally resolve a per-branch phase map.
 func resolvePhaseFromSuccessWhen(
 	ctx context.Context,
 	evaluator *ExpressionEvaluator,
@@ -255,14 +259,11 @@ func resolvePhaseFromSuccessWhen(
 		}
 		return phase, phasePerBranch, nil
 	}
-	passed, err := evaluator.evaluateValidationExpression(ctx, wrcs.Spec.Success.When.Expression, exprData)
+	phase, err := evaluator.evaluateValidationExpressionForEnvironments(ctx, wrcs.Spec.Success.When.Expression, exprData)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to evaluate validation expression: %w", err)
 	}
-	if passed {
-		return promoterv1alpha1.CommitPhaseSuccess, nil, nil
-	}
-	return promoterv1alpha1.CommitPhasePending, nil, nil
+	return phase, nil, nil
 }
 
 func marshalSuccessWhenOutput(

--- a/ui/shared/src/types/generated/view.gen.ts
+++ b/ui/shared/src/types/generated/view.gen.ts
@@ -1008,9 +1008,9 @@ export type components = {
          *
          *     Context (the context field below) controls request fan-out and what data is available in templates and trigger expressions:
          *
-         *       - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and must return a boolean (true → success, false → pending; failure is not expressible).
+         *       - "environments" (default): one HTTP request per environment; each environment has its own phase and status; success.when.expression is evaluated per response and returns the phase for that one environment — see SuccessSpec for the boolean and object return shapes.
          *
-         *       - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see WhenWithOutputSpec.Expression for boolean vs per-branch object return shapes.
+         *       - "promotionstrategy": at most one HTTP request per WebRequestCommitStatus resource; CommitStatuses remain one per environment on each environment's reportOn SHA. success.when.expression runs once on that shared response — see SuccessSpec for boolean vs per-branch object return shapes.
          *
          *     When context is "promotionstrategy", Branch is empty for the shared HTTP request and trigger expressions. Use PromotionStrategy (e.g. status environments) for branch-specific values. For description and url templates, {{ .Branch }} and {{ .Phase }} are set per environment when rendering that environment's CommitStatus.
          */
@@ -1553,10 +1553,32 @@ export type components = {
              */
             selector: string;
         };
-        /** @description SuccessSpec defines when the commit status phase is success. */
+        /**
+         * @description SuccessSpec defines the phase reported on the CommitStatus.
+         *
+         *     When.Expression is evaluated every reconcile (whether or not an HTTP request was made). Its variables are documented on WhenWithOutputSpec.Expression, plus Response (nil when no request was made this reconcile). The accepted return values depend on spec.mode.context:
+         *
+         *       - "environments" (default): a boolean (true → success, false → pending), or an object { phase } where phase
+         *         is "success", "pending", or "failure". An omitted or empty phase means "pending". Each evaluation is
+         *         already scoped to one environment, so the per-branch keys below are rejected in this context.
+         *
+         *       - "promotionstrategy": a boolean (all applicable environments get success or pending), or an object
+         *         { defaultPhase?, environments? } where environments is a list of { branch, phase }. Branches not listed
+         *         (or all of them, when environments is omitted or empty) get defaultPhase, which is "pending" when omitted.
+         *
+         *     Any other return type, or an unrecognized phase string, fails the reconcile.
+         *
+         *     Examples:
+         *
+         *     	# environments context: fail fast on a 5xx instead of waiting for a timeout
+         *     	- "Response == nil ? Phase == 'success' : (Response.StatusCode >= 500 ? {phase: 'failure'} : Response.StatusCode == 200)"
+         *
+         *     	# promotionstrategy context: map a batch payload to per-branch phases
+         *     	- "{ defaultPhase: 'pending', environments: map(Response.Body.results, {{branch: .env, phase: .state}}) }"
+         */
         SuccessSpec: {
             /**
-             * @description When is evaluated every reconcile. See WhenWithOutputSpec.Expression.
+             * @description When is evaluated every reconcile. See SuccessSpec for return values and WhenWithOutputSpec.Expression for variables.
              * @default {}
              */
             when: components["schemas"]["WhenWithOutputSpec"];
@@ -1769,7 +1791,7 @@ export type components = {
             /** @description LastSuccessfulSha is the last commit SHA that achieved success status for this environment. Supports both SHA-1 (40 chars) and SHA-256 (64 chars) Git hash formats. */
             lastSuccessfulSha?: string;
             /**
-             * @description Phase represents the current phase of the validation. This controller sets only "pending" or "success"; it never sets "failure" (failure is allowed by the enum for API consistency).
+             * @description Phase represents the current phase of the validation. A boolean success expression yields only "pending" or "success"; "failure" requires the { phase } object return form documented on SuccessSpec.
              * @default
              */
             phase: string;

--- a/webrequestsimulator/simulate_test.go
+++ b/webrequestsimulator/simulate_test.go
@@ -633,6 +633,55 @@ var _ = Describe("webrequestsimulator.Simulate scenarios", func() {
 			Expect(byBranch["prod"].LastResponseStatusCode).ToNot(BeNil())
 			Expect(*byBranch["prod"].LastResponseStatusCode).To(Equal(201))
 		})
+
+		It("resolves failure from a { phase } object return", func() {
+			wrcs := basicWRCS(
+				promoterv1alpha1.ModeSpec{Polling: &promoterv1alpha1.PollingModeSpec{Interval: metav1.Duration{Duration: 0}}},
+				`Response.StatusCode >= 500 ? { phase: "failure" } : { phase: Response.StatusCode == 200 ? "success" : "pending" }`,
+			)
+			ps := twoEnvPromotionStrategy()
+
+			result, err := webrequestsimulator.Simulate(ctx, simulatortypes.Input{
+				WebRequestCommitStatus: wrcs,
+				PromotionStrategy:      ps,
+				HTTPResponses: []simulatortypes.HTTPResponse{
+					{Branch: "dev", Response: simulatortypes.Response{StatusCode: 200}},
+					{Branch: "prod", Response: simulatortypes.Response{StatusCode: 503}},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			byBranch := map[string]promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus{}
+			for _, e := range result.Status.Environments {
+				byBranch[e.Branch] = e
+			}
+			Expect(byBranch["dev"].Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+			Expect(byBranch["dev"].LastSuccessfulSha).To(Equal(byBranch["dev"].ReportedSha))
+			Expect(byBranch["prod"].Phase).To(Equal(promoterv1alpha1.CommitPhaseFailure))
+			Expect(byBranch["prod"].LastSuccessfulSha).To(BeEmpty(), "a failed environment must not record a successful SHA")
+
+			csByBranch := map[string]promoterv1alpha1.CommitStatusPhase{}
+			for _, cs := range result.CommitStatuses {
+				csByBranch[cs.Spec.Name] = cs.Spec.Phase
+			}
+			Expect(csByBranch[wrcs.Spec.Key+"/dev"]).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+			Expect(csByBranch[wrcs.Spec.Key+"/prod"]).To(Equal(promoterv1alpha1.CommitPhaseFailure))
+		})
+
+		It("surfaces an error for a promotionstrategy-shaped object return", func() {
+			wrcs := basicWRCS(
+				promoterv1alpha1.ModeSpec{Polling: &promoterv1alpha1.PollingModeSpec{Interval: metav1.Duration{Duration: 0}}},
+				`{ defaultPhase: "success" }`,
+			)
+			ps := twoEnvPromotionStrategy()
+
+			_, err := webrequestsimulator.Simulate(ctx, simulatortypes.Input{
+				WebRequestCommitStatus: wrcs,
+				PromotionStrategy:      ps,
+				HTTPResponses:          envHTTPMocksSame([]string{"dev", "prod"}, nil),
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("promotionstrategy"))
+		})
 	})
 
 	Describe("promotionstrategy context", func() {


### PR DESCRIPTION
## What

In `environments` context (the default), `spec.success.when.expression` was compiled with `expr.AsBool()`, so it could only resolve to **success** (`true`) or **pending** (`false`). A gate could never report **failure**, even when the external system had hard-rejected the change — the promotion sat at pending until something timed out. The `promotionstrategy` context already accepted a richer return value (`bool` or `{ defaultPhase?, environments? }`).

This aligns the two: in `environments` context the expression may now return a `bool` **or** an object `{ phase }`, where `phase` is `success`, `pending`, or `failure`.

```yaml
success:
  when:
    expression: |
      Response == nil ? { phase: Phase } :
      Response.StatusCode >= 500 ? { phase: "failure" } :
      { phase: Response.StatusCode == 200 && Response.Body.approved ? "success" : "pending" }
```

Each `environments`-context evaluation is already scoped to a single branch, so the per-branch keys (`defaultPhase`, `environments`) are **not** accepted there — an expression using them fails with an error naming the context that supports them, rather than being silently reduced to pending.

## How

- `internal/webrequest/evaluator.go` — dropped `expr.AsBool()` from the environments compile path; renamed `evaluateValidationExpression` → `evaluateValidationExpressionForEnvironments`, now returning a `CommitStatusPhase`. Both contexts compile with identical options and share one expr cache entry per expression (the separate `validation_promotionstrategy` cache prefix is gone).
- `internal/webrequest/environments.go` — new `parseSinglePhase`, reusing the existing `getString` / `parsePhaseString` helpers. Omitted or empty `phase` → `pending`; an unrecognized phase string errors.
- `internal/webrequest/reconcile.go` — `resolvePhaseFromSuccessWhen` returns the resolved phase directly. The rest of the environments reconcile already handled `failure` correctly (no `lastSuccessfulSha` update, no success transition, enum already permits it).
- API doc comments — `SuccessSpec` now documents the per-context return contract; `ModeSpec` and `WebRequestCommitStatusEnvironmentStatus.Phase` no longer state that failure is unreachable. Regenerated CRDs, applyconfiguration, view-apiserver OpenAPI, and UI types.
- Docs — the success-expression return-types section is now context-neutral with `environments` / `promotionstrategy` subsections; fixed the in-page anchor that pointed at the old heading.

## Compatibility

Boolean-returning expressions behave exactly as before. The only difference for them: a non-bool return is now reported when the program runs rather than when it compiles — both surface the same way, as a reconcile error on the `Ready` condition.

## Testing

- Full non-e2e suite green: `go test $(go list ./... | grep -v /e2e)`, including the envtest-backed controller package.
- `make lint` — 0 issues; `make fmt vet` clean; all four codegen targets re-run with no drift.
- New coverage: six evaluator cases (`{phase}` success/pending/failure, default pending, unrecognized phase, promotionstrategy-only keys, non-bool/non-object); two simulator scenarios (per-branch failure with CommitStatus phases and `lastSuccessfulSha` left empty; promotionstrategy-shaped object rejected); one envtest spec asserting a `failure` phase reaches both `status.environments[]` and the CommitStatus against a real API server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAuHkCDpEWS2WB8CJoFvhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAuHkCDpEWS2WB8CJoFvhf)_

fixes: https://github.com/argoproj-labs/gitops-promoter/issues/1899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Success expressions in environment context can now return `{ phase }` objects to explicitly report pending, success, or failure.
  * Boolean results continue to map to pending or success.
  * Invalid phases, unsupported return types, and context-specific object shapes are now clearly rejected.

* **Documentation**
  * Expanded configuration, API, CRD, and simulator documentation with supported return formats, behavior, and examples.

* **Tests**
  * Added coverage for environment-specific success and failure phases, validation errors, and commit status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->