### PR TITLE
fix(ci): keep all generated output on controller-tools bump

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -422,12 +422,16 @@
           'install-tool golang 1.26.6',
           'make build-installer',
         ],
+        // build-installer also runs cel-cost-report and generate-extension-icon-styles;
+        // without these filters Renovate drops regenerated files and Check Codegen fails.
         fileFilters: [
           'config/**',
           'test/**',
           'applyconfiguration/**',
           'dist/**',
           '**/*.go',
+          'hack/celcost/report.md',
+          'ui/extension/iconStyles.generated.ts',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
## Summary

- Add `hack/celcost/report.md` and `ui/extension/iconStyles.generated.ts` to the Renovate `postUpgradeTasks.fileFilters` for `kubernetes-sigs/controller-tools` bumps
- Renovate already runs `make build-installer`, but those two outputs were filtered out before commit, causing **Check Codegen** to fail on controller-tools upgrade PRs

This was exposed by [chore(deps): update dependency kubernetes-sigs/controller-tools to v0.22.0 #1962](https://github.com/argoproj-labs/gitops-promoter/pull/1962), which failed [Check Codegen](https://github.com/argoproj-labs/gitops-promoter/actions/runs/33649510896/job/100312638278) because `hack/celcost/report.md` was stale after controller-tools v0.22.0 changed CEL `oneOf` rule generation.

## Test plan

- [ ] Merge this config fix
- [ ] Rebase or re-run Renovate on #1962 and confirm Check Codegen passes with the regenerated CEL cost report committed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency-upgrade handling to preserve generated cost reports and extension icon styling files.
  * Ensured these generated assets remain synchronized after relevant build processes run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->