### PR TITLE
fix(controller): adopt hydrator note from first-parent after ours-merge

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -809,8 +809,11 @@ func (r *ChangeTransferPolicyReconciler) setCommitMetadata(ctx context.Context, 
 
 	// Read the git note for the proposed hydrated commit to get the Note.DrySha.
 	// This is used by downstream environments to verify that hydration is complete
-	// for a given dry commit before allowing promotion.
-	proposedNote, err := gitOperations.GetHydratorNote(ctx, proposedHydratedSha)
+	// for a given dry commit before allowing promotion. When conflict-resolution
+	// ours-merge advances the branch tip past the hydrated commit (no note on the
+	// merge commit), walk first-parent ancestors for a note whose drySha matches
+	// hydrator.metadata on the tip.
+	proposedNote, err := gitOperations.FindMatchingHydratorNote(ctx, proposedHydratedSha, ctp.Status.Proposed.Dry.Sha, git.MaxHydratorNoteFirstParentWalk)
 	if err != nil {
 		return fmt.Errorf("failed to get hydrator note for proposed hydrated SHA %q: %w", proposedHydratedSha, err)
 	}

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1272,8 +1272,12 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err = runGitCmd(ctx, gitPath, "commit", "-m", "proposed hydrated commit")
 				Expect(err).NotTo(HaveOccurred())
+				hydratedSha, err := runGitCmd(ctx, gitPath, "rev-parse", "HEAD")
+				Expect(err).NotTo(HaveOccurred())
 				_, err = runGitCmd(ctx, gitPath, "push", "origin", testBranchDevelopmentNext)
 				Expect(err).NotTo(HaveOccurred())
+				By("Attaching a hydrator git note to the proposed hydrated commit (ours-merge will leave the tip without a note)")
+				Expect(pushGitNote(ctx, gitPath, strings.TrimSpace(hydratedSha), proposedDrySha)).To(Succeed())
 
 				By("Resetting the fake SCM's merge-sha-mismatch counter")
 				fake.ResetMergeShaMismatchCount()
@@ -1287,6 +1291,10 @@ var _ = Describe("ChangeTransferPolicy Controller", func() {
 					g.Expect(err).To(Succeed())
 					g.Expect(changeTransferPolicy.Status.Active.Dry.Sha).To(Equal(proposedDrySha),
 						"active branch should be promoted to the proposed dry SHA after auto-resolved conflict")
+					g.Expect(changeTransferPolicy.Status.Proposed.Note).NotTo(BeNil(),
+						"Proposed.Note must be populated after ours-merge adopts the hydrator note from the first-parent hydrated commit")
+					g.Expect(changeTransferPolicy.Status.Proposed.Note.DrySha).To(Equal(proposedDrySha),
+						"Proposed.Note.DrySha must match hydrator.metadata even when the proposed branch tip is an ours-merge commit with no note of its own")
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				By("Asserting the SCM was never asked to merge with a stale mergeSha")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -110,6 +110,11 @@ type HydratorMetadata = v1alpha1.HydratorMetadata
 // HydratorNotesRef is the git notes reference used by hydrators to store metadata about hydrated commits.
 const HydratorNotesRef = "refs/notes/hydrator.metadata"
 
+// MaxHydratorNoteFirstParentWalk bounds how many first-parent commits are inspected when the
+// proposed branch tip has no hydrator note. Ours-merge conflict resolution adds one commit on
+// top of the hydrated tip; a modest limit covers that without scanning deep history.
+const MaxHydratorNoteFirstParentWalk = 32
+
 // gitBin is resolved once at package init. CommandContext("git", ...) calls LookPath on every
 // invocation; passing the absolute path skips that walk. Missing git is a process configuration
 // error, so we panic instead of failing every later command.
@@ -782,6 +787,15 @@ func (g *EnvironmentOperations) MergeWithOursStrategyForPath(ctx context.Context
 // Read-only: never mutates the clone's index/worktree/HEAD. Requires the branch's commits to have
 // been fetched.
 func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, branch string, maxCount int) ([]string, error) {
+	return g.getRevListFirstParent(ctx, branch, maxCount)
+}
+
+// GetRevListFirstParentFromCommit lists first-parent commits starting at startSha (inclusive).
+func (g *EnvironmentOperations) GetRevListFirstParentFromCommit(ctx context.Context, startSha string, maxCount int) ([]string, error) {
+	return g.getRevListFirstParent(ctx, startSha, maxCount)
+}
+
+func (g *EnvironmentOperations) getRevListFirstParent(ctx context.Context, start string, maxCount int) ([]string, error) {
 	logger := log.FromContext(ctx)
 
 	gitPath := g.ClonePath()
@@ -792,16 +806,19 @@ func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, branc
 	args := make([]string, 0, 4)
 	args = append(args, "rev-list", "--first-parent")
 	args = append(args, "--max-count="+strconv.Itoa(maxCount))
-	args = append(args, branch)
+	args = append(args, start)
 
 	stdout, stderr, err := g.runCmd(ctx, gitPath, args...)
 	if err != nil {
-		logger.Error(err, "could not get rev-list first parent", "gitError", stderr)
-		return nil, fmt.Errorf("failed to get rev-list first parent for branch %q: %w", branch, err)
+		logger.Error(err, "could not get rev-list first parent", "gitError", stderr, "start", start)
+		return nil, fmt.Errorf("failed to get rev-list first parent for %q: %w", start, err)
 	}
 
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	return lines, nil
+	if strings.TrimSpace(stdout) == "" {
+		return nil, nil
+	}
+
+	return strings.Split(strings.TrimSpace(stdout), "\n"), nil
 }
 
 // AddTrailerToCommitMessage adds a trailer to a commit message using git interpret-trailers.
@@ -894,6 +911,41 @@ func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string)
 
 	logger.V(4).Info("Got hydrator note", "sha", sha, "note", note)
 	return &note, nil
+}
+
+// FindMatchingHydratorNote returns the first hydrator note on startSha or a first-parent ancestor
+// whose DrySha equals expectedDrySha. When expectedDrySha is empty, only a note on startSha itself
+// is considered — walking ancestors without an expected dry SHA could latch a stale note from an
+// earlier promotion.
+func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, startSha, expectedDrySha string, maxAncestors int) (*HydratorMetadata, error) {
+	if expectedDrySha == "" {
+		return g.GetHydratorNote(ctx, startSha)
+	}
+
+	shas, err := g.GetRevListFirstParentFromCommit(ctx, startSha, maxAncestors)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := log.FromContext(ctx)
+	for _, sha := range shas {
+		note, err := g.GetHydratorNote(ctx, sha)
+		if err != nil {
+			return nil, err
+		}
+		if note == nil || note.DrySha != expectedDrySha {
+			continue
+		}
+		if sha != startSha {
+			logger.V(4).Info("Adopted hydrator note from first-parent ancestor",
+				"startSha", startSha,
+				"noteSha", sha,
+				"noteDrySha", note.DrySha)
+		}
+		return note, nil
+	}
+
+	return nil, nil
 }
 
 // ParseTrailersFromMessage parses git trailers from a commit message using git interpret-trailers.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -905,15 +905,24 @@ func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string)
 	return &note, nil
 }
 
