### PR TITLE
ci: enable ginkgolinter and fix no-op Eventually assertions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
+    - ginkgolinter
     - govet
     - lll
     - loggercheck

--- a/internal/controller/promotionstrategy_controller_test.go
+++ b/internal/controller/promotionstrategy_controller_test.go
@@ -2526,7 +2526,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					GinkgoLogr.Info("Updated commit status for development to sha: " + sha)
 					g.Expect(err).To(Succeed())
 
-					g.Expect(len(ctpDev.Status.Proposed.CommitStatuses)).To(Not(BeZero()))
+					g.Expect(ctpDev.Status.Proposed.CommitStatuses).ToNot(BeEmpty())
 					g.Expect(ctpDev.Status.Proposed.CommitStatuses[0].Url).To(Equal(proposedCommitStatusDevelopment.Spec.Url))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
@@ -2595,8 +2595,8 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					g.Expect(promotionStrategy.Status.Environments[2].PullRequest.ID).To(Not(BeZero()))
 					g.Expect(promotionStrategy.Status.Environments[2].PullRequest.Url).To(ContainSubstring("localhost"))
 
-					g.Expect(len(promotionStrategy.Status.Environments) > 0).To(BeTrue())
-					g.Expect(len(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses) > 0).To(BeTrue())
+					g.Expect(promotionStrategy.Status.Environments).ToNot(BeEmpty())
+					g.Expect(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses).ToNot(BeEmpty())
 					g.Expect(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses[0].Url).To(Equal(proposedCommitStatusDevelopment.Spec.Url))
 
 					for _, environment := range promotionStrategy.Status.Environments {
@@ -2870,17 +2870,17 @@ var _ = Describe("PromotionStrategy Controller", func() {
 
 				By("Checking that the ArgoCDCommitStatus applicationsSelected field is correct")
 
-				Eventually(func() {
-					Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 						Namespace: argocdCommitStatus.Namespace,
 						Name:      argocdCommitStatus.Name,
 					}, &argocdCommitStatus)).To(Succeed())
-					Expect(argocdCommitStatus.Status.ApplicationsSelected).To(HaveLen(3))
+					g.Expect(argocdCommitStatus.Status.ApplicationsSelected).To(HaveLen(3))
 					// Check that it's sorted by dev, stage, prod.
-					Expect(argocdCommitStatus.Status.ApplicationsSelected[0].Name).To(Equal(argoCDAppDev.Name))
-					Expect(argocdCommitStatus.Status.ApplicationsSelected[1].Name).To(Equal(argoCDAppStaging.Name))
-					Expect(argocdCommitStatus.Status.ApplicationsSelected[2].Name).To(Equal(argoCDAppProduction.Name))
-				})
+					g.Expect(argocdCommitStatus.Status.ApplicationsSelected[0].Name).To(Equal(argoCDAppDev.Name))
+					g.Expect(argocdCommitStatus.Status.ApplicationsSelected[1].Name).To(Equal(argoCDAppStaging.Name))
+					g.Expect(argocdCommitStatus.Status.ApplicationsSelected[2].Name).To(Equal(argoCDAppProduction.Name))
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Checking that the CommitStatus for each environment is created from ArgoCDCommitStatus")
 
@@ -3052,7 +3052,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
 				}, constants.EventuallyTimeout).Should(Succeed())
-				Expect(time.Since(lastTransitionTime.Time) >= lastTransitionTimeThreshold).To(BeTrue())
+				Expect(time.Since(lastTransitionTime.Time)).To(BeNumerically(">=", lastTransitionTimeThreshold))
 			})
 		})
 
@@ -3308,7 +3308,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
 				}, constants.EventuallyTimeout).Should(Succeed())
-				Expect(time.Since(lastTransitionTime.Time) >= lastTransitionTimeThreshold).To(BeTrue(), fmt.Sprintf("Last transition time should be at least %s ago, but was %s ago", lastTransitionTimeThreshold, time.Since(lastTransitionTime.Time)))
+				Expect(time.Since(lastTransitionTime.Time)).To(BeNumerically(">=", lastTransitionTimeThreshold), fmt.Sprintf("Last transition time should be at least %s ago, but was %s ago", lastTransitionTimeThreshold, time.Since(lastTransitionTime.Time)))
 			})
 		})
 	})
@@ -3469,7 +3469,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					GinkgoLogr.Info("Updated commit status for development to sha: " + sha)
 					g.Expect(err).To(Succeed())
 
