### PR TITLE
fix(ci): align renovate go version with codegen

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -33,14 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Post-upgrade `make` targets compile controller-gen with whatever `go` is
-      # on PATH. Pin that to go.mod (same as Check Codegen) instead of
-      # containerbase's latest stable, which drifts applyconfiguration output.
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -64,19 +56,10 @@ jobs:
         with:
           configurationFile: renovate.json5
           token: ${{ steps.get_token.outputs.token }}
-          # setup-go lives on the runner; Renovate executes post-upgrade tasks
-          # inside its image. Mount GOROOT and pass PATH so `go` is this pin.
-          docker-volumes: |
-            /tmp:/tmp
-            ${{ env.GOROOT }}:${{ env.GOROOT }}:ro
-          env-regex: '^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy|GOROOT|PATH)$'
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
-          GOROOT: ${{ env.GOROOT }}
-          # Prepend the runner Go; keep paths the Renovate image uses for node.
-          PATH: ${{ env.GOROOT }}/bin:/home/ubuntu/bin:/usr/local/containerbase/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^make generate-apiserver$","^make generate-ui-types$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^install-tool golang \\d+\\.\\d+\\.\\d+$","^go mod tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^make generate-apiserver$","^make generate-ui-types$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'
           RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS: 'true'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Post-upgrade `make` targets compile controller-gen with whatever `go` is
+      # on PATH. Pin that to go.mod (same as Check Codegen) instead of
+      # containerbase's latest stable, which drifts applyconfiguration output.
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -56,9 +64,18 @@ jobs:
         with:
           configurationFile: renovate.json5
           token: ${{ steps.get_token.outputs.token }}
+          # setup-go lives on the runner; Renovate executes post-upgrade tasks
+          # inside its image. Mount GOROOT and pass PATH so `go` is this pin.
+          docker-volumes: |
+            /tmp:/tmp
+            ${{ env.GOROOT }}:${{ env.GOROOT }}:ro
+          env-regex: '^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy|GOROOT|PATH)$'
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
+          GOROOT: ${{ env.GOROOT }}
+          # Prepend the runner Go; keep paths the Renovate image uses for node.
+          PATH: ${{ env.GOROOT }}/bin:/home/ubuntu/bin:/usr/local/containerbase/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^go mod tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^make generate-apiserver$","^make generate-ui-types$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'

--- a/renovate.json5
+++ b/renovate.json5
@@ -100,8 +100,9 @@
           'make generate-apiserver',
           'make generate-ui-types',
         ],
+        // Go comes from actions/setup-go in renovate.yaml (go.mod), not
+        // containerbase's latest stable — that mismatch broke Check Codegen.
         installTools: {
-          golang: {},
           node: {},
         },
         fileFilters: [
@@ -142,8 +143,9 @@
           'make generate-apiserver',
           'make generate-ui-types',
         ],
+        // Go comes from actions/setup-go in renovate.yaml (go.mod), not
+        // containerbase's latest stable — that mismatch broke Check Codegen.
         installTools: {
-          golang: {},
           node: {},
         },
         fileFilters: [
@@ -292,9 +294,6 @@
           // Regenerate CRDs, applyconfiguration, deepcopy, dist/ bundles, etc. (CI Check Codegen).
           'make build-installer',
         ],
-        installTools: {
-          golang: {},
-        },
         fileFilters: [
           '**/*.go',
           '**/mock/**',
@@ -398,9 +397,6 @@
         commands: [
           'make build-installer',
         ],
-        installTools: {
-          golang: {},
-        },
         fileFilters: [
           'dist/**',
         ],
@@ -420,9 +416,6 @@
         commands: [
           'make build-installer',
         ],
-        installTools: {
-          golang: {},
-        },
         fileFilters: [
           'config/**',
           'test/**',
@@ -447,9 +440,6 @@
           'make manifests',
           'make build-installer',
         ],
-        installTools: {
-          golang: {},
-        },
         fileFilters: [
           'config/**',
           'test/**',

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,13 @@
   postUpdateOptions: [
     'gomodTidy',
   ],
+  // Post-upgrade `make` compiles controller-gen with this Go. Keep in lockstep
+  // with go.mod via the regex manager below (grouped with Go and linter tooling).
+  // Do not rely on installTools + this field: executionMode=branch drops
+  // constraints (https://github.com/renovatebot/renovate/discussions/43633).
+  constraints: {
+    golang: '1.26.6',
+  },
   // The hashed lockfile is generated from docs/requirements.txt via a post-upgrade
   // task; Renovate must never try to edit it directly.
   ignorePaths: [
@@ -96,12 +103,11 @@
       // (e.g. core/v1.PodStatusResult in 0.37) and Check Codegen fails.
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
         ],
-        // Go comes from actions/setup-go in renovate.yaml (go.mod), not
-        // containerbase's latest stable — that mismatch broke Check Codegen.
         installTools: {
           node: {},
         },
@@ -139,12 +145,11 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
         ],
-        // Go comes from actions/setup-go in renovate.yaml (go.mod), not
-        // containerbase's latest stable — that mismatch broke Check Codegen.
         installTools: {
           node: {},
         },
@@ -285,6 +290,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           // go fix applies stdlib fixers for the new toolchain (any, min/max, iterators, …).
           // Run before lint-fix so golangci-lint can clean up anything fix leaves behind.
           'make go-fix || true',
@@ -395,6 +401,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           'make build-installer',
         ],
         fileFilters: [
@@ -414,6 +421,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           'make build-installer',
         ],
         fileFilters: [
@@ -437,6 +445,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
+          'install-tool golang {{constraints.golang}}',
           'make manifests',
           'make build-installer',
         ],
