### PR TITLE
fix(utils): omit empty optional status sub-objects from server-side apply

### DIFF
--- a/internal/utils/status_apply.go
+++ b/internal/utils/status_apply.go
@@ -3,6 +3,9 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"slices"
+	"strings"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	acv1alpha1 "github.com/argoproj-labs/gitops-promoter/applyconfiguration/api/v1alpha1"
@@ -219,13 +222,143 @@ func controllerConfigurationStatusApply(o *promoterv1alpha1.ControllerConfigurat
 // jsonRoundTrip copies all JSON-tagged fields from src into dst by marshaling src and
 // unmarshaling into dst. This works for status types whose apply configuration mirrors
 // the original type's JSON shape (which is true for all generated apply configs).
+//
+// Optional sub-objects that marshal empty are dropped from the intermediate JSON before
+// it is loaded into the apply configuration. Status types embed value-typed sub-objects
+// (for example CommitBranchState.Dry) whose zero value marshals as "{}", or as an object
+// whose only members are null (a zero metav1.Time marshals as null). Applying "{}" for a
+// field whose children this manager owned on the previous apply makes the apiserver
+// remove those children and store the now-empty field as null (structured-merge-diff
+// RemoveItems semantics, restored in v6.3.3/v6.4.2 and shipped in Kubernetes 1.36.3+ and
+// 1.37+), which the CRD's non-nullable object schema then rejects. Omitting the field
+// from the apply configuration lets server-side apply unset it cleanly instead, and the
+// Go zero value round-trips identically on read.
+//
+// Only fields tagged omitempty are dropped. controller-gen marks exactly those fields
+// optional in the CRD schema, so a required object (for example
+// PromotionStrategy status.environments[].active) keeps applying as "{}" when empty.
 func jsonRoundTrip(src, dst any) error {
 	data, err := json.Marshal(src)
 	if err != nil {
 		return fmt.Errorf("marshal status: %w", err)
 	}
+	var generic any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return fmt.Errorf("unmarshal status: %w", err)
+	}
+	data, err = json.Marshal(pruneEmptyOptionalObjects(reflect.ValueOf(src), generic))
+	if err != nil {
+		return fmt.Errorf("marshal pruned status: %w", err)
+	}
 	if err := json.Unmarshal(data, dst); err != nil {
 		return fmt.Errorf("unmarshal into apply configuration: %w", err)
 	}
 	return nil
+}
+
+// pruneEmptyOptionalObjects walks the Go value rv alongside its generic JSON encoding j
+// and removes object members that correspond to struct fields tagged omitempty whose
+// encoded value is null or an object with no remaining members. Required fields (no
+// omitempty), lists, and map entries are never removed; they are only traversed so that
+// nested optional sub-objects inside them are pruned. It returns the pruned j.
+func pruneEmptyOptionalObjects(rv reflect.Value, j any) any {
+	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return j
+		}
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() {
+	case reflect.Struct:
+		m, ok := j.(map[string]any)
+		if !ok {
+			// Custom marshalers (metav1.Time and friends) do not encode as objects.
+			return j
+		}
+		return pruneStructMembers(rv, m)
+	case reflect.Slice, reflect.Array:
+		items, ok := j.([]any)
+		if !ok {
+			return j
+		}
+		for i := range items {
+			if i < rv.Len() {
+				items[i] = pruneEmptyOptionalObjects(rv.Index(i), items[i])
+			}
+		}
+		return items
+	case reflect.Map:
+		m, ok := j.(map[string]any)
+		if !ok || rv.Type().Key().Kind() != reflect.String {
+			return j
+		}
+		for _, key := range rv.MapKeys() {
+			k := key.String()
+			if child, present := m[k]; present {
+				m[k] = pruneEmptyOptionalObjects(rv.MapIndex(key), child)
+			}
+		}
+		return m
+	default:
+		return j
+	}
+}
+
+func pruneStructMembers(rv reflect.Value, m map[string]any) map[string]any {
+	t := rv.Type()
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if f.PkgPath != "" && !f.Anonymous {
+			continue // unexported
+		}
+		name, omitEmpty, inline := parseJSONTag(f)
+		if name == "-" {
+			continue
+		}
+		fv := rv.Field(i)
+		if inline {
+			// Embedded struct without a name: its members are flattened into m.
+			pruneEmptyOptionalObjects(fv, m)
+			continue
+		}
+		child, present := m[name]
+		if !present {
+			continue
+		}
+		pruned := pruneEmptyOptionalObjects(fv, child)
+		if omitEmpty {
+			if pruned == nil {
+				delete(m, name)
+				continue
+			}
+			if cm, ok := pruned.(map[string]any); ok && len(cm) == 0 {
+				delete(m, name)
+				continue
+			}
+		}
+		m[name] = pruned
+	}
+	return m
+}
+
+// parseJSONTag returns the JSON member name for f, whether it carries omitempty, and
+// whether it is an embedded struct that encoding/json flattens into its parent.
+func parseJSONTag(f reflect.StructField) (name string, omitEmpty bool, inline bool) {
+	name, opts, _ := strings.Cut(f.Tag.Get("json"), ",")
+	if name == "-" && opts == "" {
+		return "-", false, false
+	}
+	omitEmpty = slices.Contains(strings.Split(opts, ","), "omitempty")
+	if name != "" {
+		return name, omitEmpty, false
+	}
+	ft := f.Type
+	if ft.Kind() == reflect.Pointer {
+		ft = ft.Elem()
+	}
+	if f.Anonymous && ft.Kind() == reflect.Struct {
+		return "", omitEmpty, true
+	}
+	return f.Name, omitEmpty, false
 }

