### PR TITLE
refactor: extract EnqueueCommitStatusGatesForPromotionStrategy helper

### DIFF
--- a/docs/contributing/developing-a-commitstatus.md
+++ b/docs/contributing/developing-a-commitstatus.md
@@ -297,7 +297,25 @@ Only listed environments are gated; unlisted environments default to success (24
 
 Gate CRDs reference a `PromotionStrategy` via `spec.promotionStrategyRef`. When that strategy changes (for example environments or commit-status keys are updated), every gate that references it should reconcile so it can refresh owned `CommitStatus` resources.
 
-Built-in controllers watch `PromotionStrategy` and enqueue reconcile requests for matching gates. List with `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` (do not namespace-list and filter in memory). **In this repository**, registering the type on the promoter scheme is enough for that field index. **Outside this repo**, register the index in `SetupWithManager` before the watch:
+Built-in controllers watch `PromotionStrategy` and enqueue reconcile requests for matching gates in the same namespace. The list uses `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` — do not namespace-list and filter in memory.
+
+**In this repository**, registering the type on the promoter scheme is enough for that field index (`GateCommitStatusKinds()` discovers gates with `spec.promotionStrategyRef`). Wire the watch with the shared helper in [`internal/controller/enqueue.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/enqueue.go):
+
+```go
+ctrl.NewControllerManagedBy(mgr).
+    For(&promoterv1alpha1.MyCommitStatus{}).
+    Watches(
+        &promoterv1alpha1.PromotionStrategy{},
+        CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.MyCommitStatusList](r.Client),
+    ).
+    Complete(r)
+```
+
+`CommitStatusGatePromotionStrategyWatchHandler` lists gates of the given kind that reference the changed `PromotionStrategy` and returns reconcile requests for each match. Most in-tree gate controllers only need this one-liner in `SetupWithManager`.
+
+Use `EnqueueCommitStatusGatesForPromotionStrategy` directly when you need the request slice without the watch wrapper (for example ArgoCDCommitStatus wraps it for multi-cluster reconcile requests).
+
+**Outside this repo**, you cannot import `internal/controller`. Register the field index in `SetupWithManager` before the watch, then duplicate the list-and-enqueue logic from `enqueue.go` (or call your own helper with the same `MatchingFields` query):
 
 ```go
 const promotionStrategyRefField = ".spec.promotionStrategyRef.name"
@@ -311,15 +329,13 @@ func (r *MyCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ctr
     ); err != nil {
         return fmt.Errorf("failed to set field index %s: %w", promotionStrategyRefField, err)
     }
-    // …
+
+    return ctrl.NewControllerManagedBy(mgr).
+        For(&promoterv1alpha1.MyCommitStatus{}).
+        Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueMyCommitStatusForPromotionStrategy()).
+        Complete(r)
 }
-```
 
-### Watch handler
-
-Watch `PromotionStrategy` and list gates with `MatchingFields` instead of scanning the namespace:
-
-```go
 func (r *MyCommitStatusReconciler) enqueueMyCommitStatusForPromotionStrategy() handler.EventHandler {
     return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
         ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
@@ -332,7 +348,7 @@ func (r *MyCommitStatusReconciler) enqueueMyCommitStatusForPromotionStrategy() h
             client.InNamespace(ps.Namespace),
             client.MatchingFields{promotionStrategyRefField: ps.Name},
         ); err != nil {
-            log.FromContext(ctx).Error(err, "failed to list MyCommitStatus resources")
+            log.FromContext(ctx).Error(err, fmt.Sprintf("failed to list %T resources for PromotionStrategy watch", &list))
             return nil
         }
 
@@ -346,17 +362,6 @@ func (r *MyCommitStatusReconciler) enqueueMyCommitStatusForPromotionStrategy() h
     })
 }
 ```
-
-Wire the watch in `SetupWithManager`:
-
-```go
-ctrl.NewControllerManagedBy(mgr).
-    For(&promoterv1alpha1.MyCommitStatus{}).
-    Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueMyCommitStatusForPromotionStrategy()).
-    Complete(r)
-```
-
-Built-in gate controllers follow this pattern; see [`timedcommitstatus_controller.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/timedcommitstatus_controller.go) for a reference implementation.
 
 ## Dashboard view bundle
 