@@ -541,6 +550,19 @@
       ],
       matchStrings: [
         'go (?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+      ],
+      depNameTemplate: 'go',
+      datasourceTemplate: 'golang-version',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      description: 'Keep post-upgrade golang pin in lockstep with go.mod',
+      managerFilePatterns: [
+        '/^renovate\\.json5$/',
+      ],
+      matchStrings: [
+        "golang: '(?<currentValue>\\d+\\.\\d+\\.\\d+)'",
       ],
       depNameTemplate: 'go',
       datasourceTemplate: 'golang-version',

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,9 @@
     'gomodTidy',
   ],
   // Post-upgrade `make` compiles controller-gen with this Go. Keep in lockstep
-  // with go.mod via the regex manager below (grouped with Go and linter tooling).
+  // with go.mod via the regex managers below (grouped with Go and linter tooling).
+  // postUpgradeTasks cannot use {{constraints.golang}}: Renovate's template filter
+  // excludes `constraints`, so use literal install-tool lines synced by regex instead.
   // Do not rely on installTools + this field: executionMode=branch drops
   // constraints (https://github.com/renovatebot/renovate/discussions/43633).
   constraints: {
@@ -103,7 +105,7 @@
       // (e.g. core/v1.PodStatusResult in 0.37) and Check Codegen fails.
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
@@ -145,7 +147,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
@@ -290,7 +292,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           // go fix applies stdlib fixers for the new toolchain (any, min/max, iterators, …).
           // Run before lint-fix so golangci-lint can clean up anything fix leaves behind.
           'make go-fix || true',
@@ -401,7 +403,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           'make build-installer',
         ],
         fileFilters: [
@@ -421,7 +423,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           'make build-installer',
         ],
         fileFilters: [
@@ -445,7 +447,7 @@
       automerge: false,
       postUpgradeTasks: {
         commands: [
-          'install-tool golang {{constraints.golang}}',
+          'install-tool golang 1.26.6',
           'make manifests',
           'make build-installer',
         ],
@@ -557,12 +559,25 @@
     },
     {
       customType: 'regex',
-      description: 'Keep post-upgrade golang pin in lockstep with go.mod',
+      description: 'Keep constraints.golang in lockstep with go.mod',
       managerFilePatterns: [
         '/^renovate\\.json5$/',
       ],
       matchStrings: [
         "golang: '(?<currentValue>\\d+\\.\\d+\\.\\d+)'",
+      ],
+      depNameTemplate: 'go',
+      datasourceTemplate: 'golang-version',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      description: 'Keep post-upgrade install-tool golang pins in lockstep with go.mod',
+      managerFilePatterns: [
+        '/^renovate\\.json5$/',
+      ],
+      matchStrings: [
+        'install-tool golang (?<currentValue>\\d+\\.\\d+\\.\\d+)',
       ],
       depNameTemplate: 'go',
       datasourceTemplate: 'golang-version',

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,15 +20,11 @@
   postUpdateOptions: [
     'gomodTidy',
   ],
-  // Post-upgrade `make` compiles controller-gen with this Go. Keep in lockstep
-  // with go.mod via the regex managers below (grouped with Go and linter tooling).
-  // postUpgradeTasks cannot use {{constraints.golang}}: Renovate's template filter
-  // excludes `constraints`, so use literal install-tool lines synced by regex instead.
-  // Do not rely on installTools + this field: executionMode=branch drops
-  // constraints (https://github.com/renovatebot/renovate/discussions/43633).
-  constraints: {
-    golang: '1.26.6',
-  },
+  // Post-upgrade codegen needs the same Go as CI. Use literal install-tool pins
+  // (synced via regex manager below, grouped with Go and linter tooling).
+  // {{constraints.golang}} is unavailable in postUpgradeTasks templates (Renovate's
+  // template filter excludes `constraints`), and constraints.golang is unused by the
+  // gomod manager anyway (renovatebot/renovate#42601).
   // The hashed lockfile is generated from docs/requirements.txt via a post-upgrade
   // task; Renovate must never try to edit it directly.
   ignorePaths: [
@@ -552,19 +548,6 @@
       ],
       matchStrings: [
         'go (?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
-      ],
-      depNameTemplate: 'go',
-      datasourceTemplate: 'golang-version',
-      versioningTemplate: 'semver',
-    },
-    {
-      customType: 'regex',
-      description: 'Keep constraints.golang in lockstep with go.mod',
-      managerFilePatterns: [
-        '/^renovate\\.json5$/',
-      ],
-      matchStrings: [
-        "golang: '(?<currentValue>\\d+\\.\\d+\\.\\d+)'",
       ],
       depNameTemplate: 'go',
       datasourceTemplate: 'golang-version',


### PR DESCRIPTION
Right now Renovate uses the latest go version, but codegen is pinned to the repo's go version.

Pin Renovate so codegen is consistent between Renovate and PR checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renovate post-upgrade tasks now install the project’s pinned Go version before running validation and tooling updates.
  * The Go version used by Renovate is automatically synchronized with the project’s Go module configuration.
  * Renovate’s Go setup is standardized across dependency update workflows, reducing configuration differences between automated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->