### PR TITLE
chore(ci): batch GitHub Actions bumps into a weekly Dependabot PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -57,11 +57,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    # One grouped PR per week; action bumps here have been low-risk.
+    open-pull-requests-limit: 1
     groups:
-      # init/analyze/upload-sarif must share the same release; partial bumps fail
-      # CodeQL with "Loaded a configuration file for version X, but running version Y".
-      codeql-action:
+      github-actions:
         patterns:
-          - "github/codeql-action/**"
+          - "*"

--- a/RENOVATE_SETUP.md
+++ b/RENOVATE_SETUP.md
@@ -161,7 +161,7 @@ Key configuration options:
 
 Dependabot continues to handle:
 - ✅ Go module dependencies (via `gomod` package ecosystem)
-- ✅ GitHub Actions updates (via `github-actions` package ecosystem)
+- ✅ GitHub Actions updates (via `github-actions` package ecosystem), batched into one weekly grouped PR
 
 Dependabot does NOT handle:
 - ❌ Go version updates (handled by Renovate)

--- a/renovate.json5
+++ b/renovate.json5
@@ -49,7 +49,7 @@
     // Ownership split with Dependabot
     // ----------------------------------------------------------------------
     {
-      description: 'Let Dependabot own GitHub Action SHAs (avoid duplicate PRs)',
+      description: 'Let Dependabot own GitHub Action SHAs (weekly grouped PR; avoid duplicate PRs)',
       matchManagers: [
         'github-actions',
       ],


### PR DESCRIPTION
GHA bumps have all passed without trouble. Batching to minimize churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions dependency updates are now reviewed weekly on Mondays at 06:00 UTC.
  * Updates are consolidated into a single grouped pull request, with at most one open at a time.

* **Documentation**
  * Updated dependency-management documentation to reflect the weekly grouped update process and ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->