### PR TITLE
fix: gcs test flake

### DIFF
--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -783,6 +783,21 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 			_, err = runGitCmd(ctx, gitPath, "checkout", "-B", testBranchStaging, "origin/"+testBranchStaging)
 			Expect(err).NotTo(HaveOccurred())
 
+			// The webhook receiver matches a push to a ChangeTransferPolicy by looking up the
+			// payload's "before" sha against the CTP's recorded proposed/active hydrated sha, so
+			// "before" has to be the remote tip as it stands now, not a locally-created commit.
+			beforeSha, err := runGitCmd(ctx, gitPath, "rev-parse", "HEAD")
+			Expect(err).NotTo(HaveOccurred())
+			beforeSha = strings.TrimSpace(beforeSha)
+
+			By("Waiting for staging's recorded active hydrated sha to match the remote tip")
+			Eventually(func(g Gomega) {
+				var ctp promoterv1alpha1.ChangeTransferPolicy
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: stagingCTPName, Namespace: "default"}, &ctp)).To(Succeed())
+				g.Expect(ctp.Status.Active.Hydrated.Sha).To(Equal(beforeSha),
+					"the webhook's before sha must match the CTP status or the push will not trigger a reconcile")
+			}, constants.EventuallyTimeout).Should(Succeed())
+
 			// First, create a commit that we can revert
 			f, err := os.Create(gitPath + "/feature-to-revert.yaml")
 			Expect(err).NotTo(HaveOccurred())
@@ -800,11 +815,6 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 			commitToRevert, err := runGitCmd(ctx, gitPath, "rev-parse", "HEAD")
 			Expect(err).NotTo(HaveOccurred())
 			commitToRevert = strings.TrimSpace(commitToRevert)
-
-			// Get the SHA before we make the revert for the webhook
-			beforeSha, err := runGitCmd(ctx, gitPath, "rev-parse", testBranchStaging)
-			Expect(err).NotTo(HaveOccurred())
-			beforeSha = strings.TrimSpace(beforeSha)
 
 			// Use actual git revert command - this creates a commit with "Revert" prefix automatically
 			_, err = runGitCmd(ctx, gitPath, "revert", "--no-edit", commitToRevert)


### PR DESCRIPTION
## Summary

Fixes a flake in the GitCommitStatus revert webhook test. The simulated push payload's `before` SHA must match the remote tip and the staging CTP's recorded active hydrated SHA — otherwise the webhook receiver won't match the push and the test races the reconciler.

The test now captures `beforeSha` from the remote tip after checkout and waits for `ctp.Status.Active.Hydrated.Sha` to catch up before creating the revert commit.

## Test plan

- [x] Focused ginkgo run on the revert webhook spec
- [x] `make test-parallel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved revert-detection test synchronization to ensure staging branch updates are fully reflected before commit and revert actions.
  * Removed redundant branch-tip lookup during the test flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->