### PR TITLE
perf(cache): retain only promoter credential keys in Secret informer …

### DIFF
--- a/internal/cache/instanceid.go
+++ b/internal/cache/instanceid.go
@@ -22,12 +22,18 @@ var partitionedSecretObject client.Object = &corev1.Secret{}
 // set, only resources with promoter.argoproj.io/instance-id equal to *instanceID are cached.
 //
 // ControllerConfiguration is scoped to controllerNamespace only (not instance-id partitioned).
+// Secret informers additionally apply secretDataTransform so only promoter credential keys are
+// retained in cache (see secret_transform.go).
 func OptionsForInstanceID(instanceID *string, controllerNamespace string) cache.Options {
 	sel := instanceIDSelector(instanceID)
 	objs := PartitionedObjects()
 	byObject := make(map[client.Object]cache.ByObject, len(objs)+1)
 	for _, obj := range objs {
 		byObject[obj] = cache.ByObject{Label: sel}
+	}
+	byObject[partitionedSecretObject] = cache.ByObject{
+		Label:     sel,
+		Transform: secretDataTransform(),
 	}
 	byObject[PartitionedControllerConfigurationObject()] = cache.ByObject{
 		Namespaces: map[string]cache.Config{

--- a/internal/cache/instanceid_test.go
+++ b/internal/cache/instanceid_test.go
@@ -50,6 +50,22 @@ var _ = Describe("OptionsForInstanceID", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("applies a data-trimming transform only to Secret informers", func() {
+		opts := promotercache.OptionsForInstanceID(nil, testControllerNamespace)
+		secretByObj, ok := opts.ByObject[promotercache.PartitionedSecretObject()]
+		Expect(ok).To(BeTrue())
+		Expect(secretByObj.Transform).NotTo(BeNil())
+
+		for _, obj := range promotercache.PartitionedObjects() {
+			if obj == promotercache.PartitionedSecretObject() {
+				continue
+			}
+			byObj, objOK := opts.ByObject[obj]
+			Expect(objOK).To(BeTrue(), "missing ByObject for %T", obj)
+			Expect(byObj.Transform).To(BeNil(), "unexpected transform on %T", obj)
+		}
+	})
+
 	It("scopes ControllerConfiguration to the install namespace and shipped name", func() {
 		opts := promotercache.OptionsForInstanceID(nil, testControllerNamespace)
 		byObj, ok := opts.ByObject[promotercache.PartitionedControllerConfigurationObject()]

--- a/internal/cache/secret_transform.go
+++ b/internal/cache/secret_transform.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils/httpauth"
+)
+
+// githubAppPrivateKeySecretKey matches internal/scms/github/git_operations.go.
+const githubAppPrivateKeySecretKey = "githubAppPrivateKey"
+
+// promoterSecretDataKeys lists Secret data keys read by promoter controllers (SCM, HTTP auth,
+// kubeconfig). The informer transform retains only these keys to limit cache memory for unrelated
+// Secrets that share the instance-id label partition.
+func promoterSecretDataKeys() map[string]struct{} {
+	return map[string]struct{}{
+		httpauth.UsernameKey:          {},
+		httpauth.PasswordKey:          {},
+		httpauth.TokenKey:             {},
+		httpauth.ClientIDKey:          {},
+		httpauth.ClientSecretKey:      {},
+		httpauth.TLSCertKey:           {},
+		httpauth.TLSKeyKey:            {},
+		httpauth.TLSCAKey:             {},
+		constants.KubeconfigSecretKey: {},
+		githubAppPrivateKeySecretKey:  {},
+	}
+}
+
+// secretDataTransform returns a cache transform that strips managedFields and retains only promoter
+// credential keys in Secret data before objects are stored in the informer cache.
+func secretDataTransform() toolscache.TransformFunc {
+	allowed := promoterSecretDataKeys()
+	stripManaged := ctrlcache.TransformStripManagedFields()
+	return func(in any) (any, error) {
+		out, err := stripManaged(in)
+		if err != nil {
+			return out, err
+		}
+		secret, ok := out.(*corev1.Secret)
+		if !ok {
+			return out, nil
+		}
+		if len(secret.Data) == 0 && len(secret.StringData) == 0 {
+			return secret, nil
+		}
+		filtered := make(map[string][]byte, len(secret.Data))
+		for k, v := range secret.Data {
+			if _, keep := allowed[k]; keep {
+				filtered[k] = v
+			}
+		}
+		if len(filtered) == 0 {
+			secret.Data = nil
+		} else {
+			secret.Data = filtered
+		}
+		secret.StringData = nil
+		return secret, nil
+	}
+}
+
+// SecretDataTransformForTest exposes secretDataTransform for unit tests.
+func SecretDataTransformForTest() toolscache.TransformFunc {
+	return secretDataTransform()
+}

--- a/internal/cache/secret_transform_test.go
+++ b/internal/cache/secret_transform_test.go
@@ -17,10 +17,10 @@ var _ = Describe("secretDataTransform", func() {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "scm-creds"},
 			Data: map[string][]byte{
-				httpauth.TokenKey:              []byte("pat"),
-				"unrelated-config":             []byte("large-payload"),
-				constants.KubeconfigSecretKey:  []byte("kubeconfig-bytes"),
-				"githubAppPrivateKey":          []byte("private-key"),
+				httpauth.TokenKey:             []byte("pat"),
+				"unrelated-config":            []byte("large-payload"),
+				constants.KubeconfigSecretKey: []byte("kubeconfig-bytes"),
+				"githubAppPrivateKey":         []byte("private-key"),
 			},
 			StringData: map[string]string{"ignored": "value"},
 		}
@@ -28,7 +28,8 @@ var _ = Describe("secretDataTransform", func() {
 		out, err := transform(secret)
 		Expect(err).NotTo(HaveOccurred())
 
-		got := out.(*corev1.Secret)
+		got, ok := out.(*corev1.Secret)
+		Expect(ok).To(BeTrue())
 		Expect(got.Data).To(Equal(map[string][]byte{
 			httpauth.TokenKey:             []byte("pat"),
 			constants.KubeconfigSecretKey: []byte("kubeconfig-bytes"),
@@ -50,7 +51,8 @@ var _ = Describe("secretDataTransform", func() {
 		out, err := transform(secret)
 		Expect(err).NotTo(HaveOccurred())
 
-		got := out.(*corev1.Secret)
+		got, ok := out.(*corev1.Secret)
+		Expect(ok).To(BeTrue())
 		Expect(got.Data).To(BeNil())
 		Expect(got.Namespace).To(Equal("default"))
 	})

--- a/internal/cache/secret_transform_test.go
+++ b/internal/cache/secret_transform_test.go
@@ -1,0 +1,64 @@
+package cache_test
+
+import (
+	promotercache "github.com/argoproj-labs/gitops-promoter/internal/cache"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils/httpauth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("secretDataTransform", func() {
+	transform := promotercache.SecretDataTransformForTest()
+
+	It("retains only promoter credential keys", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "scm-creds"},
+			Data: map[string][]byte{
+				httpauth.TokenKey:              []byte("pat"),
+				"unrelated-config":             []byte("large-payload"),
+				constants.KubeconfigSecretKey:  []byte("kubeconfig-bytes"),
+				"githubAppPrivateKey":          []byte("private-key"),
+			},
+			StringData: map[string]string{"ignored": "value"},
+		}
+
+		out, err := transform(secret)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := out.(*corev1.Secret)
+		Expect(got.Data).To(Equal(map[string][]byte{
+			httpauth.TokenKey:             []byte("pat"),
+			constants.KubeconfigSecretKey: []byte("kubeconfig-bytes"),
+			"githubAppPrivateKey":         []byte("private-key"),
+		}))
+		Expect(got.StringData).To(BeNil())
+		Expect(got.Name).To(Equal("scm-creds"))
+	})
+
+	It("stores metadata only when no credential keys are present", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "default"},
+			Data: map[string][]byte{
+				"database-url": []byte("postgres://..."),
+				"api-key":      []byte("secret"),
+			},
+		}
+
+		out, err := transform(secret)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := out.(*corev1.Secret)
+		Expect(got.Data).To(BeNil())
+		Expect(got.Namespace).To(Equal("default"))
+	})
+
+	It("passes through non-Secret objects unchanged", func() {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg"}}
+		out, err := transform(cm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeIdenticalTo(cm))
+	})
+})


### PR DESCRIPTION
…cache

Apply a ByObject transform on partitioned Secret informers so unrelated data keys are dropped before objects are stored, reducing memory for Secrets that match the instance-id watch but are not promoter credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Secret caching to retain only required promoter credential data.
  * Removed unnecessary managed metadata and string-based Secret data from cached entries.
  * Preserved instance-ID label partitioning for cached objects.
  * Ensured non-Secret objects remain unchanged during cache processing.
  * Improved cache efficiency and reduced exposure of unrelated Secret content while maintaining expected credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->