### PR TITLE
fix(controller): never skip history recalculation when the newest entry has no PR ID

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -259,6 +259,15 @@ func (r *ChangeTransferPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 // finalization: a prior pass may have populated history from a trailer-less merge commit before
 // the note existed, while the newest entry's SHAs already match the active tip.
 //
+// A newest entry without a pull request ID is never trusted either. The note-writing reconcile
+// rebuilds history correctly, but the PullRequest deletion enqueues another reconcile right behind
+// it, and that reconcile's cached read of the CTP can predate the status patch. Its prev.History
+// then still holds the trailer-less entry (SHAs matching the tip, no PR ID); skipping there would
+// re-apply the stale entry over the correct one and pin it until the active tip moves. Rebuilding
+// whenever the PR ID is missing keeps that path self-healing: the note is on the remote, so the
+// rebuild picks it up. Commits that genuinely carry no PR metadata (direct pushes to the active
+// branch) simply keep the pre-optimization behavior of recalculating every reconcile.
+//
 // A Spec.ActivePath change without a new active tip is not detected here; history is refreshed on
 // the next promotion that moves the active branch.
 func shouldSkipHistoryRecalculation(prev, cur *promoterv1alpha1.ChangeTransferPolicyStatus, historyNoteWritten bool) bool {
@@ -275,7 +284,7 @@ func shouldSkipHistoryRecalculation(prev, cur *promoterv1alpha1.ChangeTransferPo
 		return false
 	}
 	newest := prev.History[0]
-	if newest.PullRequest == nil || newest.PullRequest.MergedTargetSha != cur.Active.Hydrated.Sha {
+	if newest.PullRequest == nil || newest.PullRequest.ID == "" || newest.PullRequest.MergedTargetSha != cur.Active.Hydrated.Sha {
 		return false
 	}
 	return newest.Active.Hydrated.Sha == cur.Active.Hydrated.Sha

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -3078,6 +3078,24 @@ var _ = Describe("commit status description trailers", func() {
 			true,
 			false,
 		),
+		Entry("recalculates when newest history entry has no pull request ID",
+			// A stale cached read after the note-writing reconcile still holds the trailer-less entry whose
+			// SHAs match the tip; skipping there would re-apply it over the note-derived history.
+			promoterv1alpha1.ChangeTransferPolicyStatus{
+				Active: promoterv1alpha1.CommitBranchState{Hydrated: promoterv1alpha1.CommitShaState{Sha: "abc"}},
+				History: []promoterv1alpha1.History{{
+					Active: promoterv1alpha1.CommitBranchState{Hydrated: promoterv1alpha1.CommitShaState{Sha: "abc"}},
+					PullRequest: &promoterv1alpha1.PullRequestCommonStatus{
+						MergedTargetSha: "abc",
+					},
+				}},
+			},
+			promoterv1alpha1.ChangeTransferPolicyStatus{
+				Active: promoterv1alpha1.CommitBranchState{Hydrated: promoterv1alpha1.CommitShaState{Sha: "abc"}},
+			},
+			false,
+			false,
+		),
 		Entry("recalculates when newest history entry targets a different commit than the active tip",
 			promoterv1alpha1.ChangeTransferPolicyStatus{
 				Active: promoterv1alpha1.CommitBranchState{Hydrated: promoterv1alpha1.CommitShaState{Sha: "abc"}},


### PR DESCRIPTION
## Problem

The `test` workflow on main commit ce3af5c failed in the controller suite:

```
ChangeTransferPolicy Controller ... writes a history note for an externally squash-merged PR and builds history without trailers
Timed out after 90.001s.
Expected <string>: ""  to equal  <string>: 12   (entry.PullRequest.ID)
```

This is a real controller race introduced by the `shouldSkipHistoryRecalculation` short-circuit in #1923, not a bad test. From the captured controller log:

1. Two reconciles ran while the PR was being deleted but before the promotion-history note existed. `calculateHistory` built the squash commit's entry from its trailer-less message: empty PR ID, but `MergedTargetSha` and `Active.Hydrated.Sha` equal to the active tip.
2. The next reconcile wrote the note, removed the finalizer, and (via `historyNoteWritten`) rebuilt history correctly from the note. Correct status was applied at the end.
3. The PullRequest deletion enqueued one more reconcile ~5ms later. Its cached `Get` returned the CTP from before that status patch landed. With no PR left, `historyNoteWritten` was false; the tip was unchanged and the stale newest entry matched it, so the reconcile logged `skipping history recalculation` and re-applied the stale, PR-less history via SSA (`status.history` is an atomic list, and the apply uses `ForceOwnership` with no optimistic-concurrency guard).

Every later reconcile also skipped, because the stale entry satisfies all skip conditions, so the correct history could not come back until the active tip moved. In production this means an externally merged or squash-merged PR can lose its PR metadata in history until the next promotion.

## Fix

`shouldSkipHistoryRecalculation` now also refuses to skip when the newest history entry has an empty pull request ID. The note is already on the remote, so the rebuild picks it up and the path is self-healing regardless of cache staleness.

Tradeoff: active tips with genuinely no PR metadata (direct pushes) recalculate history on every reconcile. That is the pre-#1923 behavior, so nothing regresses; the skip optimization just does not apply to them.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean; `golangci-lint` v2.12.2 reports 0 issues on the controller package.
- Added a `DescribeTable` entry: "recalculates when newest history entry has no pull request ID".
- Focused envtest run of the skip table plus the "writing promotion history notes" context: 11/11 passed. The three history-notes specs then passed three consecutive runs with `--repeat=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5aqP1x4gLFd3zuyzKTsWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5aqP1x4gLFd3zuyzKTsWR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * History is now recalculated when the latest history entry lacks pull request information, preventing stale or incomplete history from being retained.
  * Existing recalculation checks for changed or missing commit information remain supported.

* **Tests**
  * Added coverage to verify recalculation occurs for history entries without pull request IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->