### PR TITLE
docs: improve CRD godoc and example manifests

### DIFF
--- a/api/v1alpha1/argocdcommitstatus_types.go
+++ b/api/v1alpha1/argocdcommitstatus_types.go
@@ -200,7 +200,10 @@ type ApplicationsSelected struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// ArgoCDCommitStatus is the Schema for the argocdcommitstatuses API.
+// ArgoCDCommitStatus aggregates the status of Argo CD Applications used in a promotion strategy. It selects
+// Applications via a label selector and a reference to a PromotionStrategy, then creates CommitStatus resources
+// (with key "argocd-health") so that promotion gates reflect whether the selected applications are synced and
+// healthy. Optional URL config can generate links (e.g. to the Argo CD UI) for each status.
 // +kubebuilder:printcolumn:name="PromotionStrategy",type=string,JSONPath=`.spec.promotionStrategyRef.name`,priority=1
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type ArgoCDCommitStatus struct {

--- a/api/v1alpha1/changetransferpolicy_types.go
+++ b/api/v1alpha1/changetransferpolicy_types.go
@@ -311,7 +311,10 @@ func (ps *ChangeTransferPolicy) SetStatusInstanceID(v *string) {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// ChangeTransferPolicy is the Schema for the changetransferpolicies API
+// ChangeTransferPolicy represents a pair of hydrated environment branches: the proposed branch and the active
+// branch. When a new commit appears in the proposed branch, the controller opens a PR against the active branch.
+// When all configured proposed commit status checks pass, the controller merges the PR. Active checks are
+// continuously monitored, and their states are saved to the ChangeTransferPolicy status.
 // +kubebuilder:printcolumn:name="Active Dry Sha",type=string,JSONPath=`.status.active.dry.sha`
 // +kubebuilder:printcolumn:name="Proposed Dry Sha",type=string,JSONPath=`.status.proposed.dry.sha`
 // +kubebuilder:printcolumn:name="Proposed Note Dry Sha",type=string,JSONPath=`.status.proposed.note.drySha`

--- a/api/v1alpha1/clusterscmprovider_types.go
+++ b/api/v1alpha1/clusterscmprovider_types.go
@@ -34,7 +34,9 @@ var ClusterScmProviderKind = reflect.TypeFor[ClusterScmProvider]().Name()
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// ClusterScmProvider is the Schema for the clusterscmproviders API.
+// ClusterScmProvider is the cluster-scoped alternative to ScmProvider. It represents an SCM instance (e.g. GitHub)
+// and references a Secret in the namespace where the promoter runs. Any GitRepository in the cluster can reference
+// a ClusterScmProvider by name.
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type ClusterScmProvider struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/commitstatus_types.go
+++ b/api/v1alpha1/commitstatus_types.go
@@ -129,7 +129,8 @@ func (cs *CommitStatus) SetStatusInstanceID(v *string) {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// CommitStatus is the Schema for the commitstatuses API
+// CommitStatus is a thin wrapper for the SCM's commit status API. CommitStatuses are the primary source of truth
+// for promotion gates: the controller writes their state to the SCM so checkmarks/failures appear in the SCM UI.
 // +kubebuilder:printcolumn:name="Key",type=string,JSONPath=`.metadata.labels['promoter\.argoproj\.io/commit-status']`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Sha",type=string,JSONPath=`.status.sha`

--- a/api/v1alpha1/controllerconfiguration_types.go
+++ b/api/v1alpha1/controllerconfiguration_types.go
@@ -152,6 +152,8 @@ type ArgoCDCommitStatusConfiguration struct {
 	// in the local cluster. When false, the controller will only watch Applications in remote clusters
 	// configured via kubeconfig secrets. This is useful when the Argo CD Application CRD is not installed
 	// in the local cluster or when all Applications are deployed to remote clusters.
+	//
+	// This value is evaluated at startup and requires a restart to change.
 	// +required
 	// +kubebuilder:default=true
 	WatchLocalApplications bool `json:"watchLocalApplications"`
@@ -400,7 +402,10 @@ type ControllerConfigurationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// ControllerConfiguration is the Schema for the controllerconfigurations API.
+// ControllerConfiguration configures the behavior of the promoter controllers. A global instance is typically
+// deployed with the controller and applies to all promotions. Each controller has a section (WorkQueue settings,
+// rate limiters, and controller-specific options such as PR templates or watchLocalApplications). All fields are
+// required; defaults are provided in the installation manifests.
 type ControllerConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/gitcommitstatus_types.go
+++ b/api/v1alpha1/gitcommitstatus_types.go
@@ -201,9 +201,7 @@ type GitCommitStatusEnvironmentStatus struct {
 // +kubebuilder:printcolumn:name="Validates",type=string,JSONPath=`.spec.target`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 
-// GitCommitStatus is the Schema for the gitcommitstatuses API.
-//
-// It validates commits from PromotionStrategy environments using configurable expressions
+// GitCommitStatus validates commits from PromotionStrategy environments using configurable expressions
 // and creates CommitStatus resources with the validation results.
 //
 // Use the Target field to control which commit is validated:

--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -87,7 +87,8 @@ type GitRepositoryStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// GitRepository is the Schema for the gitrepositories API
+// GitRepository represents a single git repository. It references an ScmProvider (or ClusterScmProvider)
+// to enable access via some configured auth mechanism.
 // +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.scmProviderRef.name`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type GitRepository struct {

--- a/api/v1alpha1/promotionstrategy_types.go
+++ b/api/v1alpha1/promotionstrategy_types.go
@@ -246,7 +246,9 @@ type HealthyDryShas struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// PromotionStrategy is the Schema for the promotionstrategies API
+// PromotionStrategy is the user's interface to controlling how changes are promoted through environments.
+// In this resource you configure the list of live hydrated environment branches in promotion order and the
+// checks (active and proposed commit statuses) that must pass between promotion steps.
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type PromotionStrategy struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -98,11 +98,8 @@ type CommitConfiguration struct {
 	Message string `json:"message"`
 }
 
-// PullRequestStatus defines the observed state of PullRequest
+// PullRequestStatus defines the observed state of PullRequest.
 type PullRequestStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// ObservedGeneration is the .metadata.generation that this status was reconciled from.
 	// Because status is written via Server-Side Apply with ForceOwnership (which has no
 	// optimistic-concurrency check), this field is the canonical way to detect stale
@@ -110,12 +107,12 @@ type PullRequestStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// ID the id of the pull request
+	// ID is the unique identifier of the pull request, set by the SCM.
 	ID string `json:"id,omitempty"`
-	// State of the merge request closed/merged/open
+	// State is the state of the pull request (closed, merged, open, merged-or-closed, or unknown).
 	// +kubebuilder:validation:Enum="";closed;merged;open;merged-or-closed;unknown
 	State PullRequestState `json:"state,omitempty"`
-	// PRCreationTime the time the PR was created
+	// PRCreationTime is the time when the pull request was created.
 	PRCreationTime metav1.Time `json:"prCreationTime,omitempty"`
 	// Url is the URL of the pull request.
 	// +kubebuilder:validation:XValidation:rule="self == '' || isURL(self)",message="must be a valid URL"
@@ -156,7 +153,7 @@ type PullRequestStatus struct {
 	// +kubebuilder:validation:items:Pattern=`^[^\n\r\x00]+$`
 	AppliedLabels []string `json:"appliedLabels,omitempty"`
 
-	// Conditions Represents the observations of the current state.
+	// Conditions represent the observations of the current state.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -193,7 +190,7 @@ func (ps *PullRequest) SetStatusInstanceID(v *string) {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// PullRequest is the Schema for the pullrequests API
+// PullRequest is a thin wrapper around the SCM's pull request API.
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 // +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.sourceBranch`,priority=1

--- a/api/v1alpha1/revertcommit_types.go
+++ b/api/v1alpha1/revertcommit_types.go
@@ -40,7 +40,7 @@ type RevertCommitStatus struct{}
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// RevertCommit is the Schema for the revertcommits API
+// RevertCommit requests that the controller create a revert commit on a branch.
 type RevertCommit struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/scheduledcommitstatus_types.go
+++ b/api/v1alpha1/scheduledcommitstatus_types.go
@@ -209,7 +209,8 @@ type WindowStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// ScheduledCommitStatus is the Schema for the scheduledcommitstatuses API.
+// ScheduledCommitStatus provides calendar-based gating for environment promotions using cron expressions
+// with durations. It defines recurring allow and exclusion windows that control when promotions can happen.
 // +kubebuilder:printcolumn:name="PromotionStrategy",type=string,JSONPath=`.spec.promotionStrategyRef.name`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type ScheduledCommitStatus struct {

--- a/api/v1alpha1/scmprovider_types.go
+++ b/api/v1alpha1/scmprovider_types.go
@@ -95,7 +95,8 @@ type ScmProviderStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// ScmProvider is the Schema for the scmproviders API
+// ScmProvider represents an SCM instance (e.g. GitHub, GitLab). It references a Secret in the same namespace
+// to supply credentials for API access.
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type ScmProvider struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/timedcommitstatus_types.go
+++ b/api/v1alpha1/timedcommitstatus_types.go
@@ -148,7 +148,11 @@ type TimedCommitStatusEnvironmentsStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// TimedCommitStatus is the Schema for the timedcommitstatuses API
+// TimedCommitStatus provides time-based gating for environment promotions. It monitors how long commits have been
+// running in specified environments and creates CommitStatus resources (as active commit statuses) based on
+// configured duration requirements. This enables "soak time" or "bake time" policies: changes must run successfully
+// in an environment for at least the configured duration before being promoted. Referenced in PromotionStrategy
+// via activeCommitStatuses with key "timer".
 // +kubebuilder:printcolumn:name="PromotionStrategy",type=string,JSONPath=`.spec.promotionStrategyRef.name`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type TimedCommitStatus struct {

--- a/api/v1alpha1/webrequestcommitstatus_types.go
+++ b/api/v1alpha1/webrequestcommitstatus_types.go
@@ -587,7 +587,9 @@ type WebRequestCommitStatusEnvironmentStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// WebRequestCommitStatus is the Schema for the webrequestcommitstatuses API
+// WebRequestCommitStatus gates promotions on external HTTP/HTTPS API validation. It makes HTTP requests to
+// configurable endpoints, evaluates a validation expression against the response, and creates or updates
+// CommitStatus resources.
 // +kubebuilder:printcolumn:name="Key",type=string,JSONPath=`.spec.key`
 // +kubebuilder:printcolumn:name="PromotionStrategy",type=string,JSONPath=`.spec.promotionStrategyRef.name`
 // +kubebuilder:printcolumn:name="ReportOn",type=string,JSONPath=`.spec.reportOn`

--- a/applyconfiguration/api/v1alpha1/argocdcommitstatus.go
+++ b/applyconfiguration/api/v1alpha1/argocdcommitstatus.go
@@ -29,7 +29,10 @@ import (
 // ArgoCDCommitStatusApplyConfiguration represents a declarative configuration of the ArgoCDCommitStatus type for use
 // with apply.
 //
-// ArgoCDCommitStatus is the Schema for the argocdcommitstatuses API.
+// ArgoCDCommitStatus aggregates the status of Argo CD Applications used in a promotion strategy. It selects
+// Applications via a label selector and a reference to a PromotionStrategy, then creates CommitStatus resources
+// (with key "argocd-health") so that promotion gates reflect whether the selected applications are synced and
+// healthy. Optional URL config can generate links (e.g. to the Argo CD UI) for each status.
 type ArgoCDCommitStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/argocdcommitstatusconfiguration.go
+++ b/applyconfiguration/api/v1alpha1/argocdcommitstatusconfiguration.go
@@ -32,6 +32,8 @@ type ArgoCDCommitStatusConfigurationApplyConfiguration struct {
 	// in the local cluster. When false, the controller will only watch Applications in remote clusters
 	// configured via kubeconfig secrets. This is useful when the Argo CD Application CRD is not installed
 	// in the local cluster or when all Applications are deployed to remote clusters.
+	//
+	// This value is evaluated at startup and requires a restart to change.
 	WatchLocalApplications *bool `json:"watchLocalApplications,omitempty"`
 }
 

--- a/applyconfiguration/api/v1alpha1/changetransferpolicy.go
+++ b/applyconfiguration/api/v1alpha1/changetransferpolicy.go
@@ -29,7 +29,10 @@ import (
 // ChangeTransferPolicyApplyConfiguration represents a declarative configuration of the ChangeTransferPolicy type for use
 // with apply.
 //
-// ChangeTransferPolicy is the Schema for the changetransferpolicies API
+// ChangeTransferPolicy represents a pair of hydrated environment branches: the proposed branch and the active
+// branch. When a new commit appears in the proposed branch, the controller opens a PR against the active branch.
+// When all configured proposed commit status checks pass, the controller merges the PR. Active checks are
+// continuously monitored, and their states are saved to the ChangeTransferPolicy status.
 type ChangeTransferPolicyApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/clusterscmprovider.go
+++ b/applyconfiguration/api/v1alpha1/clusterscmprovider.go
@@ -29,7 +29,9 @@ import (
 // ClusterScmProviderApplyConfiguration represents a declarative configuration of the ClusterScmProvider type for use
 // with apply.
 //
-// ClusterScmProvider is the Schema for the clusterscmproviders API.
+// ClusterScmProvider is the cluster-scoped alternative to ScmProvider. It represents an SCM instance (e.g. GitHub)
+// and references a Secret in the namespace where the promoter runs. Any GitRepository in the cluster can reference
+// a ClusterScmProvider by name.
 type ClusterScmProviderApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/commitstatus.go
+++ b/applyconfiguration/api/v1alpha1/commitstatus.go
@@ -29,7 +29,8 @@ import (
 // CommitStatusApplyConfiguration represents a declarative configuration of the CommitStatus type for use
 // with apply.
 //
-// CommitStatus is the Schema for the commitstatuses API
+// CommitStatus is a thin wrapper for the SCM's commit status API. CommitStatuses are the primary source of truth
+// for promotion gates: the controller writes their state to the SCM so checkmarks/failures appear in the SCM UI.
 type CommitStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/controllerconfiguration.go
+++ b/applyconfiguration/api/v1alpha1/controllerconfiguration.go
@@ -29,7 +29,10 @@ import (
 // ControllerConfigurationApplyConfiguration represents a declarative configuration of the ControllerConfiguration type for use
 // with apply.
 //
-// ControllerConfiguration is the Schema for the controllerconfigurations API.
+// ControllerConfiguration configures the behavior of the promoter controllers. A global instance is typically
+// deployed with the controller and applies to all promotions. Each controller has a section (WorkQueue settings,
+// rate limiters, and controller-specific options such as PR templates or watchLocalApplications). All fields are
+// required; defaults are provided in the installation manifests.
 type ControllerConfigurationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/gitcommitstatus.go
+++ b/applyconfiguration/api/v1alpha1/gitcommitstatus.go
@@ -29,9 +29,7 @@ import (
 // GitCommitStatusApplyConfiguration represents a declarative configuration of the GitCommitStatus type for use
 // with apply.
 //
-// GitCommitStatus is the Schema for the gitcommitstatuses API.
-//
-// It validates commits from PromotionStrategy environments using configurable expressions
+// GitCommitStatus validates commits from PromotionStrategy environments using configurable expressions
 // and creates CommitStatus resources with the validation results.
 //
 // Use the Target field to control which commit is validated:

--- a/applyconfiguration/api/v1alpha1/gitrepository.go
+++ b/applyconfiguration/api/v1alpha1/gitrepository.go
@@ -29,7 +29,8 @@ import (
 // GitRepositoryApplyConfiguration represents a declarative configuration of the GitRepository type for use
 // with apply.
 //
-// GitRepository is the Schema for the gitrepositories API
+// GitRepository represents a single git repository. It references an ScmProvider (or ClusterScmProvider)
+// to enable access via some configured auth mechanism.
 type GitRepositoryApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/promotionstrategy.go
+++ b/applyconfiguration/api/v1alpha1/promotionstrategy.go
@@ -29,7 +29,9 @@ import (
 // PromotionStrategyApplyConfiguration represents a declarative configuration of the PromotionStrategy type for use
 // with apply.
 //
-// PromotionStrategy is the Schema for the promotionstrategies API
+// PromotionStrategy is the user's interface to controlling how changes are promoted through environments.
+// In this resource you configure the list of live hydrated environment branches in promotion order and the
+// checks (active and proposed commit statuses) that must pass between promotion steps.
 type PromotionStrategyApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/pullrequest.go
+++ b/applyconfiguration/api/v1alpha1/pullrequest.go
@@ -29,7 +29,7 @@ import (
 // PullRequestApplyConfiguration represents a declarative configuration of the PullRequest type for use
 // with apply.
 //
-// PullRequest is the Schema for the pullrequests API
+// PullRequest is a thin wrapper around the SCM's pull request API.
 // Once recorded, the SHA can be neither replaced nor cleared: a resource merges at most once, so any
 // later disagreement is provider inconsistency or a status write built from a stale informer read, and
 // honoring it would strand the promotion history note already written against the original SHA. Such a

--- a/applyconfiguration/api/v1alpha1/pullrequeststatus.go
+++ b/applyconfiguration/api/v1alpha1/pullrequeststatus.go
@@ -26,18 +26,18 @@ import (
 // PullRequestStatusApplyConfiguration represents a declarative configuration of the PullRequestStatus type for use
 // with apply.
 //
-// PullRequestStatus defines the observed state of PullRequest
+// PullRequestStatus defines the observed state of PullRequest.
 type PullRequestStatusApplyConfiguration struct {
 	// ObservedGeneration is the .metadata.generation that this status was reconciled from.
 	// Because status is written via Server-Side Apply with ForceOwnership (which has no
 	// optimistic-concurrency check), this field is the canonical way to detect stale
 	// status writes: compare status.observedGeneration with metadata.generation.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
-	// ID the id of the pull request
+	// ID is the unique identifier of the pull request, set by the SCM.
 	ID *string `json:"id,omitempty"`
-	// State of the merge request closed/merged/open
+	// State is the state of the pull request (closed, merged, open, merged-or-closed, or unknown).
 	State *apiv1alpha1.PullRequestState `json:"state,omitempty"`
-	// PRCreationTime the time the PR was created
+	// PRCreationTime is the time when the pull request was created.
 	PRCreationTime *v1.Time `json:"prCreationTime,omitempty"`
 	// Url is the URL of the pull request.
 	Url *string `json:"url,omitempty"`
@@ -61,7 +61,7 @@ type PullRequestStatusApplyConfiguration struct {
 	SCMSyncedSpecDigest *string `json:"scmSyncedSpecDigest,omitempty"`
 	// AppliedLabels lists SCM labels successfully applied by gitops-promoter (for sync and retraction).
 	AppliedLabels []string `json:"appliedLabels,omitempty"`
-	// Conditions Represents the observations of the current state.
+	// Conditions represent the observations of the current state.
 	Conditions []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// InstanceID mirrors metadata.labels[promoter.argoproj.io/instance-id] stamped on each
 	// reconcile attempt by this install's controller, including when Ready=False; omitted

--- a/applyconfiguration/api/v1alpha1/revertcommit.go
+++ b/applyconfiguration/api/v1alpha1/revertcommit.go
@@ -29,7 +29,7 @@ import (
 // RevertCommitApplyConfiguration represents a declarative configuration of the RevertCommit type for use
 // with apply.
 //
-// RevertCommit is the Schema for the revertcommits API
+// RevertCommit requests that the controller create a revert commit on a branch.
 type RevertCommitApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/scheduledcommitstatus.go
+++ b/applyconfiguration/api/v1alpha1/scheduledcommitstatus.go
@@ -29,7 +29,8 @@ import (
 // ScheduledCommitStatusApplyConfiguration represents a declarative configuration of the ScheduledCommitStatus type for use
 // with apply.
 //
-// ScheduledCommitStatus is the Schema for the scheduledcommitstatuses API.
+// ScheduledCommitStatus provides calendar-based gating for environment promotions using cron expressions
+// with durations. It defines recurring allow and exclusion windows that control when promotions can happen.
 type ScheduledCommitStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
 	// metadata is a standard object metadata

--- a/applyconfiguration/api/v1alpha1/scmprovider.go
+++ b/applyconfiguration/api/v1alpha1/scmprovider.go
@@ -29,7 +29,8 @@ import (
 // ScmProviderApplyConfiguration represents a declarative configuration of the ScmProvider type for use
 // with apply.
 //
-// ScmProvider is the Schema for the scmproviders API
+// ScmProvider represents an SCM instance (e.g. GitHub, GitLab). It references a Secret in the same namespace
+// to supply credentials for API access.
 type ScmProviderApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:""`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/api/v1alpha1/timedcommitstatus.go
+++ b/applyconfiguration/api/v1alpha1/timedcommitstatus.go
@@ -29,7 +29,11 @@ import (
 // TimedCommitStatusApplyConfiguration represents a declarative configuration of the TimedCommitStatus type for use
 // with apply.
 //
-// TimedCommitStatus is the Schema for the timedcommitstatuses API
+// TimedCommitStatus provides time-based gating for environment promotions. It monitors how long commits have been
+// running in specified environments and creates CommitStatus resources (as active commit statuses) based on
+// configured duration requirements. This enables "soak time" or "bake time" policies: changes must run successfully
+// in an environment for at least the configured duration before being promoted. Referenced in PromotionStrategy
+// via activeCommitStatuses with key "timer".
 type TimedCommitStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
 	// metadata is a standard object metadata

--- a/applyconfiguration/api/v1alpha1/webrequestcommitstatus.go
+++ b/applyconfiguration/api/v1alpha1/webrequestcommitstatus.go
@@ -29,7 +29,9 @@ import (
 // WebRequestCommitStatusApplyConfiguration represents a declarative configuration of the WebRequestCommitStatus type for use
 // with apply.
 //
-// WebRequestCommitStatus is the Schema for the webrequestcommitstatuses API
+// WebRequestCommitStatus gates promotions on external HTTP/HTTPS API validation. It makes HTTP requests to
+// configurable endpoints, evaluates a validation expression against the response, and creates or updates
+// CommitStatus resources.
 type WebRequestCommitStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
 	// metadata is a standard object metadata

--- a/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_argocdcommitstatuses.yaml
@@ -25,8 +25,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ArgoCDCommitStatus is the Schema for the argocdcommitstatuses
-          API.
+        description: |-
+          ArgoCDCommitStatus aggregates the status of Argo CD Applications used in a promotion strategy. It selects
+          Applications via a label selector and a reference to a PromotionStrategy, then creates CommitStatus resources
+          (with key "argocd-health") so that promotion gates reflect whether the selected applications are synced and
+          healthy. Optional URL config can generate links (e.g. to the Argo CD UI) for each status.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#argocdcommitstatus

--- a/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_changetransferpolicies.yaml
@@ -33,8 +33,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ChangeTransferPolicy is the Schema for the changetransferpolicies
-          API
+        description: |-
+          ChangeTransferPolicy represents a pair of hydrated environment branches: the proposed branch and the active
+          branch. When a new commit appears in the proposed branch, the controller opens a PR against the active branch.
+          When all configured proposed commit status checks pass, the controller merges the PR. Active checks are
+          continuously monitored, and their states are saved to the ChangeTransferPolicy status.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#changetransferpolicy

--- a/config/crd/bases/promoter.argoproj.io_clusterscmproviders.yaml
+++ b/config/crd/bases/promoter.argoproj.io_clusterscmproviders.yaml
@@ -21,8 +21,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterScmProvider is the Schema for the clusterscmproviders
-          API.
+        description: |-
+          ClusterScmProvider is the cluster-scoped alternative to ScmProvider. It represents an SCM instance (e.g. GitHub)
+          and references a Secret in the namespace where the promoter runs. Any GitRepository in the cluster can reference
+          a ClusterScmProvider by name.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#clusterscmprovider

--- a/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_commitstatuses.yaml
@@ -35,7 +35,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: CommitStatus is the Schema for the commitstatuses API
+        description: |-
+          CommitStatus is a thin wrapper for the SCM's commit status API. CommitStatuses are the primary source of truth
+          for promotion gates: the controller writes their state to the SCM so checkmarks/failures appear in the SCM UI.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#commitstatus

--- a/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
+++ b/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
@@ -17,8 +17,11 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ControllerConfiguration is the Schema for the controllerconfigurations
-          API.
+        description: |-
+          ControllerConfiguration configures the behavior of the promoter controllers. A global instance is typically
+          deployed with the controller and applies to all promotions. Each controller has a section (WorkQueue settings,
+          rate limiters, and controller-specific options such as PR templates or watchLocalApplications). All fields are
+          required; defaults are provided in the installation manifests.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#controllerconfiguration
@@ -61,6 +64,8 @@ spec:
                       in the local cluster. When false, the controller will only watch Applications in remote clusters
                       configured via kubeconfig secrets. This is useful when the Argo CD Application CRD is not installed
                       in the local cluster or when all Applications are deployed to remote clusters.
+
+                      This value is evaluated at startup and requires a restart to change.
                     type: boolean
                   workQueue:
                     description: |-

--- a/config/crd/bases/promoter.argoproj.io_gitcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_gitcommitstatuses.yaml
@@ -31,9 +31,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          GitCommitStatus is the Schema for the gitcommitstatuses API.
-
-          It validates commits from PromotionStrategy environments using configurable expressions
+          GitCommitStatus validates commits from PromotionStrategy environments using configurable expressions
           and creates CommitStatus resources with the validation results.
 
           Use the Target field to control which commit is validated:

--- a/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
+++ b/config/crd/bases/promoter.argoproj.io_gitrepositories.yaml
@@ -24,7 +24,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GitRepository is the Schema for the gitrepositories API
+        description: |-
+          GitRepository represents a single git repository. It references an ScmProvider (or ClusterScmProvider)
+          to enable access via some configured auth mechanism.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#gitrepository

--- a/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
+++ b/config/crd/bases/promoter.argoproj.io_promotionstrategies.yaml
@@ -21,7 +21,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PromotionStrategy is the Schema for the promotionstrategies API
+        description: |-
+          PromotionStrategy is the user's interface to controlling how changes are promoted through environments.
+          In this resource you configure the list of live hydrated environment branches in promotion order and the
+          checks (active and proposed commit statuses) that must pass between promotion steps.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#promotionstrategy

--- a/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
+++ b/config/crd/bases/promoter.argoproj.io_pullrequests.yaml
@@ -40,7 +40,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          PullRequest is the Schema for the pullrequests API
+          PullRequest is a thin wrapper around the SCM's pull request API.
           Once recorded, the SHA can be neither replaced nor cleared: a resource merges at most once, so any
           later disagreement is provider inconsistency or a status write built from a stale informer read, and
           honoring it would strand the promotion history note already written against the original SHA. Such a
@@ -173,7 +173,7 @@ spec:
             - title
             type: object
           status:
-            description: PullRequestStatus defines the observed state of PullRequest
+            description: PullRequestStatus defines the observed state of PullRequest.
             properties:
               appliedLabels:
                 description: AppliedLabels lists SCM labels successfully applied by
@@ -187,7 +187,7 @@ spec:
                 type: array
                 x-kubernetes-list-type: set
               conditions:
-                description: Conditions Represents the observations of the current
+                description: Conditions represent the observations of the current
                   state.
                 items:
                   description: Condition contains details for one aspect of the current
@@ -256,7 +256,8 @@ spec:
                   when copied to ChangeTransferPolicy status. This field may be removed in a future API revision.
                 type: boolean
               id:
-                description: ID the id of the pull request
+                description: ID is the unique identifier of the pull request, set
+                  by the SCM.
                 type: string
               instanceID:
                 description: |-
@@ -290,7 +291,8 @@ spec:
                 format: int64
                 type: integer
               prCreationTime:
-                description: PRCreationTime the time the PR was created
+                description: PRCreationTime is the time when the pull request was
+                  created.
                 format: date-time
                 type: string
               scmSyncedSpecDigest:
@@ -299,7 +301,8 @@ spec:
                   to the SCM via provider.Update on an open pull request.
                 type: string
               state:
-                description: State of the merge request closed/merged/open
+                description: State is the state of the pull request (closed, merged,
+                  open, merged-or-closed, or unknown).
                 enum:
                 - ""
                 - closed

--- a/config/crd/bases/promoter.argoproj.io_revertcommits.yaml
+++ b/config/crd/bases/promoter.argoproj.io_revertcommits.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: RevertCommit is the Schema for the revertcommits API
+        description: RevertCommit requests that the controller create a revert commit
+          on a branch.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/promoter.argoproj.io_scheduledcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_scheduledcommitstatuses.yaml
@@ -24,8 +24,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ScheduledCommitStatus is the Schema for the scheduledcommitstatuses
-          API.
+        description: |-
+          ScheduledCommitStatus provides calendar-based gating for environment promotions using cron expressions
+          with durations. It defines recurring allow and exclusion windows that control when promotions can happen.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#scheduledcommitstatus

--- a/config/crd/bases/promoter.argoproj.io_scmproviders.yaml
+++ b/config/crd/bases/promoter.argoproj.io_scmproviders.yaml
@@ -21,7 +21,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ScmProvider is the Schema for the scmproviders API
+        description: |-
+          ScmProvider represents an SCM instance (e.g. GitHub, GitLab). It references a Secret in the same namespace
+          to supply credentials for API access.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#scmprovider

--- a/config/crd/bases/promoter.argoproj.io_timedcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_timedcommitstatuses.yaml
@@ -24,7 +24,12 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TimedCommitStatus is the Schema for the timedcommitstatuses API
+        description: |-
+          TimedCommitStatus provides time-based gating for environment promotions. It monitors how long commits have been
+          running in specified environments and creates CommitStatus resources (as active commit statuses) based on
+          configured duration requirements. This enables "soak time" or "bake time" policies: changes must run successfully
+          in an environment for at least the configured duration before being promoted. Referenced in PromotionStrategy
+          via activeCommitStatuses with key "timer".
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#timedcommitstatus

--- a/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
+++ b/config/crd/bases/promoter.argoproj.io_webrequestcommitstatuses.yaml
@@ -30,8 +30,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WebRequestCommitStatus is the Schema for the webrequestcommitstatuses
-          API
+        description: |-
+          WebRequestCommitStatus gates promotions on external HTTP/HTTPS API validation. It makes HTTP requests to
+          configurable endpoints, evaluates a validation expression against the response, and creates or updates
+          CommitStatus resources.
         externalDocs:
           description: CRD reference (examples and behavior)
           url: https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#webrequestcommitstatus

--- a/docs/contributing/maintaining-crds.md
+++ b/docs/contributing/maintaining-crds.md
@@ -13,6 +13,8 @@ Add or update `internal/controller/testdata/<Kind>.yaml` (PascalCase filename ma
 - Use valid values that pass kubebuilder validation markers on the Go types.
 - Keep names, namespaces, and references consistent with how controllers and envtest suites create related objects.
 
+**ExactlyOneOf provider fields:** Several specs use `+kubebuilder:validation:ExactlyOneOf` (for example `GitRepositorySpec` and `ScmProviderSpec`), where exactly one provider block must be set at apply time. Keep all provider options present in the example YAML so readers can see available fields, and add a comment that only one should be set when applying. Examples only need to pass strict JSON/YAML unmarshaling into the Go type; they are not required to satisfy CEL ExactlyOneOf rules at decode time.
+
 ### 2. Embed the example on the CRD Specs page
 
 Add or update a `### <Kind>` section in [`docs/crd-specs.md`](../crd-specs.md) with a short narrative, then include the example:

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	_ "embed"
 	"os"
 	"strings"
 	"time"
@@ -36,6 +37,18 @@ import (
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 )
+
+//go:embed testdata/GitCommitStatus.yaml
+var testGitCommitStatusYAML string
+
+var _ = Describe("GitCommitStatus Controller testdata", func() {
+	Context("When unmarshalling the test data", func() {
+		It("should unmarshal the GitCommitStatus resource", func() {
+			err := unmarshalYamlStrict(testGitCommitStatusYAML, &promoterv1alpha1.GitCommitStatus{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
 
 // This Ordered suite shares one PromotionStrategy. Each spec must use a distinct
 // spec.key (and matching proposed key on that strategy) so ChangeTransferPolicy

--- a/internal/controller/testdata/GitRepository.yaml
+++ b/internal/controller/testdata/GitRepository.yaml
@@ -1,33 +1,37 @@
+# GitRepository represents a single git repository. It references an ScmProvider to enable access via some configured
+# auth mechanism.
+#
+# Only one of the git providers should be specified at apply time; all are shown here so you can see available fields
+# per provider.
 apiVersion: promoter.argoproj.io/v1alpha1
 kind: GitRepository
 metadata:
   name: example-git-repository
 spec:
-  # Only one of the git providers should be specified.
   github:
-    name:
-    owner:
+    owner: my-org
+    name: my-repo
 
   gitlab:
-    name:
-    namespace:
-    projectId:
+    namespace: my-group
+    name: my-project
+    projectId: 12345 # ID of the project in GitLab
 
   forgejo:
-    name:
-    owner:
+    owner: my-org
+    name: my-repo
 
   gitea:
-    name:
-    owner:
+    owner: my-org
+    name: my-repo
 
   bitbucketCloud:
-    owner:
-    name:
+    owner: my-workspace
+    name: my-repo
 
   azureDevOps:
-    name:
-    project:
+    project: my-project
+    name: my-repo
 
   # fake:
   #   name: example

--- a/internal/controller/testdata/PullRequest.yaml
+++ b/internal/controller/testdata/PullRequest.yaml
@@ -1,3 +1,5 @@
+# PullRequest is a thin wrapper around the SCM's pull request API. ChangeTransferPolicies use PullRequests to manage
+# promotions.
 apiVersion: promoter.argoproj.io/v1alpha1
 kind: PullRequest
 metadata:
@@ -5,21 +7,22 @@ metadata:
 spec:
   gitRepositoryRef:
     name: example-git-repository
-  targetBranch:
-  sourceBranch:
-  title:
-  description:
+  title: "Promote abc1234 to environment/dev"
+  targetBranch: environment/dev # Base: the branch we are merging into (Head ---> Base)
+  sourceBranch: environment/dev-next # Head: the branch we are merging from
+  description: |
+    This PR promotes the environment branch environment/dev.
   commit:
     # The commit message that will be written for the commit that's made when merging the PR
     message: "example message"
   # The commit SHA that must be at the head of the source branch for the merge to succeed.
   # This prevents race conditions where a different commit gets merged than intended.
-  mergeSha: abc123def456789012345678901234567890abcd
+  mergeSha: abcdef1234567890abcdef1234567890abcdef12
 
   # Must be closed, merged, or open. Default is open.
   # Must be set to "open" when initially created, and cannot be set to "closed" or "merged" unless status.id is set
   # (which the controller should do automatically as long as there are no errors).
-  state:
+  state: open
   # SCM pull request labels (not Kubernetes metadata.labels). Written by the ChangeTransferPolicy controller.
   labels:
     - lgtm
@@ -41,7 +44,7 @@ status:
   state: open # open, closed, merged, merged-or-closed, or unknown
   url: https://github.com/org/repo/pull/848
   prCreationTime: 2023-10-01T00:00:00Z
-  # mergedTargetSha: abc123def456789012345678901234567890abcd # SCM-reported target branch SHA after merge
+  # mergedTargetSha: abcdef1234567890abcdef1234567890abcdef12 # SCM-reported target branch SHA after merge
   # SCM labels successfully applied by gitops-promoter (bookkeeping for sync/retraction).
   # appliedLabels:
   #   - lgtm

--- a/internal/controller/timedcommitstatus_controller_test.go
+++ b/internal/controller/timedcommitstatus_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	_ "embed"
 	"os"
 	"time"
 
@@ -34,6 +35,18 @@ import (
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 )
+
+//go:embed testdata/TimedCommitStatus.yaml
+var testTimedCommitStatusYAML string
+
+var _ = Describe("TimedCommitStatus Controller testdata", func() {
+	Context("When unmarshalling the test data", func() {
+		It("should unmarshal the TimedCommitStatus resource", func() {
+			err := unmarshalYamlStrict(testTimedCommitStatusYAML, &promoterv1alpha1.TimedCommitStatus{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
 
 var _ = Describe("TimedCommitStatus Controller", Ordered, func() {
 	var (


### PR DESCRIPTION
Replace generic API type descriptions with user-facing documentation that flows into CRD OpenAPI schemas, flesh out GitRepository and PullRequest testdata examples, add strict unmarshal tests for GitCommitStatus and TimedCommitStatus, and document ExactlyOneOf example patterns in the CRD maintenance guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded resource and field descriptions across promotion, SCM, commit-status, pull-request, and controller-configuration APIs.
  * Clarified startup behavior for local application watching.
  * Added guidance for maintaining example CRD manifests.

* **Tests**
  * Added validation that GitCommitStatus and TimedCommitStatus example manifests strictly unmarshal.
  * Improved GitRepository and PullRequest example manifests with representative values and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->