### PR TITLE
perf: cache git path

### DIFF
--- a/internal/git/concurrency_test.go
+++ b/internal/git/concurrency_test.go
@@ -1,4 +1,4 @@
-package git
+package git_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/git"
 )
 
 // These specs guard against the most common races described in gitops-promoter#1495. Each goroutine
@@ -53,7 +54,7 @@ var _ = Describe("Concurrency (gitops-promoter#1495)", func() {
 			s.addProposedBranch(branch)
 			proposedBranches[i] = branch
 		}
-		envs := make([]*EnvironmentOperations, goroutines)
+		envs := make([]*git.EnvironmentOperations, goroutines)
 		for i := range envs {
 			envs[i] = s.newEnv(fmt.Sprintf("tenant-%d/ctp", i))
 			Expect(envs[i].CloneRepo(ctx)).To(Succeed())
@@ -104,7 +105,7 @@ var _ = Describe("Concurrency (gitops-promoter#1495)", func() {
 
 		// Each reader is a distinct CTP identity. Pre-clone sequentially so the concurrent phase
 		// exercises only fetch races, not clone races.
-		envs := make([]*EnvironmentOperations, readers)
+		envs := make([]*git.EnvironmentOperations, readers)
 		for i := range envs {
 			envs[i] = s.newEnv(fmt.Sprintf("tenant-%d/ctp", i))
 			Expect(envs[i].CloneRepo(ctx)).To(Succeed())
@@ -236,8 +237,8 @@ func buildConflictRepo() *sharedRepo {
 	// Seed a hydrator notes ref so FetchNotes performs a real force-updating fetch (otherwise it
 	// returns early on "couldn't find remote ref" and exercises no concurrency).
 	baseSha := strings.TrimSpace(mustGit(workDir, "rev-parse", base))
-	mustGit(workDir, "notes", "--ref="+HydratorNotesRef, "add", "-m", `{"drySha":"base"}`, baseSha)
-	mustGit(workDir, "push", "origin", HydratorNotesRef+":"+HydratorNotesRef)
+	mustGit(workDir, "notes", "--ref="+git.HydratorNotesRef, "add", "-m", `{"drySha":"base"}`, baseSha)
+	mustGit(workDir, "push", "origin", git.HydratorNotesRef+":"+git.HydratorNotesRef)
 
 	return &sharedRepo{
 		gap:      &fakeGitProvider{tempDirPath: bareRepo},
@@ -262,8 +263,8 @@ func buildConflictRepo() *sharedRepo {
 // newEnv returns an EnvironmentOperations for a distinct CTP identity (namespace/name) against the
 // same repo + activeBranch. Because the clone key includes identity, each env gets its own on-disk
 // clone.
-func (s *sharedRepo) newEnv(identity string) *EnvironmentOperations {
-	return NewEnvironmentOperations(s.repo, s.gap, identity)
+func (s *sharedRepo) newEnv(identity string) *git.EnvironmentOperations {
+	return git.NewEnvironmentOperations(s.repo, s.gap, identity)
 }
 
 // addProposedBranch creates a distinct proposed branch off base. Distinct CTPs have their own

--- a/internal/git/concurrency_test.go
+++ b/internal/git/concurrency_test.go
@@ -1,4 +1,4 @@
-package git_test
+package git
 
 import (
 	"context"
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
-	"github.com/argoproj-labs/gitops-promoter/internal/git"
 )
 
 // These specs guard against the most common races described in gitops-promoter#1495. Each goroutine
@@ -54,7 +53,7 @@ var _ = Describe("Concurrency (gitops-promoter#1495)", func() {
 			s.addProposedBranch(branch)
 			proposedBranches[i] = branch
 		}
-		envs := make([]*git.EnvironmentOperations, goroutines)
+		envs := make([]*EnvironmentOperations, goroutines)
 		for i := range envs {
 			envs[i] = s.newEnv(fmt.Sprintf("tenant-%d/ctp", i))
 			Expect(envs[i].CloneRepo(ctx)).To(Succeed())
@@ -105,7 +104,7 @@ var _ = Describe("Concurrency (gitops-promoter#1495)", func() {
 
 		// Each reader is a distinct CTP identity. Pre-clone sequentially so the concurrent phase
 		// exercises only fetch races, not clone races.
-		envs := make([]*git.EnvironmentOperations, readers)
+		envs := make([]*EnvironmentOperations, readers)
 		for i := range envs {
 			envs[i] = s.newEnv(fmt.Sprintf("tenant-%d/ctp", i))
 			Expect(envs[i].CloneRepo(ctx)).To(Succeed())
@@ -237,8 +236,8 @@ func buildConflictRepo() *sharedRepo {
 	// Seed a hydrator notes ref so FetchNotes performs a real force-updating fetch (otherwise it
 	// returns early on "couldn't find remote ref" and exercises no concurrency).
 	baseSha := strings.TrimSpace(mustGit(workDir, "rev-parse", base))
-	mustGit(workDir, "notes", "--ref="+git.HydratorNotesRef, "add", "-m", `{"drySha":"base"}`, baseSha)
-	mustGit(workDir, "push", "origin", git.HydratorNotesRef+":"+git.HydratorNotesRef)
+	mustGit(workDir, "notes", "--ref="+HydratorNotesRef, "add", "-m", `{"drySha":"base"}`, baseSha)
+	mustGit(workDir, "push", "origin", HydratorNotesRef+":"+HydratorNotesRef)
 
 	return &sharedRepo{
 		gap:      &fakeGitProvider{tempDirPath: bareRepo},
@@ -263,8 +262,8 @@ func buildConflictRepo() *sharedRepo {
 // newEnv returns an EnvironmentOperations for a distinct CTP identity (namespace/name) against the
 // same repo + activeBranch. Because the clone key includes identity, each env gets its own on-disk
 // clone.
-func (s *sharedRepo) newEnv(identity string) *git.EnvironmentOperations {
-	return git.NewEnvironmentOperations(s.repo, s.gap, identity)
+func (s *sharedRepo) newEnv(identity string) *EnvironmentOperations {
+	return NewEnvironmentOperations(s.repo, s.gap, identity)
 }
 
 // addProposedBranch creates a distinct proposed branch off base. Distinct CTPs have their own

--- a/internal/git/export_test.go
+++ b/internal/git/export_test.go
@@ -5,5 +5,4 @@ package git
 var (
 	GitChildEnv = gitChildEnv
 	GitBin      = gitBin
-	ErrGitBin   = gitBinErr
 )

--- a/internal/git/export_test.go
+++ b/internal/git/export_test.go
@@ -1,0 +1,9 @@
+package git
+
+// Test-only aliases for unexported helpers. Visible to package git_test in this directory,
+// not to other packages that import git.
+var (
+	GitChildEnv = gitChildEnv
+	GitBin      = gitBin
+	ErrGitBin   = gitBinErr
+)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -110,6 +110,17 @@ type HydratorMetadata = v1alpha1.HydratorMetadata
 // HydratorNotesRef is the git notes reference used by hydrators to store metadata about hydrated commits.
 const HydratorNotesRef = "refs/notes/hydrator.metadata"
 
+// gitBin is resolved once at package init. CommandContext("git", ...) calls LookPath on every
+// invocation; passing the absolute path skips that walk.
+var gitBin, gitBinErr = exec.LookPath("git")
+
+func gitCommandContext(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	if gitBinErr != nil {
+		return nil, fmt.Errorf("git executable not found: %w", gitBinErr)
+	}
+	return exec.CommandContext(ctx, gitBin, args...), nil
+}
+
 // NewEnvironmentOperations creates a new EnvironmentOperations instance. The identity parameter is an opaque,
 // caller-supplied identifier (for example the owning object's namespace/name); together with the repo URL it forms
 // the clone key, so each identity gets its own on-disk clone. Each identity corresponds to a single environment, so
@@ -553,6 +564,20 @@ func proxyRelatedEnvVars() []string {
 	return out
 }
 
+// gitChildEnv is the environment for git subprocesses. cmd.Env replaces the child environment
+// entirely, so auth, PATH, and proxy/TLS vars from this process must be copied explicitly.
+func gitChildEnv(user, token string, extraEnv []string) []string {
+	env := []string{
+		"GIT_ASKPASS=promoter_askpass.sh", // Needs to be on path
+		"GIT_USERNAME=" + user,
+		"GIT_PASSWORD=" + token,
+		"PATH=" + os.Getenv("PATH"),
+		"GIT_TERMINAL_PROMPT=0",
+	}
+	env = append(env, proxyRelatedEnvVars()...)
+	return append(env, extraEnv...)
+}
+
 // runCmdWithEnv runs a git command, appending extraEnv to the standard auth environment, and
 // returns stdout, stderr, and error.
 func runCmdWithEnv(ctx context.Context, gap scms.GitOperationsProvider, directory string, extraEnv []string, args ...string) (string, string, error) {
@@ -566,15 +591,11 @@ func runCmdWithEnv(ctx context.Context, gap scms.GitOperationsProvider, director
 		return "", "", fmt.Errorf("failed to get token: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append([]string{
-		"GIT_ASKPASS=promoter_askpass.sh", // Needs to be on path
-		"GIT_USERNAME=" + user,
-		"GIT_PASSWORD=" + token,
-		"PATH=" + os.Getenv("PATH"),
-		"GIT_TERMINAL_PROMPT=0",
-	}, proxyRelatedEnvVars()...)
-	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd, err := gitCommandContext(ctx, args...)
+	if err != nil {
+		return "", "", err
+	}
+	cmd.Env = gitChildEnv(user, token, extraEnv)
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
@@ -795,7 +816,10 @@ func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, branc
 func AddTrailerToCommitMessage(ctx context.Context, commitMessage, trailerKey, trailerValue string) (string, error) {
 	trailerLine := fmt.Sprintf("%s: %s", trailerKey, trailerValue)
 
-	cmd := exec.CommandContext(ctx, "git", "interpret-trailers", "--trailer", trailerLine)
+	cmd, err := gitCommandContext(ctx, "interpret-trailers", "--trailer", trailerLine)
+	if err != nil {
+		return "", err
+	}
 	cmd.Stdin = strings.NewReader(commitMessage)
 
 	var stdoutBuf bytes.Buffer
@@ -880,7 +904,10 @@ func ParseTrailersFromMessage(ctx context.Context, commitMessage string) (map[st
 	logger := log.FromContext(ctx)
 
 	// Pipe the message to git interpret-trailers using stdin
-	cmd := exec.CommandContext(ctx, "git", "interpret-trailers", "--only-trailers")
+	cmd, err := gitCommandContext(ctx, "interpret-trailers", "--only-trailers")
+	if err != nil {
+		return nil, err
+	}
 	cmd.Stdin = strings.NewReader(commitMessage)
 
 	var stdoutBuf bytes.Buffer
@@ -888,7 +915,7 @@ func ParseTrailersFromMessage(ctx context.Context, commitMessage string) (map[st
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	err := cmd.Run()
+	err = cmd.Run()
 	stderr := stderrBuf.String()
 	if err != nil {
 		logger.Error(err, "failed to run git interpret-trailers", "stderr", stderr)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -111,14 +111,20 @@ type HydratorMetadata = v1alpha1.HydratorMetadata
 const HydratorNotesRef = "refs/notes/hydrator.metadata"
 
 // gitBin is resolved once at package init. CommandContext("git", ...) calls LookPath on every
-// invocation; passing the absolute path skips that walk.
-var gitBin, gitBinErr = exec.LookPath("git")
+// invocation; passing the absolute path skips that walk. Missing git is a process configuration
+// error, so we panic instead of failing every later command.
+var gitBin = mustLookPathGit()
 
-func gitCommandContext(ctx context.Context, args ...string) (*exec.Cmd, error) {
-	if gitBinErr != nil {
-		return nil, fmt.Errorf("git executable not found: %w", gitBinErr)
+func mustLookPathGit() string {
+	path, err := exec.LookPath("git")
+	if err != nil {
+		panic("git executable not found: " + err.Error())
 	}
-	return exec.CommandContext(ctx, gitBin, args...), nil
+	return path
+}
+
+func gitCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, gitBin, args...)
 }
 
 // NewEnvironmentOperations creates a new EnvironmentOperations instance. The identity parameter is an opaque,
@@ -591,10 +597,7 @@ func runCmdWithEnv(ctx context.Context, gap scms.GitOperationsProvider, director
 		return "", "", fmt.Errorf("failed to get token: %w", err)
 	}
 
-	cmd, err := gitCommandContext(ctx, args...)
-	if err != nil {
-		return "", "", err
-	}
+	cmd := gitCommandContext(ctx, args...)
 	cmd.Env = gitChildEnv(user, token, extraEnv)
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
@@ -816,10 +819,7 @@ func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, branc
 func AddTrailerToCommitMessage(ctx context.Context, commitMessage, trailerKey, trailerValue string) (string, error) {
 	trailerLine := fmt.Sprintf("%s: %s", trailerKey, trailerValue)
 
-	cmd, err := gitCommandContext(ctx, "interpret-trailers", "--trailer", trailerLine)
-	if err != nil {
-		return "", err
-	}
+	cmd := gitCommandContext(ctx, "interpret-trailers", "--trailer", trailerLine)
 	cmd.Stdin = strings.NewReader(commitMessage)
 
 	var stdoutBuf bytes.Buffer
@@ -904,10 +904,7 @@ func ParseTrailersFromMessage(ctx context.Context, commitMessage string) (map[st
 	logger := log.FromContext(ctx)
 
 	// Pipe the message to git interpret-trailers using stdin
-	cmd, err := gitCommandContext(ctx, "interpret-trailers", "--only-trailers")
-	if err != nil {
-		return nil, err
-	}
+	cmd := gitCommandContext(ctx, "interpret-trailers", "--only-trailers")
 	cmd.Stdin = strings.NewReader(commitMessage)
 
 	var stdoutBuf bytes.Buffer
@@ -915,7 +912,7 @@ func ParseTrailersFromMessage(ctx context.Context, commitMessage string) (map[st
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	err = cmd.Run()
+	err := cmd.Run()
 	stderr := stderrBuf.String()
 	if err != nil {
 		logger.Error(err, "failed to run git interpret-trailers", "stderr", stderr)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1121,9 +1121,6 @@ var _ = Describe("gitChildEnv", func() {
 
 var _ = Describe("gitBin", func() {
 	It("is resolved to an existing executable at init", func() {
-		if git.ErrGitBin != nil {
-			Skip("git not on PATH at init: " + git.ErrGitBin.Error())
-		}
 		Expect(git.GitBin).NotTo(BeEmpty())
 		_, err := os.Stat(git.GitBin)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,12 +1,12 @@
-package git_test
+package git
 
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
-	"github.com/argoproj-labs/gitops-promoter/internal/git"
 )
 
 func TestGit(t *testing.T) {
@@ -118,7 +117,7 @@ var _ = Describe("GetBranchShas", func() {
 				},
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-			g := git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+			g := NewEnvironmentOperations(repo, gap, "default/testrepo")
 			Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 			// Call GetBranchShas with a non-existent branch
@@ -138,7 +137,7 @@ var _ = Describe("GetBranchShas skip-fetch behavior", func() {
 	var branch string
 	var repo *v1alpha1.GitRepository
 	var gap *fakeGitProvider
-	var g *git.EnvironmentOperations
+	var g *EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -191,7 +190,7 @@ var _ = Describe("GetBranchShas skip-fetch behavior", func() {
 			},
 		}
 		gap = &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/skip-fetch-test")
+		g = NewEnvironmentOperations(repo, gap, "default/skip-fetch-test")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 	})
 
@@ -327,7 +326,7 @@ var _ = Describe("LsRemote", func() {
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
 
-			_, err = git.LsRemote(
+			_, err = LsRemote(
 				context.Background(),
 				gap,
 				repo,
@@ -377,7 +376,7 @@ var _ = Describe("LsRemote", func() {
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
 
-			_, err = git.LsRemote(
+			_, err = LsRemote(
 				context.Background(),
 				gap,
 				repo,
@@ -400,7 +399,7 @@ var _ = Describe("HasConflict", func() {
 	var workDir string
 	var defaultBranch string
 	var repo *v1alpha1.GitRepository
-	var g *git.EnvironmentOperations
+	var g *EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -487,7 +486,7 @@ var _ = Describe("HasConflict", func() {
 
 	prepareEnvOps := func() {
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err := g.GetBranchShas(GinkgoT().Context(), "active", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -581,7 +580,7 @@ var _ = Describe("HasConflict", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "active", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -598,7 +597,7 @@ var _ = Describe("ActivePath support", func() {
 	var tempRepoDir string
 	var workDir string
 	var repo *v1alpha1.GitRepository
-	var g *git.EnvironmentOperations
+	var g *EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -659,7 +658,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 		shas, err := g.GetBranchShas(GinkgoT().Context(), "environment/development", "apps/app-one", "")
@@ -698,7 +697,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 		// Place the path in the clone's working tree to prove the read is worktree-independent:
@@ -764,7 +763,7 @@ var _ = Describe("ActivePath support", func() {
 		activeTip := strings.TrimSpace(mustGit(workDir, "rev-parse", "active"))
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -857,7 +856,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -935,7 +934,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -1008,7 +1007,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -1041,8 +1040,47 @@ var _ = Describe("ActivePath support", func() {
 	})
 })
 
-var _ = Describe("Git subprocess proxy env", func() {
-	It("forwards proxy and TLS env vars via runCmd", func() {
+var _ = Describe("gitChildEnv", func() {
+	proxyEnvKeys := []string{
+		"HTTPS_PROXY", "https_proxy",
+		"HTTP_PROXY", "http_proxy",
+		"NO_PROXY", "no_proxy",
+		"GIT_SSL_CAINFO", "SSL_CERT_FILE",
+	}
+
+	clearProxyEnv := func() {
+		for _, key := range proxyEnvKeys {
+			GinkgoT().Setenv(key, "")
+		}
+	}
+
+	envMap := func(env []string) map[string]string {
+		got := make(map[string]string, len(env))
+		for _, entry := range env {
+			key, val, ok := strings.Cut(entry, "=")
+			Expect(ok).To(BeTrue(), "invalid env entry %q", entry)
+			got[key] = val
+		}
+		return got
+	}
+
+	It("includes auth vars and PATH and omits unset proxy keys", func() {
+		GinkgoT().Setenv("PATH", "/custom/bin")
+		clearProxyEnv()
+
+		got := envMap(gitChildEnv("alice", "s3cret", nil))
+		Expect(got["GIT_ASKPASS"]).To(Equal("promoter_askpass.sh"))
+		Expect(got["GIT_USERNAME"]).To(Equal("alice"))
+		Expect(got["GIT_PASSWORD"]).To(Equal("s3cret"))
+		Expect(got["PATH"]).To(Equal("/custom/bin"))
+		Expect(got["GIT_TERMINAL_PROMPT"]).To(Equal("0"))
+		for _, key := range proxyEnvKeys {
+			Expect(got).NotTo(HaveKey(key))
+		}
+	})
+
+	It("forwards proxy and TLS env vars", func() {
+		clearProxyEnv()
 		want := map[string]string{
 			"HTTPS_PROXY":    "http://proxy.test:8443",
 			"HTTP_PROXY":     "http://proxy.test:8080",
@@ -1054,53 +1092,40 @@ var _ = Describe("Git subprocess proxy env", func() {
 			GinkgoT().Setenv(key, val)
 		}
 
-		workDir := GinkgoT().TempDir()
-		envDump := filepath.Join(workDir, "proxy-env-dump")
-		gitBin := filepath.Join(workDir, "git")
-		script := fmt.Sprintf(`#!/bin/sh
-ENV_DUMP=%q
-if [ "$1" = "ls-remote" ] && [ "$2" = "--heads" ]; then
-  : > "$ENV_DUMP"
-  for key in HTTPS_PROXY HTTP_PROXY NO_PROXY GIT_SSL_CAINFO SSL_CERT_FILE; do
-    eval "val=\$$key"
-    echo "$key=$val" >> "$ENV_DUMP"
-  done
-  echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef	refs/heads/main"
-  exit 0
-fi
-echo "unexpected git args: $*" >&2
-exit 1
-`, envDump)
-		Expect(os.WriteFile(gitBin, []byte(script), 0o755)).To(Succeed())
-		GinkgoT().Setenv("PATH", workDir)
-
-		repo := &v1alpha1.GitRepository{
-			Spec: v1alpha1.GitRepositorySpec{
-				GitHub: &v1alpha1.GitHubRepo{Owner: "test-owner", Name: "testrepo"},
-				ScmProviderRef: v1alpha1.ScmProviderObjectReference{
-					Kind: "ScmProvider",
-					Name: "testprovider",
-				},
-			},
-			ObjectMeta: metav1.ObjectMeta{Name: "testrepo", Namespace: "default"},
-		}
-		gap := &fakeGitProvider{tempDirPath: filepath.Join(workDir, "ignored-repo")}
-
-		shas, err := git.LsRemote(context.Background(), gap, repo, "main")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(shas).To(HaveKeyWithValue("main", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
-
-		dump, err := os.ReadFile(envDump)
-		Expect(err).NotTo(HaveOccurred())
-		got := map[string]string{}
-		for line := range strings.SplitSeq(strings.TrimSpace(string(dump)), "\n") {
-			key, val, ok := strings.Cut(line, "=")
-			Expect(ok).To(BeTrue(), "unexpected dump line %q", line)
-			got[key] = val
-		}
+		got := envMap(gitChildEnv("user", "token", nil))
 		for key, val := range want {
 			Expect(got[key]).To(Equal(val), "proxy env var %s", key)
 		}
+	})
+
+	It("forwards lowercase proxy env vars", func() {
+		clearProxyEnv()
+		GinkgoT().Setenv("https_proxy", "http://lower-https:8443")
+		GinkgoT().Setenv("http_proxy", "http://lower-http:8080")
+		GinkgoT().Setenv("no_proxy", "example.internal")
+
+		got := envMap(gitChildEnv("user", "token", nil))
+		Expect(got["https_proxy"]).To(Equal("http://lower-https:8443"))
+		Expect(got["http_proxy"]).To(Equal("http://lower-http:8080"))
+		Expect(got["no_proxy"]).To(Equal("example.internal"))
+	})
+
+	It("appends extraEnv after auth vars", func() {
+		clearProxyEnv()
+		env := gitChildEnv("user", "token", []string{"GIT_INDEX_FILE=/tmp/index"})
+		Expect(env).To(ContainElement("GIT_INDEX_FILE=/tmp/index"))
+		Expect(slices.Index(env, "GIT_INDEX_FILE=/tmp/index")).To(BeNumerically(">", slices.Index(env, "GIT_ASKPASS=promoter_askpass.sh")))
+	})
+})
+
+var _ = Describe("gitBin", func() {
+	It("is resolved to an existing executable at init", func() {
+		if gitBinErr != nil {
+			Skip("git not on PATH at init: " + gitBinErr.Error())
+		}
+		Expect(gitBin).NotTo(BeEmpty())
+		_, err := os.Stat(gitBin)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,4 +1,4 @@
-package git
+package git_test
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/git"
 )
 
 func TestGit(t *testing.T) {
@@ -117,7 +118,7 @@ var _ = Describe("GetBranchShas", func() {
 				},
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-			g := NewEnvironmentOperations(repo, gap, "default/testrepo")
+			g := git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 			Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 			// Call GetBranchShas with a non-existent branch
@@ -137,7 +138,7 @@ var _ = Describe("GetBranchShas skip-fetch behavior", func() {
 	var branch string
 	var repo *v1alpha1.GitRepository
 	var gap *fakeGitProvider
-	var g *EnvironmentOperations
+	var g *git.EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -190,7 +191,7 @@ var _ = Describe("GetBranchShas skip-fetch behavior", func() {
 			},
 		}
 		gap = &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/skip-fetch-test")
+		g = git.NewEnvironmentOperations(repo, gap, "default/skip-fetch-test")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 	})
 
@@ -326,7 +327,7 @@ var _ = Describe("LsRemote", func() {
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
 
-			_, err = LsRemote(
+			_, err = git.LsRemote(
 				context.Background(),
 				gap,
 				repo,
@@ -376,7 +377,7 @@ var _ = Describe("LsRemote", func() {
 			}
 			gap := &fakeGitProvider{tempDirPath: tempRepoDir}
 
-			_, err = LsRemote(
+			_, err = git.LsRemote(
 				context.Background(),
 				gap,
 				repo,
@@ -399,7 +400,7 @@ var _ = Describe("HasConflict", func() {
 	var workDir string
 	var defaultBranch string
 	var repo *v1alpha1.GitRepository
-	var g *EnvironmentOperations
+	var g *git.EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -486,7 +487,7 @@ var _ = Describe("HasConflict", func() {
 
 	prepareEnvOps := func() {
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err := g.GetBranchShas(GinkgoT().Context(), "active", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -580,7 +581,7 @@ var _ = Describe("HasConflict", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "active", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -597,7 +598,7 @@ var _ = Describe("ActivePath support", func() {
 	var tempRepoDir string
 	var workDir string
 	var repo *v1alpha1.GitRepository
-	var g *EnvironmentOperations
+	var g *git.EnvironmentOperations
 
 	BeforeEach(func() {
 		var err error
@@ -658,7 +659,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 		shas, err := g.GetBranchShas(GinkgoT().Context(), "environment/development", "apps/app-one", "")
@@ -697,7 +698,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 
 		// Place the path in the clone's working tree to prove the read is worktree-independent:
@@ -763,7 +764,7 @@ var _ = Describe("ActivePath support", func() {
 		activeTip := strings.TrimSpace(mustGit(workDir, "rev-parse", "active"))
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -856,7 +857,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -934,7 +935,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed-app-one-next", "apps/app-one", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -1007,7 +1008,7 @@ var _ = Describe("ActivePath support", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
-		g = NewEnvironmentOperations(repo, gap, "default/testrepo")
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
 		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
 		_, err = g.GetBranchShas(GinkgoT().Context(), "proposed", "", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -1068,7 +1069,7 @@ var _ = Describe("gitChildEnv", func() {
 		GinkgoT().Setenv("PATH", "/custom/bin")
 		clearProxyEnv()
 
-		got := envMap(gitChildEnv("alice", "s3cret", nil))
+		got := envMap(git.GitChildEnv("alice", "s3cret", nil))
 		Expect(got["GIT_ASKPASS"]).To(Equal("promoter_askpass.sh"))
 		Expect(got["GIT_USERNAME"]).To(Equal("alice"))
 		Expect(got["GIT_PASSWORD"]).To(Equal("s3cret"))
@@ -1092,7 +1093,7 @@ var _ = Describe("gitChildEnv", func() {
 			GinkgoT().Setenv(key, val)
 		}
 
-		got := envMap(gitChildEnv("user", "token", nil))
+		got := envMap(git.GitChildEnv("user", "token", nil))
 		for key, val := range want {
 			Expect(got[key]).To(Equal(val), "proxy env var %s", key)
 		}
@@ -1104,7 +1105,7 @@ var _ = Describe("gitChildEnv", func() {
 		GinkgoT().Setenv("http_proxy", "http://lower-http:8080")
 		GinkgoT().Setenv("no_proxy", "example.internal")
 
-		got := envMap(gitChildEnv("user", "token", nil))
+		got := envMap(git.GitChildEnv("user", "token", nil))
 		Expect(got["https_proxy"]).To(Equal("http://lower-https:8443"))
 		Expect(got["http_proxy"]).To(Equal("http://lower-http:8080"))
 		Expect(got["no_proxy"]).To(Equal("example.internal"))
@@ -1112,7 +1113,7 @@ var _ = Describe("gitChildEnv", func() {
 
 	It("appends extraEnv after auth vars", func() {
 		clearProxyEnv()
-		env := gitChildEnv("user", "token", []string{"GIT_INDEX_FILE=/tmp/index"})
+		env := git.GitChildEnv("user", "token", []string{"GIT_INDEX_FILE=/tmp/index"})
 		Expect(env).To(ContainElement("GIT_INDEX_FILE=/tmp/index"))
 		Expect(slices.Index(env, "GIT_INDEX_FILE=/tmp/index")).To(BeNumerically(">", slices.Index(env, "GIT_ASKPASS=promoter_askpass.sh")))
 	})
@@ -1120,11 +1121,11 @@ var _ = Describe("gitChildEnv", func() {
 
 var _ = Describe("gitBin", func() {
 	It("is resolved to an existing executable at init", func() {
-		if gitBinErr != nil {
-			Skip("git not on PATH at init: " + gitBinErr.Error())
+		if git.ErrGitBin != nil {
+			Skip("git not on PATH at init: " + git.ErrGitBin.Error())
 		}
-		Expect(gitBin).NotTo(BeEmpty())
-		_, err := os.Stat(gitBin)
+		Expect(git.GitBin).NotTo(BeEmpty())
+		_, err := os.Stat(git.GitBin)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Believe it or not, looking up the git path gets costly after enough exec calls.

Refactored a test that previously relied on temporarily setting a different git path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running Git commands by consistently using the detected Git executable.
  * Preserved authentication, proxy, TLS, `PATH`, and other environment settings during Git operations.
  * Improved handling of Git trailer-related commands and terminal prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->