### PR TITLE
fix(ui): use correct PR link in history view detail drawer

### DIFF
--- a/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
+++ b/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
@@ -71,6 +71,11 @@ const DetailDrawer: React.FC<{
     : undefined;
   const refs = cell.references ?? [];
 
+  const [prId, prUrl] =
+    cell.pullRequest?.id && cell.pullRequest?.url
+      ? [cell.pullRequest.id, cell.pullRequest.url]
+      : [row.prId, row.prUrl];
+
   return (
     <aside
       className={`hp-drawer hp-drawer--open ${isResizing ? 'hp-drawer--resizing' : ''}`}
@@ -145,19 +150,19 @@ const DetailDrawer: React.FC<{
                 <span className="hp-drawer__sha">{row.dryShaShort}</span>
               </Tooltip>
             )}
-            {(cell.pullRequest?.id ?? row.prId) && (
+            {prId && prUrl && (
               <>
                 <span className="hp-drawer__sep" aria-hidden="true">
                   ·
                 </span>
                 <a
-                  href={cell.pullRequest?.url ?? row.prUrl}
+                  href={prUrl}
                   target="_blank"
                   rel="noreferrer"
                   className="hp-drawer__pr"
-                  aria-label={`Pull request #${cell.pullRequest?.id ?? row.prId}, opens in new tab`}
+                  aria-label={`Pull request #${prId}, opens in new tab`}
                 >
-                  <GoGitPullRequest aria-hidden="true" /> #{cell.pullRequest?.id ?? row.prId}
+                  <GoGitPullRequest aria-hidden="true" /> #{prId}
                 </a>
               </>
             )}

--- a/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
+++ b/ui/components-lib/src/components/HistoryView/DetailDrawer/DetailDrawer.tsx
@@ -145,19 +145,19 @@ const DetailDrawer: React.FC<{
                 <span className="hp-drawer__sha">{row.dryShaShort}</span>
               </Tooltip>
             )}
-            {row.prId && (
+            {(cell.pullRequest?.id ?? row.prId) && (
               <>
                 <span className="hp-drawer__sep" aria-hidden="true">
                   ·
                 </span>
                 <a
-                  href={row.prUrl}
+                  href={cell.pullRequest?.url ?? row.prUrl}
                   target="_blank"
                   rel="noreferrer"
                   className="hp-drawer__pr"
-                  aria-label={`Pull request #${row.prId}, opens in new tab`}
+                  aria-label={`Pull request #${cell.pullRequest?.id ?? row.prId}, opens in new tab`}
                 >
-                  <GoGitPullRequest aria-hidden="true" /> #{row.prId}
+                  <GoGitPullRequest aria-hidden="true" /> #{cell.pullRequest?.id ?? row.prId}
                 </a>
               </>
             )}


### PR DESCRIPTION
use the PR link for the cell as opposed to the row's PR ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pull-request links in history details now use matching ID and URL information from the most specific available source.
  - Links appear only when both required values are available, preventing incomplete or misleading links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->