-// FindMatchingHydratorNote returns the first hydrator note on startSha or a first-parent ancestor
-// whose DrySha equals expectedDrySha. When expectedDrySha is empty, only a note on startSha itself
-// is considered — walking ancestors without an expected dry SHA could latch a stale note from an
-// earlier promotion.
+// FindMatchingHydratorNote returns the hydrator note for startSha, or — when the tip has
+// no note — the first note on a first-parent ancestor whose DrySha equals expectedDrySha.
+// A note on the branch tip is always preferred, including note-only hydrator updates where
+// hydrator.metadata still references an older dry SHA. The ancestor walk (filtered by
+// expectedDrySha) covers ours-merge tips that advance past the hydrated commit without a note.
 func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, startSha, expectedDrySha string, maxAncestors int) (*HydratorMetadata, error) {
+	tipNote, err := g.GetHydratorNote(ctx, startSha)
+	if err != nil {
+		return nil, err
+	}
+	if tipNote != nil {
+		return tipNote, nil
+	}
+
 	// Without a dry SHA from hydrator.metadata we cannot tell which ancestor note belongs to the
 	// current promotion; walking would risk adopting a stale note from an earlier hydrated commit.
 	if expectedDrySha == "" {
-		return g.GetHydratorNote(ctx, startSha)
+		return nil, nil
 	}
 
 	shas, err := g.GetRevListFirstParent(ctx, startSha, maxAncestors)
@@ -923,6 +932,9 @@ func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, st
 
 	logger := log.FromContext(ctx)
 	for _, sha := range shas {
+		if sha == startSha {
+			continue
+		}
 		note, err := g.GetHydratorNote(ctx, sha)
 		if err != nil {
 			return nil, err
@@ -930,12 +942,10 @@ func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, st
 		if note == nil || note.DrySha != expectedDrySha {
 			continue
 		}
-		if sha != startSha {
-			logger.V(4).Info("Adopted hydrator note from first-parent ancestor",
-				"startSha", startSha,
-				"noteSha", sha,
-				"noteDrySha", note.DrySha)
-		}
+		logger.V(4).Info("Adopted hydrator note from first-parent ancestor",
+			"startSha", startSha,
+			"noteSha", sha,
+			"noteDrySha", note.DrySha)
 		return note, nil
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -918,6 +918,8 @@ func (g *EnvironmentOperations) GetHydratorNote(ctx context.Context, sha string)
 // is considered — walking ancestors without an expected dry SHA could latch a stale note from an
 // earlier promotion.
 func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, startSha, expectedDrySha string, maxAncestors int) (*HydratorMetadata, error) {
+	// Without a dry SHA from hydrator.metadata we cannot tell which ancestor note belongs to the
+	// current promotion; walking would risk adopting a stale note from an earlier hydrated commit.
 	if expectedDrySha == "" {
 		return g.GetHydratorNote(ctx, startSha)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -782,20 +782,12 @@ func (g *EnvironmentOperations) MergeWithOursStrategyForPath(ctx context.Context
 	return nil
 }
 
-// GetRevListFirstParent retrieves the first parent commit SHAs for the given branch using git rev-list.
+// GetRevListFirstParent retrieves the first-parent commit SHAs starting at revision using git rev-list.
+// revision may be a branch ref (e.g. origin/main) or a commit SHA.
 //
-// Read-only: never mutates the clone's index/worktree/HEAD. Requires the branch's commits to have
+// Read-only: never mutates the clone's index/worktree/HEAD. Requires the revision's commits to have
 // been fetched.
-func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, branch string, maxCount int) ([]string, error) {
-	return g.getRevListFirstParent(ctx, branch, maxCount)
-}
-
-// GetRevListFirstParentFromCommit lists first-parent commits starting at startSha (inclusive).
-func (g *EnvironmentOperations) GetRevListFirstParentFromCommit(ctx context.Context, startSha string, maxCount int) ([]string, error) {
-	return g.getRevListFirstParent(ctx, startSha, maxCount)
-}
-
-func (g *EnvironmentOperations) getRevListFirstParent(ctx context.Context, start string, maxCount int) ([]string, error) {
+func (g *EnvironmentOperations) GetRevListFirstParent(ctx context.Context, revision string, maxCount int) ([]string, error) {
 	logger := log.FromContext(ctx)
 
 	gitPath := g.ClonePath()
@@ -806,12 +798,12 @@ func (g *EnvironmentOperations) getRevListFirstParent(ctx context.Context, start
 	args := make([]string, 0, 4)
 	args = append(args, "rev-list", "--first-parent")
 	args = append(args, "--max-count="+strconv.Itoa(maxCount))
-	args = append(args, start)
+	args = append(args, revision)
 
 	stdout, stderr, err := g.runCmd(ctx, gitPath, args...)
 	if err != nil {
-		logger.Error(err, "could not get rev-list first parent", "gitError", stderr, "start", start)
-		return nil, fmt.Errorf("failed to get rev-list first parent for %q: %w", start, err)
+		logger.Error(err, "could not get rev-list first parent", "gitError", stderr, "revision", revision)
+		return nil, fmt.Errorf("failed to get rev-list first parent for %q: %w", revision, err)
 	}
 
 	if strings.TrimSpace(stdout) == "" {
@@ -924,7 +916,7 @@ func (g *EnvironmentOperations) FindMatchingHydratorNote(ctx context.Context, st
 		return g.GetHydratorNote(ctx, startSha)
 	}
 
-	shas, err := g.GetRevListFirstParentFromCommit(ctx, startSha, maxAncestors)
+	shas, err := g.GetRevListFirstParent(ctx, startSha, maxAncestors)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1119,6 +1119,14 @@ var _ = Describe("gitChildEnv", func() {
 	})
 })
 
+// FindMatchingHydratorNote exercises adoption of hydrator git notes when the proposed branch tip
+// is an ours-merge commit with no note of its own. The fixture mirrors production-usw-next after
+// conflict resolution: first-parent history is
+//
+//	merge (no note) → hydrated@currentDry (note) → hydrated@staleDry (note) → …
+//
+// FindMatchingHydratorNote must return the note for currentDry (matching hydrator.metadata on the
+// tip), not the stale ancestor note.
 var _ = Describe("FindMatchingHydratorNote", func() {
 	var (
 		tempRepoDir string
@@ -1174,6 +1182,7 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		const currentDry = "0c9ff02a8f23a7bb85e92e0ab395af91c530f18c"
 		const staleDry = "f1b84ed4df293385f9904b6934d14e784762fecd"
 
+		By("bootstrapping active with a base hydrator.metadata commit")
 		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"base"}`), 0o644)).To(Succeed())
 		_, err := runGitCmd(workDir, "add", "hydrator.metadata")
 		Expect(err).NotTo(HaveOccurred())
@@ -1184,6 +1193,7 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		_, err = runGitCmd(workDir, "push", "-u", "origin", "active")
 		Expect(err).NotTo(HaveOccurred())
 
+		By("building proposed-next with two hydrated commits and distinct git notes")
 		_, err = runGitCmd(workDir, "checkout", "-b", "proposed-next")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"`+staleDry+`"}`), 0o644)).To(Succeed())
@@ -1213,6 +1223,7 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		_, err = runGitCmd(workDir, "push", "origin", git.HydratorNotesRef+":"+git.HydratorNotesRef)
 		Expect(err).NotTo(HaveOccurred())
 
+		By("advancing active so Promoter's ours-merge has something to merge")
 		_, err = runGitCmd(workDir, "checkout", "active")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"active-advanced"}`), 0o644)).To(Succeed())
@@ -1223,6 +1234,7 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		_, err = runGitCmd(workDir, "push", "origin", "active")
 		Expect(err).NotTo(HaveOccurred())
 
+		By("running ours-merge on proposed-next; the merge commit has no hydrator note")
 		clonePath := g.ClonePath()
 		_, err = runGitCmd(clonePath, "fetch", "origin", "proposed-next", "active")
 		Expect(err).NotTo(HaveOccurred())
@@ -1239,11 +1251,13 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(directNote).To(BeNil())
 
+		By("walking first-parent ancestors for a note whose drySha matches hydrator.metadata on the tip")
 		note, err := g.FindMatchingHydratorNote(GinkgoT().Context(), mergeSha, currentDry, git.MaxHydratorNoteFirstParentWalk)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(note).NotTo(BeNil())
 		Expect(note.DrySha).To(Equal(currentDry))
 
+		By("returning nil when no ancestor note matches the expected dry SHA")
 		mismatch, err := g.FindMatchingHydratorNote(GinkgoT().Context(), mergeSha, "does-not-exist", git.MaxHydratorNoteFirstParentWalk)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mismatch).To(BeNil())

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1262,6 +1262,41 @@ var _ = Describe("FindMatchingHydratorNote", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mismatch).To(BeNil())
 	})
+
+	It("returns a tip git note even when its drySha differs from expectedDrySha", func() {
+		const metadataDry = "0c9ff02a8f23a7bb85e92e0ab395af91c530f18c"
+		const noteDry = "f1b84ed4df293385f9904b6934d14e784762fecd"
+
+		_, err := runGitCmd(workDir, "checkout", "-b", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"`+metadataDry+`"}`), 0o644)).To(Succeed())
+		_, err = runGitCmd(workDir, "add", "hydrator.metadata")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "hydrated")
+		Expect(err).NotTo(HaveOccurred())
+		hydratedSha, err := runGitCmd(workDir, "rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		hydratedSha = strings.TrimSpace(hydratedSha)
+		_, err = runGitCmd(workDir, "notes", "--ref="+git.HydratorNotesRef, "add", "-f", "-m", `{"drySha":"`+noteDry+`"}`, hydratedSha)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "-u", "origin", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", git.HydratorNotesRef+":"+git.HydratorNotesRef)
+		Expect(err).NotTo(HaveOccurred())
+
+		clonePath := g.ClonePath()
+		_, err = runGitCmd(clonePath, "fetch", "origin", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(g.FetchNotes(GinkgoT().Context())).To(Succeed())
+		tipSha, err := runGitCmd(clonePath, "rev-parse", "origin/proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		tipSha = strings.TrimSpace(tipSha)
+
+		note, err := g.FindMatchingHydratorNote(GinkgoT().Context(), tipSha, metadataDry, git.MaxHydratorNoteFirstParentWalk)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(note).NotTo(BeNil())
+		Expect(note.DrySha).To(Equal(noteDry))
+	})
 })
 
 var _ = Describe("gitBin", func() {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1119,6 +1119,137 @@ var _ = Describe("gitChildEnv", func() {
 	})
 })
 