--- a/internal/utils/status_apply_test.go
+++ b/internal/utils/status_apply_test.go
@@ -1,0 +1,197 @@
+package utils
+
+import (
+	"encoding/json"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+)
+
+// applyStatusJSON builds the full status apply configuration for obj and returns the
+// "status" member of its JSON encoding, decoded generically.
+func applyStatusJSON(o *promoterv1alpha1.ChangeTransferPolicy) map[string]any {
+	GinkgoHelper()
+	cfg, err := statusApplyConfig(o, false)
+	Expect(err).NotTo(HaveOccurred())
+	data, err := json.Marshal(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	var decoded map[string]any
+	Expect(json.Unmarshal(data, &decoded)).To(Succeed())
+	status, ok := decoded["status"].(map[string]any)
+	Expect(ok).To(BeTrue(), "status should be an object: %s", string(data))
+	return status
+}
+
+var _ = Describe("statusApplyConfig", func() {
+	It("omits empty sub-objects so SSA unsets them instead of applying {}", func() {
+		ctp := &promoterv1alpha1.ChangeTransferPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "ctp", Namespace: "default"},
+		}
+		// The failure mode: the proposed branch moved to a commit with no readable
+		// hydrator.metadata, so Proposed.Dry is reset to its zero value while
+		// Proposed.Hydrated is populated.
+		ctp.Status.Proposed.Hydrated.Sha = "ee98e8f78c020572402312f711eb0f2f138df854"
+
+		status := applyStatusJSON(ctp)
+
+		proposed, ok := status["proposed"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(proposed).NotTo(HaveKey("dry"), "zero-value Dry must not be applied as {}")
+		Expect(proposed).To(HaveKeyWithValue("hydrated", HaveKeyWithValue("sha", ctp.Status.Proposed.Hydrated.Sha)))
+		// A zero metav1.Time marshals as null and must not survive as an explicit null.
+		Expect(proposed["hydrated"]).NotTo(HaveKey("commitTime"))
+		Expect(status).NotTo(HaveKey("active"), "fully-empty Active must be omitted")
+	})
+
+	It("keeps populated sub-objects intact", func() {
+		ctp := &promoterv1alpha1.ChangeTransferPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "ctp", Namespace: "default"},
+		}
+		ctp.Status.Proposed.Dry.Sha = "c33e44496bd2afa0f683c43083582fefab282ece"
+		ctp.Status.Proposed.Dry.CommitTime = metav1.Now()
+		ctp.Status.Proposed.Hydrated.Sha = "b06e7e71b37a32e1e9955eef93c71722c1c3bce4"
+		ctp.Status.Active.Hydrated.Sha = "b06e7e71b37a32e1e9955eef93c71722c1c3bce4"
+
+		status := applyStatusJSON(ctp)
+
+		Expect(status).To(HaveKeyWithValue("proposed", SatisfyAll(
+			HaveKeyWithValue("dry", SatisfyAll(
+				HaveKeyWithValue("sha", ctp.Status.Proposed.Dry.Sha),
+				HaveKey("commitTime"),
+			)),
+			HaveKeyWithValue("hydrated", HaveKeyWithValue("sha", ctp.Status.Proposed.Hydrated.Sha)),
+		)))
+		Expect(status).To(HaveKeyWithValue("active", HaveKeyWithValue("hydrated", HaveKeyWithValue("sha", ctp.Status.Active.Hydrated.Sha))))
+		Expect(status["active"]).NotTo(HaveKey("dry"))
+	})
+
+	It("leaves the conditions-only apply configuration unchanged", func() {
+		ctp := &promoterv1alpha1.ChangeTransferPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "ctp", Namespace: "default"},
+		}
+		ctp.Status.Conditions = []metav1.Condition{{Type: "Ready", Status: metav1.ConditionFalse, Reason: "ReconciliationError", Message: "boom"}}
+		ctp.Status.Proposed.Hydrated.Sha = "ee98e8f78c020572402312f711eb0f2f138df854"
+
+		cfg, err := statusApplyConfig(ctp, true)
+		Expect(err).NotTo(HaveOccurred())
+		data, err := json.Marshal(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		var decoded map[string]any
+		Expect(json.Unmarshal(data, &decoded)).To(Succeed())
+		status, ok := decoded["status"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(status).To(HaveKey("conditions"))
+		Expect(status).NotTo(HaveKey("proposed"))
+	})
+})
+
+var _ = Describe("statusApplyConfig for PromotionStrategy", func() {
+	It("keeps required environment sub-objects while dropping optional empty ones", func() {
+		ps := &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: "ps", Namespace: "default"},
+		}
+		// status.environments[].active and .proposed are required in the CRD (no
+		// omitempty), so an empty environment must still apply them as {}. The
+		// optional dry/hydrated objects inside them must be omitted when empty.
+		ps.Status.Environments = []promoterv1alpha1.EnvironmentStatus{
+			{Branch: "environment/development"},
+			{Branch: "environment/staging", Proposed: promoterv1alpha1.CommitBranchState{
+				Hydrated: promoterv1alpha1.CommitShaState{Sha: "ee98e8f78c020572402312f711eb0f2f138df854"},
+			}},
+		}
+
+		cfg, err := statusApplyConfig(ps, false)
+		Expect(err).NotTo(HaveOccurred())
+		data, err := json.Marshal(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		var decoded map[string]any
+		Expect(json.Unmarshal(data, &decoded)).To(Succeed())
+		envs, ok := decoded["status"].(map[string]any)["environments"].([]any)
+		Expect(ok).To(BeTrue())
+		Expect(envs).To(HaveLen(2))
+
+		Expect(envs[0]).To(SatisfyAll(
+			HaveKeyWithValue("branch", "environment/development"),
+			HaveKeyWithValue("active", BeEmpty()),
+			HaveKeyWithValue("proposed", BeEmpty()),
+		))
+		Expect(envs[1]).To(SatisfyAll(
+			HaveKeyWithValue("active", BeEmpty()),
+			HaveKeyWithValue("proposed", SatisfyAll(
+				HaveKeyWithValue("hydrated", HaveKeyWithValue("sha", "ee98e8f78c020572402312f711eb0f2f138df854")),
+				Not(HaveKey("dry")),
+			)),
+		))
+	})
+})
+
+type pruneLeaf struct {
+	Time metav1.Time `json:"time,omitempty"`
+	Sha  string      `json:"sha,omitempty"`
+}
+
+type pruneEmbedded struct {
+	Inline pruneLeaf `json:"inline,omitempty"`
+}
+
+type pruneRoot struct {
+	pruneEmbedded `json:",inline"`
+	Optional      pruneLeaf            `json:"optional,omitempty"`
+	Required      pruneLeaf            `json:"required"`
+	Renamed       pruneLeaf            `json:"renamedField,omitempty"`
+	Skipped       pruneLeaf            `json:"-"`
+	unexported    pruneLeaf            //nolint:unused // exercises the unexported-field branch
+	OptionalPtr   *pruneLeaf           `json:"optionalPtr,omitempty"`
+	ByKey         map[string]pruneLeaf `json:"byKey,omitempty"`
+	Items         []pruneLeaf          `json:"items,omitempty"`
+}
+
+var _ = Describe("pruneEmptyOptionalObjects", func() {
+	prune := func(v any) map[string]any {
+		GinkgoHelper()
+		data, err := json.Marshal(v)
+		Expect(err).NotTo(HaveOccurred())
+		var generic any
+		Expect(json.Unmarshal(data, &generic)).To(Succeed())
+		out, ok := pruneEmptyOptionalObjects(reflect.ValueOf(v), generic).(map[string]any)
+		Expect(ok).To(BeTrue())
+		return out
+	}
+
+	It("drops empty optional objects and nulls but keeps required ones", func() {
+		out := prune(&pruneRoot{
+			OptionalPtr: &pruneLeaf{},
+			Items:       []pruneLeaf{{}, {Sha: "a"}},
+			ByKey:       map[string]pruneLeaf{"k": {}},
+		})
+		Expect(out).NotTo(HaveKey("optional"))
+		Expect(out).NotTo(HaveKey("optionalPtr"))
+		Expect(out).NotTo(HaveKey("renamedField"))
+		Expect(out).NotTo(HaveKey("inline"), "inlined embedded struct members are pruned in place")
+		Expect(out).To(HaveKeyWithValue("required", BeEmpty()), "required object stays as {} with its null time removed")
+		// List elements and map entries are traversed but never removed.
+		Expect(out).To(HaveKeyWithValue("items", ConsistOf(BeEmpty(), HaveKeyWithValue("sha", "a"))))
+		Expect(out).To(HaveKeyWithValue("byKey", HaveKeyWithValue("k", BeEmpty())))
+	})
+
+	It("keeps populated optional objects", func() {
+		out := prune(&pruneRoot{
+			pruneEmbedded: pruneEmbedded{Inline: pruneLeaf{Sha: "i"}},
+			Optional:      pruneLeaf{Time: metav1.Now()},
+			Required:      pruneLeaf{Sha: "r"},
+		})
+		Expect(out).To(HaveKeyWithValue("inline", HaveKeyWithValue("sha", "i")))
+		Expect(out).To(HaveKeyWithValue("optional", HaveKey("time")))
+		Expect(out).To(HaveKeyWithValue("required", HaveKeyWithValue("sha", "r")))
+	})
+
+	It("leaves non-object encodings untouched", func() {
+		Expect(pruneEmptyOptionalObjects(reflect.ValueOf(metav1.Time{}), nil)).To(BeNil())
+		Expect(pruneEmptyOptionalObjects(reflect.ValueOf((*pruneRoot)(nil)), map[string]any{"x": 1})).To(HaveKeyWithValue("x", 1))
+		Expect(pruneEmptyOptionalObjects(reflect.ValueOf("s"), "s")).To(Equal("s"))
+	})
+})