--- a/docs/contributing/maintaining-crds.md
+++ b/docs/contributing/maintaining-crds.md
@@ -76,7 +76,7 @@ When the new kind is a **commit-status gate** CRD with `spec.promotionStrategyRe
    - [`internal/controller/suite_test.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/suite_test.go) — main envtest suite
    - [`internal/controller/test_manager_test.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/internal/controller/test_manager_test.go) (`startPartitionedManager`) — instance-id migration / partitioned-manager tests  
    Omitting the last site is a common miss: migration tests will time out waiting for child `CommitStatus` objects that never get created.
-3. In the gate controller, watch `PromotionStrategy` and list your kind with `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` (do not namespace-list and filter in memory). See [Watching PromotionStrategy](developing-a-commitstatus.md#watching-promotionstrategy).
+3. In `SetupWithManager`, watch `PromotionStrategy` with `controller.CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.MyCommitStatusList](r.Client)`. See [Watching PromotionStrategy](developing-a-commitstatus.md#watching-promotionstrategy).
 
 Skip this step for types that do not reference a `PromotionStrategy` or never use field selectors on the cache client.
 

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -452,22 +452,14 @@ func enqueueArgoCDCommitStatusForPromotionStrategy(mcMgr mcmanager.Manager) mcha
 		if !ok {
 			return nil
 		}
-		logger := log.FromContext(ctx)
-		var list promoterv1alpha1.ArgoCDCommitStatusList
-		if err := mcMgr.GetLocalManager().GetClient().List(ctx, &list,
-			client.InNamespace(ps.Namespace),
-			client.MatchingFields{PromotionStrategyRefField: ps.Name},
-		); err != nil {
-			logger.Error(err, "failed to list ArgoCDCommitStatus resources for PromotionStrategy watch")
-			return nil
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.ArgoCDCommitStatusList](
+			ctx, mcMgr.GetLocalManager().GetClient(), ps,
+		)
+		mcReqs := make([]mcreconcile.Request, len(reqs))
+		for i, req := range reqs {
+			mcReqs[i] = mcreconcile.Request{Request: req}
 		}
-		reqs := make([]mcreconcile.Request, 0, len(list.Items))
-		for i := range list.Items {
-			reqs = append(reqs, mcreconcile.Request{
-				Request: reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])},
-			})
-		}
-		return reqs
+		return mcReqs
 	})
 }
 

--- a/internal/controller/argocdcommitstatus_controller.go
+++ b/internal/controller/argocdcommitstatus_controller.go
@@ -452,7 +452,7 @@ func enqueueArgoCDCommitStatusForPromotionStrategy(mcMgr mcmanager.Manager) mcha
 		if !ok {
 			return nil
 		}
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.ArgoCDCommitStatusList](
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.ArgoCDCommitStatusList](
 			ctx, mcMgr.GetLocalManager().GetClient(), ps,
 		)
 		mcReqs := make([]mcreconcile.Request, len(reqs))

--- a/internal/controller/enqueue.go
+++ b/internal/controller/enqueue.go
@@ -18,9 +18,12 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -29,26 +32,24 @@ import (
 
 // EnqueueCommitStatusGatesForPromotionStrategy lists gate resources in the
 // PromotionStrategy namespace that reference ps via spec.promotionStrategyRef.name
-// and returns reconcile requests for each match. resourceKind is used in error
-// logs (for example "GitCommitStatus").
+// and returns reconcile requests for each match.
 func EnqueueCommitStatusGatesForPromotionStrategy[L client.ObjectList](
 	ctx context.Context,
 	c client.Client,
 	ps *promoterv1alpha1.PromotionStrategy,
-	list L,
-	resourceKind string,
 ) []reconcile.Request {
+	list := newObjectList[L]()
 	if err := c.List(ctx, list,
 		client.InNamespace(ps.Namespace),
 		client.MatchingFields{PromotionStrategyRefField: ps.Name},
 	); err != nil {
-		log.FromContext(ctx).Error(err, "failed to list "+resourceKind+" resources for PromotionStrategy watch")
+		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to list %T resources for PromotionStrategy watch", list))
 		return nil
 	}
 
 	rawItems, err := meta.ExtractList(list)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to extract list items for PromotionStrategy watch", "resourceKind", resourceKind)
+		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to extract list items from %T for PromotionStrategy watch", list))
 		return nil
 	}
 
@@ -64,4 +65,25 @@ func EnqueueCommitStatusGatesForPromotionStrategy[L client.ObjectList](
 	}
 
 	return requests
+}
+
+// CommitStatusGatePromotionStrategyWatchHandler returns a watch handler that enqueues
+// every gate of type L in the PromotionStrategy namespace that references that strategy.
+func CommitStatusGatePromotionStrategyWatchHandler[L client.ObjectList](c client.Client) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
+		if !ok {
+			return nil
+		}
+		return EnqueueCommitStatusGatesForPromotionStrategy[L](ctx, c, ps)
+	})
+}
+
+func newObjectList[L client.ObjectList]() L {
+	var list L
+	v := reflect.ValueOf(&list).Elem()
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		v.Set(reflect.New(v.Type().Elem()))
+	}
+	return list
 }

--- a/internal/controller/enqueue.go
+++ b/internal/controller/enqueue.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,12 +32,18 @@ import (
 // EnqueueCommitStatusGatesForPromotionStrategy lists gate resources in the
 // PromotionStrategy namespace that reference ps via spec.promotionStrategyRef.name
 // and returns reconcile requests for each match.
-func EnqueueCommitStatusGatesForPromotionStrategy[L client.ObjectList](
+func EnqueueCommitStatusGatesForPromotionStrategy[
+	GateList any,
+	GateListPtr interface {
+		*GateList
+		client.ObjectList
+	},
+](
 	ctx context.Context,
 	c client.Client,
 	ps *promoterv1alpha1.PromotionStrategy,
 ) []reconcile.Request {
-	list := newObjectList[L]()
+	list := GateListPtr(new(GateList))
 	if err := c.List(ctx, list,
 		client.InNamespace(ps.Namespace),
 		client.MatchingFields{PromotionStrategyRefField: ps.Name},
@@ -68,22 +73,19 @@ func EnqueueCommitStatusGatesForPromotionStrategy[L client.ObjectList](
 }
 
 // CommitStatusGatePromotionStrategyWatchHandler returns a watch handler that enqueues
-// every gate of type L in the PromotionStrategy namespace that references that strategy.
-func CommitStatusGatePromotionStrategyWatchHandler[L client.ObjectList](c client.Client) handler.EventHandler {
+// every gate of type GateList in the PromotionStrategy namespace that references that strategy.
+func CommitStatusGatePromotionStrategyWatchHandler[
+	GateList any,
+	GateListPtr interface {
+		*GateList
+		client.ObjectList
+	},
+](c client.Client) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
 		if !ok {
 			return nil
 		}
-		return EnqueueCommitStatusGatesForPromotionStrategy[L](ctx, c, ps)
+		return EnqueueCommitStatusGatesForPromotionStrategy[GateList, GateListPtr](ctx, c, ps)
 	})
-}
-
-func newObjectList[L client.ObjectList]() L {
-	var list L
-	v := reflect.ValueOf(&list).Elem()
-	if v.Kind() == reflect.Pointer && v.IsNil() {
-		v.Set(reflect.New(v.Type().Elem()))
-	}
-	return list
 }

--- a/internal/controller/enqueue.go
+++ b/internal/controller/enqueue.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+)
+
+// EnqueueCommitStatusGatesForPromotionStrategy lists gate resources in the
+// PromotionStrategy namespace that reference ps via spec.promotionStrategyRef.name
+// and returns reconcile requests for each match. resourceKind is used in error
+// logs (for example "GitCommitStatus").
+func EnqueueCommitStatusGatesForPromotionStrategy[L client.ObjectList](
+	ctx context.Context,
+	c client.Client,
+	ps *promoterv1alpha1.PromotionStrategy,
+	list L,
+	resourceKind string,
+) []reconcile.Request {
+	if err := c.List(ctx, list,
+		client.InNamespace(ps.Namespace),
+		client.MatchingFields{PromotionStrategyRefField: ps.Name},
+	); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list "+resourceKind+" resources for PromotionStrategy watch")
+		return nil
+	}
+
+	rawItems, err := meta.ExtractList(list)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to extract list items for PromotionStrategy watch", "resourceKind", resourceKind)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(rawItems))
+	for _, raw := range rawItems {
+		obj, ok := raw.(client.Object)
+		if !ok {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(obj),
+		})
+	}
+
+	return requests
+}

--- a/internal/controller/enqueue_test.go
+++ b/internal/controller/enqueue_test.go
@@ -18,12 +18,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
@@ -137,5 +139,18 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 		c := newClient(gateA, gateB)
 		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(requestNames(reqs)).To(ConsistOf(ns+"/gate-a", ns+"/gate-b"))
+	})
+
+	It("returns nil when listing gates fails", func() {
+		c := fake.NewClientBuilder().
+			WithScheme(utils.GetScheme()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return errors.New("simulated list failure")
+				},
+			}).
+			Build()
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+		Expect(reqs).To(BeNil())
 	})
 })

--- a/internal/controller/enqueue_test.go
+++ b/internal/controller/enqueue_test.go
@@ -78,7 +78,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 				Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
 			func(c client.Client) []reconcile.Request {
-				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+				return EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 			},
 		),
 		Entry("TimedCommitStatus",
@@ -87,7 +87,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 				Spec:       promoterv1alpha1.TimedCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
 			func(c client.Client) []reconcile.Request {
-				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.TimedCommitStatusList](ctx, c, ps)
+				return EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.TimedCommitStatusList](ctx, c, ps)
 			},
 		),
 		Entry("WebRequestCommitStatus",
@@ -96,7 +96,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 				Spec:       promoterv1alpha1.WebRequestCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
 			func(c client.Client) []reconcile.Request {
-				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.WebRequestCommitStatusList](ctx, c, ps)
+				return EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.WebRequestCommitStatusList](ctx, c, ps)
 			},
 		),
 	)
@@ -107,7 +107,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: otherPS}},
 		}
 		c := newClient(gate)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(reqs).To(BeEmpty())
 	})
 
@@ -121,7 +121,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 		}
 		c := newClient(localGate, otherGate)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(requestNames(reqs)).To(Equal([]string{ns + "/local"}))
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 		}
 		c := newClient(gateA, gateB)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(requestNames(reqs)).To(ConsistOf(ns+"/gate-a", ns+"/gate-b"))
 	})
 })

--- a/internal/controller/enqueue_test.go
+++ b/internal/controller/enqueue_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
+)
+
+var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
+	const (
+		ns       = "test-ns"
+		psName   = "my-ps"
+		otherPS  = "other-ps"
+		otherNS  = "other-ns"
+		gateName = "my-gate"
+	)
+
+	var (
+		ctx context.Context
+		ps  *promoterv1alpha1.PromotionStrategy
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ps = &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: psName, Namespace: ns},
+		}
+	})
+
+	newClient := func(objs ...client.Object) client.Client {
+		b := fake.NewClientBuilder().WithScheme(utils.GetScheme())
+		for _, obj := range GateCommitStatusKinds() {
+			b = b.WithIndex(obj, PromotionStrategyRefField, PromotionStrategyRefIndexValues)
+		}
+		return b.WithObjects(objs...).Build()
+	}
+
+	requestNames := func(reqs []reconcile.Request) []string {
+		names := make([]string, len(reqs))
+		for i, req := range reqs {
+			names[i] = req.String()
+		}
+		return names
+	}
+
+	DescribeTable("returns reconcile requests for matching gates",
+		func(gate client.Object, list client.ObjectList) {
+			c := newClient(gate)
+			reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, list, "TestGate")
+			Expect(requestNames(reqs)).To(ConsistOf(ns + "/" + gateName))
+		},
+		Entry("GitCommitStatus",
+			&promoterv1alpha1.GitCommitStatus{
+				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
+				Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+			},
+			&promoterv1alpha1.GitCommitStatusList{},
+		),
+		Entry("TimedCommitStatus",
+			&promoterv1alpha1.TimedCommitStatus{
+				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
+				Spec:       promoterv1alpha1.TimedCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+			},
+			&promoterv1alpha1.TimedCommitStatusList{},
+		),
+		Entry("WebRequestCommitStatus",
+			&promoterv1alpha1.WebRequestCommitStatus{
+				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
+				Spec:       promoterv1alpha1.WebRequestCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+			},
+			&promoterv1alpha1.WebRequestCommitStatusList{},
+		),
+	)
+
+	It("returns nil when no gates match the PromotionStrategy ref", func() {
+		gate := &promoterv1alpha1.GitCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
+			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: otherPS}},
+		}
+		c := newClient(gate)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		Expect(reqs).To(BeEmpty())
+	})
+
+	It("scopes results to the PromotionStrategy namespace", func() {
+		localGate := &promoterv1alpha1.GitCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: "local", Namespace: ns},
+			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+		}
+		otherGate := &promoterv1alpha1.GitCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: "remote", Namespace: otherNS},
+			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+		}
+		c := newClient(localGate, otherGate)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		Expect(requestNames(reqs)).To(Equal([]string{ns + "/local"}))
+	})
+
+	It("returns reconcile requests for multiple matching gates", func() {
+		gateA := &promoterv1alpha1.GitCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: "gate-a", Namespace: ns},
+			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+		}
+		gateB := &promoterv1alpha1.GitCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{Name: "gate-b", Namespace: ns},
+			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
+		}
+		c := newClient(gateA, gateB)
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		Expect(requestNames(reqs)).To(ConsistOf(ns+"/gate-a", ns+"/gate-b"))
+	})
+})

--- a/internal/controller/enqueue_test.go
+++ b/internal/controller/enqueue_test.go
@@ -68,31 +68,36 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 	}
 
 	DescribeTable("returns reconcile requests for matching gates",
-		func(gate client.Object, list client.ObjectList) {
+		func(gate client.Object, enqueue func(client.Client) []reconcile.Request) {
 			c := newClient(gate)
-			reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, list, "TestGate")
-			Expect(requestNames(reqs)).To(ConsistOf(ns + "/" + gateName))
+			Expect(requestNames(enqueue(c))).To(ConsistOf(ns + "/" + gateName))
 		},
 		Entry("GitCommitStatus",
 			&promoterv1alpha1.GitCommitStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
 				Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
-			&promoterv1alpha1.GitCommitStatusList{},
+			func(c client.Client) []reconcile.Request {
+				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
+			},
 		),
 		Entry("TimedCommitStatus",
 			&promoterv1alpha1.TimedCommitStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
 				Spec:       promoterv1alpha1.TimedCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
-			&promoterv1alpha1.TimedCommitStatusList{},
+			func(c client.Client) []reconcile.Request {
+				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.TimedCommitStatusList](ctx, c, ps)
+			},
 		),
 		Entry("WebRequestCommitStatus",
 			&promoterv1alpha1.WebRequestCommitStatus{
 				ObjectMeta: metav1.ObjectMeta{Name: gateName, Namespace: ns},
 				Spec:       promoterv1alpha1.WebRequestCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 			},
-			&promoterv1alpha1.WebRequestCommitStatusList{},
+			func(c client.Client) []reconcile.Request {
+				return EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.WebRequestCommitStatusList](ctx, c, ps)
+			},
 		),
 	)
 
@@ -102,7 +107,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: otherPS}},
 		}
 		c := newClient(gate)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(reqs).To(BeEmpty())
 	})
 
@@ -116,7 +121,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 		}
 		c := newClient(localGate, otherGate)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(requestNames(reqs)).To(Equal([]string{ns + "/local"}))
 	})
 
@@ -130,7 +135,7 @@ var _ = Describe("EnqueueCommitStatusGatesForPromotionStrategy", func() {
 			Spec:       promoterv1alpha1.GitCommitStatusSpec{PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: psName}},
 		}
 		c := newClient(gateA, gateB)
-		reqs := EnqueueCommitStatusGatesForPromotionStrategy(ctx, c, ps, &promoterv1alpha1.GitCommitStatusList{}, "GitCommitStatus")
+		reqs := EnqueueCommitStatusGatesForPromotionStrategy[*promoterv1alpha1.GitCommitStatusList](ctx, c, ps)
 		Expect(requestNames(reqs)).To(ConsistOf(ns+"/gate-a", ns+"/gate-b"))
 	})
 })

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -420,21 +420,6 @@ func (r *GitCommitStatusReconciler) enqueueGitCommitStatusForPromotionStrategy()
 		}
 
 		var gcsList promoterv1alpha1.GitCommitStatusList
-		if err := r.List(ctx, &gcsList,
-			client.InNamespace(ps.Namespace),
-			client.MatchingFields{PromotionStrategyRefField: ps.Name},
-		); err != nil {
-			log.FromContext(ctx).Error(err, "failed to list GitCommitStatus resources")
-			return nil
-		}
-
-		requests := make([]ctrl.Request, 0, len(gcsList.Items))
-		for i := range gcsList.Items {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKeyFromObject(&gcsList.Items[i]),
-			})
-		}
-
-		return requests
+		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &gcsList, "GitCommitStatus")
 	})
 }

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -152,7 +152,7 @@ func (r *GitCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ct
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.GitCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.GitCommitStatusList](r.Client)).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.GitCommitStatusList](r.Client)).
 		Named("gitcommitstatus").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -153,7 +152,7 @@ func (r *GitCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ct
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.GitCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueGitCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.GitCommitStatusList](r.Client)).
 		Named("gitcommitstatus").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
@@ -408,18 +407,4 @@ func (r *GitCommitStatusReconciler) evaluateExpression(expression string, commit
 		return promoterv1alpha1.CommitPhaseSuccess, new(true), nil
 	}
 	return promoterv1alpha1.CommitPhaseFailure, new(false), nil
-}
-
-// enqueueGitCommitStatusForPromotionStrategy returns a handler that enqueues all GitCommitStatus resources
-// that reference a PromotionStrategy when that PromotionStrategy changes.
-func (r *GitCommitStatusReconciler) enqueueGitCommitStatusForPromotionStrategy() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
-		if !ok {
-			return nil
-		}
-
-		var gcsList promoterv1alpha1.GitCommitStatusList
-		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &gcsList, "GitCommitStatus")
-	})
 }

--- a/internal/controller/scheduledcommitstatus_controller.go
+++ b/internal/controller/scheduledcommitstatus_controller.go
@@ -139,7 +139,7 @@ func (r *ScheduledCommitStatusReconciler) SetupWithManager(ctx context.Context, 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.ScheduledCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.ScheduledCommitStatusList](r.Client)).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.ScheduledCommitStatusList](r.Client)).
 		Named("scheduledcommitstatus").
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
@@ -306,6 +306,7 @@ func (r *ScheduledCommitStatusReconciler) calculateRequeueDuration(ctx context.C
 
 	return defaultDuration
 }
+
 // windowEvalResult holds the result of evaluating scheduled windows for an environment.
 type windowEvalResult struct {
 	Active  *windowInfo

--- a/internal/controller/scheduledcommitstatus_controller.go
+++ b/internal/controller/scheduledcommitstatus_controller.go
@@ -316,22 +316,7 @@ func (r *ScheduledCommitStatusReconciler) enqueueScheduledCommitStatusForPromoti
 		}
 
 		var scsList promoterv1alpha1.ScheduledCommitStatusList
-		if err := r.List(ctx, &scsList,
-			client.InNamespace(ps.Namespace),
-			client.MatchingFields{PromotionStrategyRefField: ps.Name},
-		); err != nil {
-			log.FromContext(ctx).Error(err, "failed to list ScheduledCommitStatus resources")
-			return nil
-		}
-
-		requests := make([]ctrl.Request, 0, len(scsList.Items))
-		for i := range scsList.Items {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKeyFromObject(&scsList.Items[i]),
-			})
-		}
-
-		return requests
+		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &scsList, "ScheduledCommitStatus")
 	})
 }
 

--- a/internal/controller/scheduledcommitstatus_controller.go
+++ b/internal/controller/scheduledcommitstatus_controller.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -140,7 +139,7 @@ func (r *ScheduledCommitStatusReconciler) SetupWithManager(ctx context.Context, 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.ScheduledCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueScheduledCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.ScheduledCommitStatusList](r.Client)).
 		Named("scheduledcommitstatus").
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
@@ -307,19 +306,6 @@ func (r *ScheduledCommitStatusReconciler) calculateRequeueDuration(ctx context.C
 
 	return defaultDuration
 }
-
-func (r *ScheduledCommitStatusReconciler) enqueueScheduledCommitStatusForPromotionStrategy() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
-		if !ok {
-			return nil
-		}
-
-		var scsList promoterv1alpha1.ScheduledCommitStatusList
-		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &scsList, "ScheduledCommitStatus")
-	})
-}
-
 // windowEvalResult holds the result of evaluating scheduled windows for an environment.
 type windowEvalResult struct {
 	Active  *windowInfo

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -152,7 +151,7 @@ func (r *TimedCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.TimedCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueTimedCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.TimedCommitStatusList](r.Client)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
 	if err != nil {
@@ -327,18 +326,4 @@ func (r *TimedCommitStatusReconciler) calculateRequeueDuration(ctx context.Conte
 	}
 
 	return defaultDuration
-}
-
-// enqueueTimedCommitStatusForPromotionStrategy returns a handler that enqueues all TimedCommitStatus resources
-// that reference a PromotionStrategy when that PromotionStrategy changes
-func (r *TimedCommitStatusReconciler) enqueueTimedCommitStatusForPromotionStrategy() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
-		if !ok {
-			return nil
-		}
-
-		var tcsList promoterv1alpha1.TimedCommitStatusList
-		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &tcsList, "TimedCommitStatus")
-	})
 }

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -151,7 +151,7 @@ func (r *TimedCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.TimedCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.TimedCommitStatusList](r.Client)).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.TimedCommitStatusList](r.Client)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
 	if err != nil {

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -339,21 +339,6 @@ func (r *TimedCommitStatusReconciler) enqueueTimedCommitStatusForPromotionStrate
 		}
 
 		var tcsList promoterv1alpha1.TimedCommitStatusList
-		if err := r.List(ctx, &tcsList,
-			client.InNamespace(ps.Namespace),
-			client.MatchingFields{PromotionStrategyRefField: ps.Name},
-		); err != nil {
-			log.FromContext(ctx).Error(err, "failed to list TimedCommitStatus resources")
-			return nil
-		}
-
-		requests := make([]ctrl.Request, 0, len(tcsList.Items))
-		for i := range tcsList.Items {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKeyFromObject(&tcsList.Items[i]),
-			})
-		}
-
-		return requests
+		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &tcsList, "TimedCommitStatus")
 	})
 }

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -536,22 +536,7 @@ func (r *WebRequestCommitStatusReconciler) enqueueWebRequestCommitStatusForPromo
 		}
 
 		var wrcsList promoterv1alpha1.WebRequestCommitStatusList
-		if err := r.List(ctx, &wrcsList,
-			client.InNamespace(ps.Namespace),
-			client.MatchingFields{PromotionStrategyRefField: ps.Name},
-		); err != nil {
-			log.FromContext(ctx).Error(err, "failed to list WebRequestCommitStatus resources")
-			return nil
-		}
-
-		requests := make([]ctrl.Request, 0, len(wrcsList.Items))
-		for i := range wrcsList.Items {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKeyFromObject(&wrcsList.Items[i]),
-			})
-		}
-
-		return requests
+		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &wrcsList, "WebRequestCommitStatus")
 	})
 }
 

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -240,7 +239,7 @@ func (r *WebRequestCommitStatusReconciler) SetupWithManager(ctx context.Context,
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.WebRequestCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueWebRequestCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.WebRequestCommitStatusList](r.Client)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Named("webrequestcommitstatus").
 		Complete(r)
@@ -523,21 +522,6 @@ func (r *WebRequestCommitStatusReconciler) upsertCommitStatus(ctx context.Contex
 	}
 
 	return commitStatus, nil
-}
-
-// enqueueWebRequestCommitStatusForPromotionStrategy returns the watch handler for PromotionStrategy. When a
-// PromotionStrategy is created/updated (e.g. environment SHAs or status change), it enqueues every
-// WebRequestCommitStatus in the same namespace that references that strategy, so they reconcile with fresh data.
-func (r *WebRequestCommitStatusReconciler) enqueueWebRequestCommitStatusForPromotionStrategy() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-		ps, ok := obj.(*promoterv1alpha1.PromotionStrategy)
-		if !ok {
-			return nil
-		}
-
-		var wrcsList promoterv1alpha1.WebRequestCommitStatusList
-		return EnqueueCommitStatusGatesForPromotionStrategy(ctx, r.Client, ps, &wrcsList, "WebRequestCommitStatus")
-	})
 }
 
 // getNamespaceMetadata fetches the namespace's labels and annotations for use in templateData, so URL, header,

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -239,7 +239,7 @@ func (r *WebRequestCommitStatusReconciler) SetupWithManager(ctx context.Context,
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.WebRequestCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[*promoterv1alpha1.WebRequestCommitStatusList](r.Client)).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, CommitStatusGatePromotionStrategyWatchHandler[promoterv1alpha1.WebRequestCommitStatusList](r.Client)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Named("webrequestcommitstatus").
 		Complete(r)


### PR DESCRIPTION
Deduplicate PromotionStrategy watch enqueue logic across commit-status gate controllers using field-indexed listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized how commit-status resources respond to promotion-strategy changes, helping related statuses reconcile consistently.
  - Improved handling across Git, scheduled, timed, web-request, Argo CD, and dependent-success workflows.

- **Documentation**
  - Updated contributor guidance with clearer instructions for configuring promotion-strategy watches.
  - Documented requirements for typed gate resolution and environment status reporting, including branch mapping, status mirroring, and report retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->