+var _ = Describe("FindMatchingHydratorNote", func() {
+	var (
+		tempRepoDir string
+		workDir     string
+		g           *git.EnvironmentOperations
+		repo        *v1alpha1.GitRepository
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempRepoDir, err = os.MkdirTemp("", "git-note-walk-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(tempRepoDir, "init", "--bare")
+		Expect(err).NotTo(HaveOccurred())
+
+		workDir, err = os.MkdirTemp("", "git-note-walk-work-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(workDir, "clone", tempRepoDir, ".")
+		Expect(err).NotTo(HaveOccurred())
+		for _, cfg := range [][]string{
+			{"config", "user.name", "Test User"},
+			{"config", "user.email", "test@example.com"},
+			{"config", "commit.gpgsign", "false"},
+		} {
+			_, err = runGitCmd(workDir, cfg...)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		repo = &v1alpha1.GitRepository{
+			ObjectMeta: metav1.ObjectMeta{Name: "testrepo", Namespace: "default"},
+			Spec: v1alpha1.GitRepositorySpec{
+				GitHub:         &v1alpha1.GitHubRepo{Owner: "test-owner", Name: "testrepo"},
+				ScmProviderRef: v1alpha1.ScmProviderObjectReference{Kind: "ScmProvider", Name: "testprovider"},
+			},
+		}
+		gap := &fakeGitProvider{tempDirPath: tempRepoDir}
+		g = git.NewEnvironmentOperations(repo, gap, "default/testrepo")
+		Expect(g.CloneRepo(GinkgoT().Context())).To(Succeed())
+	})
+
+	AfterEach(func() {
+		if workDir != "" {
+			_ = os.RemoveAll(workDir)
+		}
+		if tempRepoDir != "" {
+			_ = os.RemoveAll(tempRepoDir)
+		}
+	})
+
+	It("adopts a matching hydrator note from a first-parent ancestor after ours-merge", func() {
+		const currentDry = "0c9ff02a8f23a7bb85e92e0ab395af91c530f18c"
+		const staleDry = "f1b84ed4df293385f9904b6934d14e784762fecd"
+
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"base"}`), 0o644)).To(Succeed())
+		_, err := runGitCmd(workDir, "add", "hydrator.metadata")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "base")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "branch", "-M", "active")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "-u", "origin", "active")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(workDir, "checkout", "-b", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"`+staleDry+`"}`), 0o644)).To(Succeed())
+		_, err = runGitCmd(workDir, "add", "hydrator.metadata")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "319fb00: older hydrated")
+		Expect(err).NotTo(HaveOccurred())
+		staleSha, err := runGitCmd(workDir, "rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		staleSha = strings.TrimSpace(staleSha)
+
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"`+currentDry+`"}`), 0o644)).To(Succeed())
+		_, err = runGitCmd(workDir, "add", "hydrator.metadata")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "0c9ff02: hydrated")
+		Expect(err).NotTo(HaveOccurred())
+		hydratedSha, err := runGitCmd(workDir, "rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		hydratedSha = strings.TrimSpace(hydratedSha)
+
+		_, err = runGitCmd(workDir, "notes", "--ref="+git.HydratorNotesRef, "add", "-f", "-m", `{"drySha":"`+staleDry+`"}`, staleSha)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "notes", "--ref="+git.HydratorNotesRef, "add", "-f", "-m", `{"drySha":"`+currentDry+`"}`, hydratedSha)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "-u", "origin", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", git.HydratorNotesRef+":"+git.HydratorNotesRef)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runGitCmd(workDir, "checkout", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"active-advanced"}`), 0o644)).To(Succeed())
+		_, err = runGitCmd(workDir, "add", "hydrator.metadata")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "commit", "-m", "active advance")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runGitCmd(workDir, "push", "origin", "active")
+		Expect(err).NotTo(HaveOccurred())
+
+		clonePath := g.ClonePath()
+		_, err = runGitCmd(clonePath, "fetch", "origin", "proposed-next", "active")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(g.FetchNotes(GinkgoT().Context())).To(Succeed())
+		Expect(g.MergeWithOursStrategy(GinkgoT().Context(), "proposed-next", "active")).To(Succeed())
+
+		_, err = runGitCmd(clonePath, "fetch", "origin", "proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		mergeSha, err := runGitCmd(clonePath, "rev-parse", "origin/proposed-next")
+		Expect(err).NotTo(HaveOccurred())
+		mergeSha = strings.TrimSpace(mergeSha)
+
+		directNote, err := g.GetHydratorNote(GinkgoT().Context(), mergeSha)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(directNote).To(BeNil())
+
+		note, err := g.FindMatchingHydratorNote(GinkgoT().Context(), mergeSha, currentDry, git.MaxHydratorNoteFirstParentWalk)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(note).NotTo(BeNil())
+		Expect(note.DrySha).To(Equal(currentDry))
+
+		mismatch, err := g.FindMatchingHydratorNote(GinkgoT().Context(), mergeSha, "does-not-exist", git.MaxHydratorNoteFirstParentWalk)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mismatch).To(BeNil())
+	})
+})
+
 var _ = Describe("gitBin", func() {
 	It("is resolved to an existing executable at init", func() {
 		Expect(git.GitBin).NotTo(BeEmpty())


### PR DESCRIPTION
## Summary

- When conflict-resolution **ours-merge** advances the proposed branch tip past the hydrated commit, the merge commit has no hydrator git note and `proposed.note.drySha` stays empty on downstream environments.
- Add `FindMatchingHydratorNote` to walk the first-parent chain (bounded to 32 commits) and adopt a note whose `drySha` matches `hydrator.metadata` on the branch tip.
- Update CTP `setCommitMetadata` to use the walk instead of reading the note only on the tip SHA.

## Test plan

- [x] `go tool ginkgo -v --focus="FindMatchingHydratorNote" internal/git/`
- [x] `make test-parallel`
- [x] Deploy controller and confirm production `-next` branches populate `proposed.note.drySha` after reconcile


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of conflict-resolution merges so hydration metadata remains associated with the correct commit.
  * Hydration details are now recovered when branch history advances beyond the original hydrated commit.
  * Bounded history searches improve reliability while avoiding unnecessary repository scanning.

* **Tests**
  * Added coverage for metadata recovery across merge scenarios, including matching and non-matching commit histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->