### PR DESCRIPTION
## Problem

#1927 (envtest 1.36.2 → 1.37.0) fails one spec on every push: `ChangeTransferPolicy proposed dry metadata validation / without activePath / fails reconciliation when metadata is not at the repository root`. The controller log shows why:

```
full status apply failed, attempting conditions-only apply
  error: ChangeTransferPolicy "..." is invalid: [status.proposed.dry: Invalid value: "null":
  proposed.dry in body must be of type object: "null", ...]
```

When the controller cannot read a dry SHA it resets `Status.Proposed.Dry` to its zero value, which marshals as `{}` (technically `{"commitTime": null}`, which the apply configuration turns into `{}`). Server-side apply then removes the `dry.sha` etc. children this field owner applied last time, and structured-merge-diff's `RemoveItems` stores the now-empty map as `null`. The CRD's non-nullable `type: object` schema rejects it, the conditions-only fallback runs, and `status.proposed.hydrated.sha` goes stale while the Ready condition names the newer commit. The spec asserts the two agree and times out.

This is not a regression introduced by #1927. It is the long-standing SSA behavior behind kubernetes/kubernetes#104694 and #117447:

- structured-merge-diff #306 (SMD v6.3.2, shipped in Kubernetes 1.36.0–1.36.2) changed `RemoveItems` to keep `{}` instead of `null`. That is the only window in which this status apply ever worked, and it happens to be where envtest 1.36.2 sits.
- kubernetes-sigs/structured-merge-diff#331 reported that #306 broke nullable containers with required fields, and #334 reverted it (SMD v6.3.3 / v6.4.2). Kubernetes 1.36.3+ (kubernetes/kubernetes#140296) and 1.37.0 carry the revert.

