### PR TITLE
chore(ci): more mod tidy from Renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -61,5 +61,5 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' }}
           # Global-only options that cannot be in renovate.json5
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^install-tool golang \\d+\\.\\d+\\.\\d+$","^go mod tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^make generate-apiserver$","^make generate-ui-types$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^install-tool golang \\d+\\.\\d+\\.\\d+$","^go mod tidy$","^make mod-tidy$","^make go-fix \\|\\| true$","^make lint-fix \\|\\| true$","^make mockery-gen$","^make build-installer$","^make manifests$","^make generate$","^make generate-apiserver$","^make generate-ui-types$","^pip-compile --generate-hashes -o docs/requirements-hashed.txt docs/requirements.txt$"]'
           RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS: 'true'

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,11 @@ apiserver-certs: ## Generate self-signed serving certs for the dashboard apiserv
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: mod-tidy
+mod-tidy: ## Tidy the root module and the celcost helper module.
+	go mod tidy
+	cd hack/celcost && go mod tidy
+
 .PHONY: go-fix
 go-fix: ## Apply stdlib go fix modernizations (e.g. after a Go version bump).
 	go fix ./...

--- a/renovate.json5
+++ b/renovate.json5
@@ -102,9 +102,12 @@
       // k8s.io OpenAPI/types flow into committed view codegen and CRDs. Without this,
       // a platform bump leaves zz_generated.openapi.go referencing removed types
       // (e.g. core/v1.PodStatusResult in 0.37) and Check Codegen fails.
+      // gomodUpdateImportPaths adds SMD /vN+1 but leaves the old /vN require when
+      // nothing imports SMD; make mod-tidy drops the unused major before generate.
       postUpgradeTasks: {
         commands: [
           'install-tool golang 1.27.1',
+          'make mod-tidy',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
@@ -148,6 +151,7 @@
       postUpgradeTasks: {
         commands: [
           'install-tool golang 1.27.1',
+          'make mod-tidy',
           'make build-installer',
           'make generate-apiserver',
           'make generate-ui-types',
@@ -175,8 +179,8 @@
     },
     {
       // SMD majors are a new module path (/v6 -> /v7), not a semver bump of /v6.
-      // gomodUpdateImportPaths rewrites the require (and any imports). Scoped to
-      // the direct require so an indirect /vN does not fight a leftover /v6.
+      // gomodUpdateImportPaths adds the new module path. With no SMD imports in
+      // this repo it does not drop the old require; platform make mod-tidy does.
       description: 'SMD /vN majors: rewrite module path in the Kubernetes platform PR',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
Major version bumps, like SMD, require a tidy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update workflows to keep Go module metadata synchronized.
  * Added automated cleanup for unused or outdated module requirements following dependency upgrades.
  * Standardized module maintenance across the main project and supporting tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->