### PR TITLE
chore(ci): run build-installer to update manifests

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -232,6 +232,8 @@
           'make lint-fix || true',
           // Regenerate mocks with the bumped mockery (must match the Go toolchain).
           'make mockery-gen',
+          // Regenerate CRDs, applyconfiguration, deepcopy, dist/ bundles, etc. (CI Check Codegen).
+          'make build-installer',
         ],
         installTools: {
           golang: {},
@@ -241,6 +243,12 @@
           '**/mock/**',
           'go.mod',
           'go.sum',
+          'config/**',
+          'test/**',
+          'applyconfiguration/**',
+          'dist/**',
+          'hack/celcost/report.md',
+          'ui/extension/iconStyles.generated.ts',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
This step currently gets missed, and the codegen CI check fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency upgrade workflows to regenerate installer and code-generation outputs.
  * Expanded change detection to cover configuration, tests, distribution bundles, cost reports, and generated UI styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->