Verified with a minimal SSA repro (apply `dry: {sha}` then `dry: {}` on the status subresource): envtest 1.34.1, 1.35.0 and 1.37.0 all reject it as `null`; only 1.36.2 accepts it. The client-side patch bytes are identical under the 0.36.4 and 0.37.0 Go modules, so only the apiserver binary matters. This also means real clusters on 1.36.3+ / 1.37 hit the same fallback path today; the kind e2e matrix (1.34.8 / 1.35.5 / 1.36.1) does not exercise the populated → empty transition.

## Fix

`jsonRoundTrip` now walks the status struct alongside its JSON encoding and drops members that are `null` or empty objects **only when the Go field is tagged `omitempty`**, so SSA unsets those fields instead of applying `{}`. controller-gen marks exactly the `omitempty` fields optional in the CRD, so required objects such as PromotionStrategy `status.environments[].active` / `.proposed` keep applying as `{}` when empty (a first, blanket "drop every empty object" version broke that spec, which is why the pruning is tag-driven). Lists and map entries are traversed but never removed. The Go zero value round-trips identically on read.

## Testing

- New unit tests in `internal/utils/status_apply_test.go` for the CTP shape (empty `dry` omitted, populated `dry` kept, conditions-only path unchanged), the PromotionStrategy shape (required `active`/`proposed` kept as `{}`, nested optional `dry` dropped), and the walker itself (omitempty vs required, pointers, inline embedded structs, lists, maps, custom marshalers).
- The previously failing spec passes on envtest 1.37.0 and 1.36.2 with zero fallback applies.
- Full `internal/` + `webrequestsimulator/` ginkgo suite (369 controller specs) passes against envtest 1.37.0.
- `make lint`: 0 issues.

Once this merges, #1927 should go green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2sPY9p6amoyEGkPpddVuY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2sPY9p6amoyEGkPpddVuY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Status updates now correctly clear optional empty fields during server-side apply without sending invalid empty objects.
  - Populated status objects and required fields continue to be preserved.
- **Tests**
  - Added coverage for empty and populated objects, embedded fields, collections, JSON tags, conditions-only configurations, required environment fields, and non-object inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->