-					g.Expect(len(ctpDev.Status.Proposed.CommitStatuses)).To(Not(BeZero()))
+					g.Expect(ctpDev.Status.Proposed.CommitStatuses).ToNot(BeEmpty())
 					g.Expect(ctpDev.Status.Proposed.CommitStatuses[0].Url).To(Equal(proposedCommitStatusDevelopment.Spec.Url))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
@@ -3545,7 +3545,7 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					GinkgoLogr.Info("Updated commit status for staging to sha: " + sha)
 					g.Expect(err).To(Succeed())
 
-					g.Expect(len(ctpStaging.Status.Proposed.CommitStatuses)).To(Not(BeZero()))
+					g.Expect(ctpStaging.Status.Proposed.CommitStatuses).ToNot(BeEmpty())
 					g.Expect(ctpStaging.Status.Proposed.CommitStatuses[0].Url).To(Equal(proposedCommitStatusStaging.Spec.Url))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
@@ -3614,8 +3614,8 @@ var _ = Describe("PromotionStrategy Controller", func() {
 					g.Expect(promotionStrategy.Status.Environments[2].PullRequest.ID).To(Not(BeZero()))
 					g.Expect(promotionStrategy.Status.Environments[2].PullRequest.Url).To(ContainSubstring("localhost"))
 
-					g.Expect(len(promotionStrategy.Status.Environments) > 0).To(BeTrue())
-					g.Expect(len(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses) > 0).To(BeTrue())
+					g.Expect(promotionStrategy.Status.Environments).ToNot(BeEmpty())
+					g.Expect(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses).ToNot(BeEmpty())
 					g.Expect(promotionStrategy.Status.Environments[0].Proposed.CommitStatuses[0].Url).To(Equal(proposedCommitStatusDevelopment.Spec.Url))
 
 					for _, environment := range promotionStrategy.Status.Environments {

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -86,13 +86,14 @@ var _ = Describe("PullRequest Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
+					g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
 				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 
 			It("should successfully reconcile the resource when updating title then merging", func() {
 				By("Reconciling updating of the PullRequest")
 				Eventually(func(g Gomega) {
-					_ = k8sClient.Get(ctx, typeNamespacedName, pullRequest)
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					pullRequest.Spec.Title = "Updated Title"
 					g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
 				}, constants.EventuallyTimeout).Should(Succeed())
@@ -100,19 +101,24 @@ var _ = Describe("PullRequest Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Spec.Title).To(Equal("Updated Title"))
+					readyCond := meta.FindStatusCondition(pullRequest.Status.Conditions, string(conditions.Ready))
+					g.Expect(readyCond).NotTo(BeNil())
+					g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(readyCond.ObservedGeneration).To(Equal(pullRequest.Generation))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Reconciling merging of the PullRequest")
+				mergeSha := getGitBranchSHA(ctx, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name, pullRequest.Spec.SourceBranch)
 				Eventually(func(g Gomega) {
-					_ = k8sClient.Get(ctx, typeNamespacedName, pullRequest)
-					pullRequest.Spec.State = "merged"
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+					pullRequest.Spec.MergeSha = mergeSha
+					pullRequest.Spec.State = promoterv1alpha1.PullRequestMerged
 					g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("PullRequest Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 
 			It("should successfully reconcile the resource when updating title then merging", func() {
@@ -95,12 +95,12 @@ var _ = Describe("PullRequest Controller", func() {
 					_ = k8sClient.Get(ctx, typeNamespacedName, pullRequest)
 					pullRequest.Spec.Title = "Updated Title"
 					g.Expect(k8sClient.Update(ctx, pullRequest)).To(Succeed())
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Eventually(func(g Gomega) {
-					Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Spec.Title).To(Equal("Updated Title"))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Reconciling merging of the PullRequest")
 				Eventually(func(g Gomega) {
@@ -113,7 +113,7 @@ var _ = Describe("PullRequest Controller", func() {
 					err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(err.Error()).To(ContainSubstring("pullrequests.promoter.argoproj.io \"" + name + "\" not found"))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})
 
@@ -533,11 +533,16 @@ var _ = Describe("PullRequest Controller", func() {
 				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
 				Expect(k8sClient.Create(ctx, pullRequest)).To(Succeed())
 
-				By("Waiting for PullRequest to be ready")
+				By("Waiting for GitRepository finalizer and PullRequest to be ready")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+					g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 
 			It("should prevent deletion of GitRepository while PullRequest exists", func() {
@@ -546,9 +551,11 @@ var _ = Describe("PullRequest Controller", func() {
 
 				By("Verifying GitRepository is not deleted while PullRequest exists")
 				Consistently(func(g Gomega) {
-					err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
-					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed(),
+						"GitRepository was deleted while a referencing PullRequest still exists")
 					g.Expect(gitRepo.DeletionTimestamp).ToNot(BeNil())
+					g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer),
+						"GitRepository finalizer should remain until all referencing PullRequests are gone")
 				}, "5s", "1s").Should(Succeed())
 
 				By("Deleting the PullRequest")
@@ -557,16 +564,14 @@ var _ = Describe("PullRequest Controller", func() {
 				By("Verifying PullRequest is deleted")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Verifying GitRepository is now deleted")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})
 
@@ -589,6 +594,17 @@ var _ = Describe("PullRequest Controller", func() {
 				Expect(k8sClient.Create(ctx, scmSecret)).To(Succeed())
 				Expect(k8sClient.Create(ctx, scmProvider)).To(Succeed())
 				Expect(k8sClient.Create(ctx, gitRepo)).To(Succeed())
+
+				By("Waiting for ScmProvider and GitRepository finalizers")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmProvider)).To(Succeed())
+					g.Expect(scmProvider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, gitRepo)).To(Succeed())
+					g.Expect(gitRepo.Finalizers).To(ContainElement(promoterv1alpha1.GitRepositoryFinalizer))
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 
 			It("should prevent deletion of ScmProvider while GitRepository exists", func() {
@@ -597,9 +613,11 @@ var _ = Describe("PullRequest Controller", func() {
 
 				By("Verifying ScmProvider is not deleted while GitRepository exists")
 				Consistently(func(g Gomega) {
-					err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
-					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmProvider)).To(Succeed(),
+						"ScmProvider was deleted while a referencing GitRepository still exists")
 					g.Expect(scmProvider.DeletionTimestamp).ToNot(BeNil())
+					g.Expect(scmProvider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer),
+						"ScmProvider finalizer should remain until all referencing GitRepositories are gone")
 				}, "5s", "1s").Should(Succeed())
 
 				By("Deleting the GitRepository")
@@ -608,16 +626,14 @@ var _ = Describe("PullRequest Controller", func() {
 				By("Verifying GitRepository is deleted")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Verifying ScmProvider is now deleted")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})
 
@@ -650,13 +666,13 @@ var _ = Describe("PullRequest Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmSecret)).To(Succeed())
 					g.Expect(scmSecret.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderSecretFinalizer))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Verifying ScmProvider has its own finalizer")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmProvider)).To(Succeed())
 					g.Expect(scmProvider.Finalizers).To(ContainElement(promoterv1alpha1.ScmProviderFinalizer))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Deleting the ScmProvider")
 				Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
@@ -664,14 +680,13 @@ var _ = Describe("PullRequest Controller", func() {
 				By("Verifying ScmProvider is deleted and Secret finalizer is removed")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, scmSecret)).To(Succeed())
 					g.Expect(scmSecret.Finalizers).ToNot(ContainElement(promoterv1alpha1.ScmProviderSecretFinalizer))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})
 
@@ -717,7 +732,7 @@ var _ = Describe("PullRequest Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 
 			It("should allow deletion of entire resource hierarchy when deleting from top down", func() {
@@ -725,26 +740,26 @@ var _ = Describe("PullRequest Controller", func() {
 				Expect(k8sClient.Delete(ctx, pullRequest)).To(Succeed())
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, pullRequest)
-					g.Expect(err).To(HaveOccurred())
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Expect(k8sClient.Delete(ctx, gitRepo)).To(Succeed())
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, gitRepo)
-					g.Expect(err).To(HaveOccurred())
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Expect(k8sClient.Delete(ctx, scmProvider)).To(Succeed())
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, scmProvider)
-					g.Expect(err).To(HaveOccurred())
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				Expect(k8sClient.Delete(ctx, scmSecret)).To(Succeed())
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(ctx, typeNamespacedName, scmSecret)
-					g.Expect(err).To(HaveOccurred())
-				}, constants.EventuallyTimeout)
+					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}, constants.EventuallyTimeout).Should(Succeed())
 			})
 		})
 
@@ -781,7 +796,7 @@ var _ = Describe("PullRequest Controller", func() {
 					g.Expect(k8sClient.Get(ctx, typeNamespacedName, pullRequest)).To(Succeed())
 					g.Expect(pullRequest.Status.State).To(Equal(promoterv1alpha1.PullRequestOpen))
 					g.Expect(pullRequest.Status.ID).ToNot(BeEmpty())
-				}, constants.EventuallyTimeout)
+				}, constants.EventuallyTimeout).Should(Succeed())
 
 				// Get the actual SHA of the source branch for the merge
 				mergeSha = getGitBranchSHA(ctx, gitRepo.Spec.Fake.Owner, gitRepo.Spec.Fake.Name, pullRequest.Spec.SourceBranch)

--- a/internal/controller/pullrequest_controller_test.go
+++ b/internal/controller/pullrequest_controller_test.go
@@ -72,6 +72,10 @@ var _ = Describe("PullRequest Controller", func() {
 				By("Creating test resources")
 				name, scmSecret, scmProvider, gitRepo, pullRequest = pullRequestResources(ctx, "update-title-merge")
 
+				// Override branches to use ones that exist in the test git server setup
+				pullRequest.Spec.TargetBranch = testBranchDevelopment
+				pullRequest.Spec.SourceBranch = testBranchDevelopmentNext
+
 				typeNamespacedName = types.NamespacedName{
 					Name:      name,
 					Namespace: "default",

--- a/internal/controller/webrequestcommitstatus_controller_test.go
+++ b/internal/controller/webrequestcommitstatus_controller_test.go
@@ -603,7 +603,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
 				for i := range wrcs.Status.Environments {

--- a/internal/controller/webrequestcommitstatus_controller_test.go
+++ b/internal/controller/webrequestcommitstatus_controller_test.go
@@ -255,7 +255,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 
 				// Should have status for all environments (dev, staging, production)
 				// since ProposedCommitStatuses is set globally on the PromotionStrategy
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				// Find the dev environment status
 				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
@@ -417,7 +417,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				// Should have status for environments
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				// Find the dev environment status
 				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
@@ -501,7 +501,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
 				for i := range wrcs.Status.Environments {
@@ -702,7 +702,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(Equal(3), "all three environments must be processed before snapshotting the request count")
+				g.Expect(wrcs.Status.Environments).To(HaveLen(3), "all three environments must be processed before snapshotting the request count")
 				for i := range wrcs.Status.Environments {
 					g.Expect(wrcs.Status.Environments[i].LastRequestTime).ToNot(BeNil(), "LastRequestTime should be set after first request")
 					g.Expect(wrcs.Status.Environments[i].Phase).To(Equal(promoterv1alpha1.CommitPhasePending), "validation fails (approved: false) so phase stays Pending")
@@ -820,7 +820,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				// Should have status for environments
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				// Find an environment with trigger data stored
 				var foundEnvWithData bool
@@ -1375,7 +1375,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				// Should have status for at least dev environment
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				devCommitStatusName = utils.CommitStatusResourceName(ctx, &wrcs, testBranchDevelopment)
 				var cs promoterv1alpha1.CommitStatus
@@ -1474,7 +1474,7 @@ var _ = Describe("WebRequestCommitStatus Controller", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				// Should have status for environments
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				// Find the dev environment status
 				var devEnvStatus *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
@@ -1618,7 +1618,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				devEnv := wrcs.Status.Environments[0]
 
@@ -1703,7 +1703,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 				g.Expect(wrcs.Status.Environments[0].ResponseOutput).NotTo(BeNil())
 				firstResponseData = wrcs.Status.Environments[0].ResponseOutput.Raw
 			}, constants.EventuallyTimeout).Should(Succeed())
@@ -1716,7 +1716,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				currentResponseData := wrcs.Status.Environments[0].ResponseOutput.Raw
 				g.Expect(currentResponseData).To(Equal(firstResponseData), "response output should be preserved")
@@ -1802,7 +1802,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				devEnv := wrcs.Status.Environments[0]
 				g.Expect(devEnv.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
@@ -1896,7 +1896,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				devEnv := wrcs.Status.Environments[0]
 				g.Expect(devEnv.ResponseOutput).NotTo(BeNil())
@@ -1915,7 +1915,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 
 				// Verify the values
 				g.Expect(responseData["statusCode"]).To(Equal(float64(200)))
-				g.Expect(responseData["approved"]).To(Equal(true))
+				g.Expect(responseData["approved"]).To(BeTrue())
 				g.Expect(responseData["nestedField"]).To(Equal("value1"))
 				g.Expect(responseData["rateLimit"]).To(Equal(float64(42)))
 				g.Expect(responseData["timestamp"]).To(Equal("2024-01-15T10:30:00Z"))
@@ -1980,7 +1980,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 
 				// Verify validation succeeded
 				g.Expect(wrcs.Status.Environments[0].Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
@@ -2115,7 +2115,7 @@ var _ = Describe("WebRequestCommitStatus Controller - ResponseOutput", Ordered, 
 					Namespace: "default",
 				}, &wrcs)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(wrcs.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(wrcs.Status.Environments).ToNot(BeEmpty())
 				var devEnv *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
 				for i := range wrcs.Status.Environments {
 					if wrcs.Status.Environments[i].Branch == testBranchDevelopment {
@@ -3411,7 +3411,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Context Switching", Ordere
 			var fetched promoterv1alpha1.WebRequestCommitStatus
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(len(fetched.Status.Environments)).To(Equal(3), "all PromotionStrategy environments should have status entries")
+			g.Expect(fetched.Status.Environments).To(HaveLen(3), "all PromotionStrategy environments should have status entries")
 			g.Expect(fetched.Status.PromotionStrategyContext).To(BeNil(), "PromotionStrategyContext should be nil in environments context")
 
 			for _, branch := range []string{testBranchDevelopment, testBranchStaging, testBranchProduction} {
@@ -3470,7 +3470,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Context Switching", Ordere
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(fetched.Status.PromotionStrategyContext).To(BeNil(), "PromotionStrategyContext should be nil after switching back to environments context")
-			g.Expect(len(fetched.Status.Environments)).To(Equal(3), "all environments should be repopulated after switching back")
+			g.Expect(fetched.Status.Environments).To(HaveLen(3), "all environments should be repopulated after switching back")
 
 			for _, branch := range []string{testBranchDevelopment, testBranchStaging, testBranchProduction} {
 				var envSt *promoterv1alpha1.WebRequestCommitStatusEnvironmentStatus
@@ -3598,7 +3598,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Success.when Every Reconci
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(fetched.Status.Environments).ToNot(BeEmpty())
 
 				for _, env := range fetched.Status.Environments {
 					if env.Branch == testBranchDevelopment {
@@ -3773,8 +3773,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Success.when Every Reconci
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(Equal(3),
-					"all three environments must be processed before snapshotting the HTTP request count")
+				g.Expect(fetched.Status.Environments).To(HaveLen(3), "all three environments must be processed before snapshotting the HTTP request count")
 				for _, env := range fetched.Status.Environments {
 					g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess),
 						"environment %s should be success before snapshotting", env.Branch)
@@ -3879,8 +3878,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Success.when Every Reconci
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(Equal(3),
-					"all three environments must be processed before snapshotting the HTTP hit count")
+				g.Expect(fetched.Status.Environments).To(HaveLen(3), "all three environments must be processed before snapshotting the HTTP hit count")
 				for _, env := range fetched.Status.Environments {
 					g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess),
 						"environment %s should be success before snapshotting", env.Branch)
@@ -4042,7 +4040,7 @@ var _ = Describe("WebRequestCommitStatus Controller - SuccessOutput", Ordered, f
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(fetched.Status.Environments).ToNot(BeEmpty())
 
 				var foundEnvWithSuccessOutput bool
 				for _, envStatus := range fetched.Status.Environments {
@@ -4116,7 +4114,7 @@ var _ = Describe("WebRequestCommitStatus Controller - SuccessOutput", Ordered, f
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(fetched.Status.Environments).ToNot(BeEmpty())
 
 				for _, envStatus := range fetched.Status.Environments {
 					if envStatus.Phase == promoterv1alpha1.CommitPhaseSuccess {
@@ -4269,7 +4267,7 @@ var _ = Describe("WebRequestCommitStatus Controller - SuccessOutput", Ordered, f
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(fetched.Status.Environments).ToNot(BeEmpty())
 
 				var foundWithOutput bool
 				for _, envStatus := range fetched.Status.Environments {
@@ -4411,7 +4409,7 @@ var _ = Describe("WebRequestCommitStatus Controller - Dry SHA Guard", Ordered, f
 				var fetched promoterv1alpha1.WebRequestCommitStatus
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: wrcs.Name, Namespace: "default"}, &fetched)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(len(fetched.Status.Environments)).To(BeNumerically(">=", 1))
+				g.Expect(fetched.Status.Environments).ToNot(BeEmpty())
 
 				for _, env := range fetched.Status.Environments {
 					if env.Branch == testBranchDevelopment {


### PR DESCRIPTION
Eventually without Should() never polls, which made GitRepository finalizer tests flake under load. Enable the linter and fix the existing hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved controller test assertions for clearer validation of asynchronous operations, collection contents, timestamps, and resource finalizers.
  - Strengthened deletion checks and status verification in pull request and web request workflows.
  - Added coverage for polling failures returning an appropriate failure status.
- **Chores**
  - Enabled an additional linter to improve code quality and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->