### PR TITLE
fix(controller): write the promotion history note as soon as the PR reports a merge

### DIFF
--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1073,11 +1073,20 @@ func (r *ChangeTransferPolicyReconciler) setPullRequestState(ctx context.Context
 	return nil
 }
 
-// handlePRFinalizerRemoval checks if there's a PR being deleted with our finalizer where the CTP status
-// already matches the PR status. If so, it writes the promotion-history git note for the merge and then
-// removes the finalizer to allow the PR to be deleted. The returned bool is true when a note was written
-// on this reconcile, which forces a history rebuild: a prior pass may have populated history from the
-// trailer-less merge commit before the note existed.
+// handlePRFinalizerRemoval handles a PR being deleted with our finalizer. As soon as the PR reports a merge
+// it makes sure the promotion-history git note exists on the merge commit, and once the CTP status matches
+// the PR status it removes the finalizer to allow the PR to be deleted. The returned bool is true when a
+// note is present on the merge commit (written now or by an earlier pass), which forces a history rebuild
+// from it instead of trusting a persisted entry that may predate the note.
+//
+// The note is written before the CTP-status gate on purpose. The PullRequest controller reports the merge
+// (state and mergedTargetSha) a reconcile or two before the CTP's own copy of that status is persisted, and
+// during that window the active tip has already moved to the merge commit. Without the note, the history
+// rebuild in those reconciles falls back to the merge commit's message, which for a squash or SCM-side merge
+// carries no trailers, and persists an entry with no pull request metadata that a later pass has to correct.
+// Writing the note first means every persisted history entry for the merge commit is built from it. Only
+// the finalizer release keeps waiting for the CTP status, so the PR object stays around until the CTP has
+// durably recorded it.
 func (r *ChangeTransferPolicyReconciler) handlePRFinalizerRemoval(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, gitOperations *git.EnvironmentOperations) (bool, error) {
 	logger := log.FromContext(ctx)
 
@@ -1111,9 +1120,21 @@ func (r *ChangeTransferPolicyReconciler) handlePRFinalizerRemoval(ctx context.Co
 		return false, nil
 	}
 
+	// Write the promotion-history note before the CTP-status checks below: the note is built from the PR
+	// object and the merge commit, neither of which the CTP status gates, and the history rebuild later in
+	// this reconcile needs it to describe the new active tip correctly. The PR's commit message is the last
+	// place the trailers survive when the SCM rewrote the merge commit (squash or external merge), and the
+	// finalizer is what guarantees that data is still around. A failure here keeps the finalizer so the next
+	// reconcile retries; SetHistoryNote's overwrite semantics make the retry idempotent.
+	historyNoteWritten, err := r.ensurePromotionHistoryNote(ctx, ctp, gitOperations, &livePR)
+	if err != nil {
+		r.Recorder.Eventf(ctp, nil, "Warning", constants.PromotionHistoryNoteFailedReason, "WritingPromotionHistoryNote", constants.PromotionHistoryNoteFailedMessage, livePR.Name, err)
+		return false, fmt.Errorf("failed to write promotion history note for PullRequest %q: %w", livePR.Name, err)
+	}
+
 	if ctp.Status.PullRequest == nil {
 		logger.V(4).Info("PR being deleted but CTP has no PR status, cannot remove finalizer yet")
-		return false, nil
+		return historyNoteWritten, nil
 	}
 
 	statusMatches := ctp.Status.PullRequest.ID == livePR.Status.ID &&
@@ -1127,7 +1148,7 @@ func (r *ChangeTransferPolicyReconciler) handlePRFinalizerRemoval(ctx context.Co
 			"prState", livePR.Status.State,
 			"ctpMergedTargetSha", ctp.Status.PullRequest.MergedTargetSha,
 			"prMergedTargetSha", livePR.Status.MergedTargetSha)
-		return false, nil
+		return historyNoteWritten, nil
 	}
 
 	// Do not release our finalizer until the PullRequest controller records a finalized deletion outcome.
@@ -1135,17 +1156,7 @@ func (r *ChangeTransferPolicyReconciler) handlePRFinalizerRemoval(ctx context.Co
 		logger.V(4).Info("PR being deleted but PullRequest status is not finalized yet, cannot remove finalizer yet",
 			"prState", livePR.Status.State,
 			"mergedTargetSha", livePR.Status.MergedTargetSha)
-		return false, nil
-	}
-
-	// Write the promotion-history note before releasing the finalizer: the PR's commit message is the last
-	// place the trailers survive when the SCM rewrote the merge commit (squash or external merge), and the
-	// finalizer is what guarantees that data is still around. A failure here keeps the finalizer so the next
-	// reconcile retries; SetHistoryNote's overwrite semantics make the retry idempotent.
-	historyNoteWritten, err := r.writePromotionHistoryNote(ctx, ctp, gitOperations, &livePR)
-	if err != nil {
-		r.Recorder.Eventf(ctp, nil, "Warning", constants.PromotionHistoryNoteFailedReason, "WritingPromotionHistoryNote", constants.PromotionHistoryNoteFailedMessage, livePR.Name, err)
-		return false, fmt.Errorf("failed to write promotion history note for PullRequest %q: %w", livePR.Name, err)
+		return historyNoteWritten, nil
 	}
 
 	logger.Info("Removing CTP finalizer from PR - status already synced",
@@ -1164,6 +1175,44 @@ func (r *ChangeTransferPolicyReconciler) handlePRFinalizerRemoval(ctx context.Co
 
 	logger.V(4).Info("PR finalizer removed")
 	return historyNoteWritten, nil
+}
+
+// ensurePromotionHistoryNote makes sure the promotion-history note for a merged, terminating PullRequest
+// exists on its merge commit. It returns true when a note is present on the merge commit after the call,
+// whether written now or by an earlier reconcile, so the caller forces a history rebuild from it.
+//
+// handlePRFinalizerRemoval calls this on every reconcile between the PullRequest reporting the merge and
+// the finalizer release, typically two or three passes. The note's content is fixed once the PR is merged
+// (spec.commit.message is never rewritten for a merged PR and the merge commit is immutable), so an existing
+// note is reused rather than rewritten, which avoids a redundant notes-ref push per pass.
+//
+// The merge commit may not be in the local clone yet: CloneRepo is blob-less and the active branch is only
+// fetched later in the reconcile by calculateStatus, so on the first pass after an external merge the active
+// branch is fetched here before the note is built from the commit.
+func (r *ChangeTransferPolicyReconciler) ensurePromotionHistoryNote(ctx context.Context, ctp *promoterv1alpha1.ChangeTransferPolicy, gitOperations *git.EnvironmentOperations, livePR *promoterv1alpha1.PullRequest) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	// Nothing to record yet: the PR was closed, or the SCM has not reported the merge commit. This mirrors
+	// writePromotionHistoryNote's own early returns and skips the branch fetch in those cases.
+	if livePR.Status.State != promoterv1alpha1.PullRequestMerged || livePR.Status.MergedTargetSha == "" {
+		return false, nil
+	}
+	mergedTargetSha := livePR.Status.MergedTargetSha
+
+	existing, err := gitOperations.GetHistoryNote(ctx, mergedTargetSha)
+	if err != nil {
+		return false, fmt.Errorf("failed to check for an existing history note on merge commit %q: %w", mergedTargetSha, err)
+	}
+	if len(existing) > 0 {
+		logger.V(4).Info("Promotion history note already present on merge commit", "mergeCommit", mergedTargetSha, "prID", livePR.Status.ID)
+		return true, nil
+	}
+
+	if err := gitOperations.FetchBranch(ctx, ctp.Spec.ActiveBranch); err != nil {
+		return false, fmt.Errorf("failed to fetch active branch %q before writing promotion history note: %w", ctp.Spec.ActiveBranch, err)
+	}
+
+	return r.writePromotionHistoryNote(ctx, ctp, gitOperations, livePR)
 }
 
 // writePromotionHistoryNote records the pull request's commit message trailers as a git note on the merge

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -2850,6 +2851,211 @@ var _ = Describe("writePromotionHistoryNote merge commit snapshot mismatch", fun
 		Expect(err).NotTo(HaveOccurred())
 		Expect(include).To(BeTrue())
 		Expect(entry.MergeCommitSnapshotMismatch).To(BeFalse())
+	})
+})
+
+var _ = Describe("handlePRFinalizerRemoval early promotion history note", func() {
+	var workDir string
+	var bareDir string
+	var gitOps *git.EnvironmentOperations
+	var ctp *promoterv1alpha1.ChangeTransferPolicy
+	var proposedSha, squashSha string
+
+	const (
+		activeBranch   = "env-active"
+		proposedBranch = "env-proposed"
+		prID           = "77"
+		drySha         = "dry-1-sha"
+	)
+
+	mustRunGit := func(dir string, args ...string) string {
+		GinkgoHelper()
+		out, err := runGitCmd(ctx, dir, args...)
+		Expect(err).NotTo(HaveOccurred())
+		return strings.TrimSpace(out)
+	}
+
+	// newPR returns a terminating PullRequest that still carries the CTP finalizer, in the given SCM state.
+	// Its spec.commit.message carries the trailers the promoter wrote before the merge, exactly what the
+	// history note is built from.
+	newPR := func(state promoterv1alpha1.PullRequestState, mergedTargetSha string) *promoterv1alpha1.PullRequest {
+		msg := "Promote change\n\n" +
+			constants.TrailerPullRequestID + ": " + prID + "\n" +
+			constants.TrailerShaHydratedProposed + ": " + proposedSha + "\n" +
+			constants.TrailerShaDryProposed + ": " + drySha
+		return &promoterv1alpha1.PullRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "early-note-pr",
+				Namespace: ctp.Namespace,
+				Labels: map[string]string{
+					promoterv1alpha1.PromotionStrategyLabel:    utils.KubeSafeLabel(ctp.Labels[promoterv1alpha1.PromotionStrategyLabel]),
+					promoterv1alpha1.ChangeTransferPolicyLabel: utils.KubeSafeLabel(ctp.Name),
+					promoterv1alpha1.EnvironmentLabel:          utils.KubeSafeLabel(activeBranch),
+				},
+				Finalizers:        []string{promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer},
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			},
+			Spec: promoterv1alpha1.PullRequestSpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "early-note-repo"},
+				MergeSha:            proposedSha,
+				Commit:              promoterv1alpha1.CommitConfiguration{Message: msg},
+			},
+			Status: promoterv1alpha1.PullRequestStatus{
+				ID:              prID,
+				State:           state,
+				MergedTargetSha: mergedTargetSha,
+			},
+		}
+	}
+
+	newReconciler := func(pr *promoterv1alpha1.PullRequest) *ChangeTransferPolicyReconciler {
+		c := ctrlfake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(pr).Build()
+		return &ChangeTransferPolicyReconciler{Client: c, Recorder: events.NewFakeRecorder(100)}
+	}
+
+	notesRefSha := func() string {
+		GinkgoHelper()
+		return mustRunGit(bareDir, "rev-parse", git.PromoterHistoryNotesRef)
+	}
+
+	BeforeEach(func() {
+		var err error
+		bareDir, err = os.MkdirTemp("", "early-note-bare-*")
+		Expect(err).NotTo(HaveOccurred())
+		mustRunGit(bareDir, "init", "--bare")
+
+		workDir, err = os.MkdirTemp("", "early-note-work-*")
+		Expect(err).NotTo(HaveOccurred())
+		mustRunGit(workDir, "clone", bareDir, ".")
+		mustRunGit(workDir, "config", "user.name", "Test User")
+		mustRunGit(workDir, "config", "user.email", "test@example.com")
+		mustRunGit(workDir, "config", "commit.gpgsign", "false")
+
+		Expect(os.WriteFile(path.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"dry-0-sha"}`), 0o644)).To(Succeed())
+		mustRunGit(workDir, "add", "-A")
+		mustRunGit(workDir, "commit", "-m", "base")
+		defaultBranch := mustRunGit(workDir, "rev-parse", "--abbrev-ref", "HEAD")
+		mustRunGit(workDir, "push", "-u", "origin", defaultBranch)
+
+		mustRunGit(workDir, "checkout", "-B", activeBranch, defaultBranch)
+		mustRunGit(workDir, "push", "-u", "origin", activeBranch)
+
+		mustRunGit(workDir, "checkout", "-B", proposedBranch, defaultBranch)
+		Expect(os.WriteFile(path.Join(workDir, "hydrator.metadata"), []byte(`{"drySha":"`+drySha+`"}`), 0o644)).To(Succeed())
+		mustRunGit(workDir, "add", "-A")
+		mustRunGit(workDir, "commit", "-m", "p1")
+		proposedSha = mustRunGit(workDir, "rev-parse", "HEAD")
+		mustRunGit(workDir, "push", "-u", "origin", proposedBranch)
+
+		ctp = &promoterv1alpha1.ChangeTransferPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "early-note-ctp",
+				Namespace: "default",
+				Labels:    map[string]string{promoterv1alpha1.PromotionStrategyLabel: "early-note-ps"},
+			},
+			Spec: promoterv1alpha1.ChangeTransferPolicySpec{
+				ActiveBranch:   activeBranch,
+				ProposedBranch: proposedBranch,
+			},
+			// The CTP has not yet copied the merged state from the PullRequest. This is the window in which
+			// the finalizer must stay put but the note can already be written.
+			Status: promoterv1alpha1.ChangeTransferPolicyStatus{
+				PullRequest: &promoterv1alpha1.PullRequestCommonStatus{ID: prID, State: promoterv1alpha1.PullRequestOpen},
+			},
+		}
+
+		// Clone for the controller BEFORE the external merge lands, so the merge commit is not in the local
+		// clone yet: handlePRFinalizerRemoval runs before calculateStatus fetches the active branch.
+		gitRepo := &promoterv1alpha1.GitRepository{
+			ObjectMeta: metav1.ObjectMeta{Name: "early-note-repo", Namespace: "default"},
+			Spec: promoterv1alpha1.GitRepositorySpec{
+				Fake: &promoterv1alpha1.FakeRepo{Owner: "test-owner", Name: "early-note-repo"},
+			},
+		}
+		gitOps = git.NewEnvironmentOperations(gitRepo, &localGitProvider{repoPath: bareDir}, "default/early-note-"+proposedSha)
+		Expect(gitOps.CloneRepo(ctx)).To(Succeed())
+		Expect(gitOps.FetchNotes(ctx)).To(Succeed())
+
+		// An external squash merge: the commit message carries no trailers, exactly like a merge performed
+		// in the SCM UI.
+		mustRunGit(workDir, "checkout", activeBranch)
+		mustRunGit(workDir, "merge", "--squash", proposedBranch)
+		mustRunGit(workDir, "commit", "-m", "external squash merge")
+		squashSha = mustRunGit(workDir, "rev-parse", "HEAD")
+		mustRunGit(workDir, "push", "origin", activeBranch)
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(bareDir)
+		_ = os.RemoveAll(workDir)
+	})
+
+	It("writes the note as soon as the PR reports the merge, without releasing the finalizer", func() {
+		By("Confirming the controller's clone has not fetched the merge yet")
+		// The clone predates the external merge; origin/<active> only advances when FetchBranch runs.
+		Expect(mustRunGit(gitOps.ClonePath(), "rev-parse", "origin/"+activeBranch)).NotTo(Equal(squashSha))
+
+		pr := newPR(promoterv1alpha1.PullRequestMerged, squashSha)
+		r := newReconciler(pr)
+
+		written, err := r.handlePRFinalizerRemoval(ctx, ctp, gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(written).To(BeTrue(), "a note on the merge commit must force a history rebuild this reconcile")
+
+		By("Verifying the active branch was fetched so the merge commit could be read")
+		Expect(mustRunGit(gitOps.ClonePath(), "rev-parse", "origin/"+activeBranch)).To(Equal(squashSha))
+
+		By("Verifying the note is on the remote with the PR's trailers")
+		note, err := fetchPromotionHistoryNote(workDir, squashSha)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(note[constants.TrailerPullRequestID]).To(Equal([]string{prID}))
+		Expect(note[constants.TrailerShaHydratedProposed]).To(Equal([]string{proposedSha}))
+		Expect(note[constants.TrailerPullRequestMergeTime]).ToNot(BeEmpty())
+
+		By("Verifying the history entry built in this same reconcile already carries the PR metadata")
+		entry, include, err := r.buildHistoryEntry(ctx, squashSha, "", gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(include).To(BeTrue())
+		Expect(entry.PullRequest.ID).To(Equal(prID))
+
+		By("Verifying the finalizer is still held because the CTP status has not caught up")
+		var livePR promoterv1alpha1.PullRequest
+		Expect(r.Get(ctx, ctrlclient.ObjectKeyFromObject(pr), &livePR)).To(Succeed())
+		Expect(livePR.Finalizers).To(ContainElement(promoterv1alpha1.ChangeTransferPolicyPullRequestFinalizer))
+	})
+
+	It("reuses an existing note on later passes instead of rewriting it", func() {
+		r := newReconciler(newPR(promoterv1alpha1.PullRequestMerged, squashSha))
+
+		written, err := r.handlePRFinalizerRemoval(ctx, ctp, gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(written).To(BeTrue())
+		firstNotesRef := notesRefSha()
+
+		written, err = r.handlePRFinalizerRemoval(ctx, ctp, gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(written).To(BeTrue(), "an existing note must still force the history rebuild")
+		Expect(notesRefSha()).To(Equal(firstNotesRef), "the notes ref must not be pushed again for an unchanged note")
+	})
+
+	It("writes nothing while the SCM has not reported the merge commit", func() {
+		r := newReconciler(newPR(promoterv1alpha1.PullRequestMerged, ""))
+
+		written, err := r.handlePRFinalizerRemoval(ctx, ctp, gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(written).To(BeFalse())
+		_, err = fetchPromotionHistoryNote(workDir, squashSha)
+		Expect(err).To(HaveOccurred(), "no notes ref should exist yet")
+	})
+
+	It("writes nothing for a PR closed without merging", func() {
+		r := newReconciler(newPR(promoterv1alpha1.PullRequestClosed, ""))
+
+		written, err := r.handlePRFinalizerRemoval(ctx, ctp, gitOps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(written).To(BeFalse())
+		_, err = fetchPromotionHistoryNote(workDir, squashSha)
+		Expect(err).To(HaveOccurred(), "no notes ref should exist")
 	})
 })
 


### PR DESCRIPTION
Follow-up to #1955, which should merge first (see "Relationship to #1955" below). Independent diff, no overlapping lines.

## Problem

`handlePRFinalizerRemoval` only wrote the promotion-history note once the CTP's copy of the PullRequest status matched the live PR, immediately before releasing the finalizer. The PullRequest controller reports the merge (`status.state` and `status.mergedTargetSha`) a reconcile or two before that, and by then the active tip has already moved to the merge commit.

In those in-between reconciles `calculateHistory` finds no note and falls back to the merge commit's message. For a squash or SCM-side merge that message has no trailers, so the controller persists a history entry for the merge commit with no pull request metadata (`pullRequest.id == ""`), which the note-writing pass later has to correct. The PromotionStrategy controller copies `ctp.Status.History` into its own status unconditionally, so that gap is briefly visible in the dashboard as a history row with no PR.

In the CI failure that #1955 diagnosed, the log for the pre-note reconcile shows the PR already had everything the note needs:

```
PR being deleted but CTP status doesn't match PR status, cannot remove finalizer yet
  ctpPRState: open   prState: merged   ctpMergedTargetSha: ""   prMergedTargetSha: a2acc667
```

Only the CTP's own status was behind. The status-match gate is right for the finalizer release (the PR object must outlive the CTP durably recording it) but unnecessary for the note, whose content comes from the PR object and the merge commit.

## Fix

- Move the note write ahead of the CTP-status and finalized gates in `handlePRFinalizerRemoval`. The finalizer release logic is unchanged and still waits for the CTP status. The returned `historyNoteWritten` is carried through the early returns so the same reconcile rebuilds history from the note.
- New `ensurePromotionHistoryNote` helper:
  - Skips when the PR is not merged or has no `mergedTargetSha` (same cases `writePromotionHistoryNote` already skips), avoiding the fetch below.
  - Reuses an existing note instead of rewriting it. This runs on every pass between "PR reports merged" and "finalizer released" (typically two or three), and the note content is fixed once the PR is merged, so re-pushing the notes ref each pass would be redundant.
  - Fetches the active branch before writing. `CloneRepo` is blob-less and `calculateStatus` (which normally fetches the active branch) runs after `handlePRFinalizerRemoval`, so on the first reconcile after an external merge the merge commit may not be in the local clone yet.

Behavior change to be aware of: a transient git failure while fetching or writing in the pre-note window now errors the reconcile (finalizer retained, retried), where previously those passes returned nil and the failure would have surfaced at release time instead. This matches the existing note-write failure handling.

## Relationship to #1955

This does not replace the empty-PR-ID guard in #1955. The push webhook can trigger a CTP reconcile while the PR is still `open` on the SCM; that reconcile has nothing to write and still builds the empty-ID entry for the new tip, and the stale-cache follow-up reconcile can still re-apply it. #1955 is the fix for that; this PR narrows the window so the empty entry is not persisted in the common path at all.

## Testing

- `go build`, `go vet`, `gofmt` clean; `golangci-lint` v2.12.2 reports 0 issues on the controller package.
- New unit-style `Describe("handlePRFinalizerRemoval early promotion history note")` using a local bare repo and the controller-runtime fake client, with the clone taken before the external squash merge lands:
  - writes the note while the CTP's PR status still says `open`, fetches the active branch to do it, the history entry built in the same reconcile carries the PR ID, and the finalizer is still held;
  - a second pass reuses the note (notes ref SHA unchanged) and still returns true;
  - no note for a merged PR without `mergedTargetSha`, or for a PR closed without merging.
- Focused envtest run of the new specs plus the existing "writing promotion history notes" context, the `writePromotionHistoryNote` snapshot-mismatch specs, and the `shouldSkipHistoryRecalculation` table: 16/16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5aqP1x4gLFd3zuyzKTsWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5aqP1x4gLFd3zuyzKTsWR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion history is now recorded as soon as a pull request is reported as merged, even before related status checks complete.
  * Existing promotion history notes are reused to avoid unnecessary updates.
  * History notes are not written for pull requests that are closed without merging.
  * Promotion history is rebuilt reliably when a note is created during any reconciliation pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->