### PR TITLE
chore(ci): align k8s platform versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   # Note: Go version and golangci-lint version updates are handled by Renovate.
-  # The coupled Kubernetes platform packages (k8s.io/*, controller-runtime,
-  # multicluster-runtime, and their staging deps) are ALSO owned by Renovate so
-  # they can be bumped in lockstep with the Makefile envtest versions; they are
-  # ignored here to avoid duplicate PRs. go-github (major /vNN paths) and
-  # ghinstallation are also Renovate-owned for import rewrites on major bumps.
+  # The coupled Kubernetes platform packages (tagged k8s.io/*, controller-runtime,
+  # multicluster-runtime, staging deps) are owned by Renovate; kube-openapi and
+  # structured-merge-diff are follower deps (see RENOVATE_SETUP.md). Ignored here
+  # to avoid duplicate PRs. go-github (major /vNN paths) and ghinstallation are
+  # also Renovate-owned for import rewrites on major bumps.
   # See renovate.json5 for configuration.
   - package-ecosystem: "gomod"
     directory: "/"

--- a/RENOVATE_SETUP.md
+++ b/RENOVATE_SETUP.md
@@ -18,6 +18,8 @@ Renovate has been configured to:
 
 4. **Group Go and golangci-lint updates together** in a single PR when both have updates
 
+5. **Group Kubernetes platform updates** (`controller-runtime`, tagged `k8s.io/*`, envtest) in one PR, with follower dependencies resolved by `make mod-tidy` (see [Kubernetes platform alignment](#kubernetes-platform-alignment) below)
+
 ## Why Self-Hosted Renovate?
 
 We use self-hosted Renovate (via GitHub Workflows) instead of the hosted GitHub App because:
@@ -149,11 +151,12 @@ Key workflow features:
 
 Key configuration options:
 
-- **Schedule**: Updates are checked every weekend to minimize disruption
+- **Schedule**: Updates are checked on the workflow schedule (Sun/Wed/Sat); see workflow file
 - **Labels**: PRs are labeled with `dependencies`
-- **Concurrent Limit**: Maximum of 3 PRs at once
+- **Concurrent limit**: See `prConcurrentLimit` in `renovate.json5`
 - **Automerge**: Disabled (requires manual review)
-- **Post-upgrade tasks**: Runs `go mod tidy`, `make go-fix`, and `make lint-fix`
+- **Kubernetes platform group**: Anchor bumps (controller-runtime, tagged `k8s.io/*`); follower deps (`kube-openapi`, structured-merge-diff) disabled—see [Kubernetes platform alignment](#kubernetes-platform-alignment)
+- **Post-upgrade tasks**: Platform PRs run `make mod-tidy`, `make build-installer`, codegen; Go/linter group runs `go mod tidy`, `make go-fix`, `make lint-fix`
   - These only work because we're using self-hosted Renovate
   - Commands must be whitelisted in the workflow
 
@@ -168,6 +171,47 @@ Dependabot does NOT handle:
 - ❌ golangci-lint version updates (handled by Renovate)
 
 This avoids conflicts between the two tools.
+
+## Kubernetes platform alignment
+
+Renovate opens a **Kubernetes platform** PR when **`sigs.k8s.io/controller-runtime`** (and the matching tagged **`k8s.io/*`** modules at `v0.N.x`) move, together with Makefile **envtest** pins. That matches how the ecosystem versions itself:
+
+- [controller-runtime VERSIONING](https://github.com/kubernetes-sigs/controller-runtime/blob/main/VERSIONING.md): one controller-runtime **minor** per Kubernetes **minor**; the supported dependency set is whatever that release’s **`go.mod`** lists — not “latest” of every related module.
+- controller-runtime **does not** publish a compatibility matrix among Kubernetes Go libraries; mixing minors is unsupported.
+
+### Anchor vs follower dependencies
+
+| Role | Packages | How they update |
+|------|----------|-----------------|
+| **Anchor** (Renovate proposes bumps) | `sigs.k8s.io/controller-runtime`, `sigs.k8s.io/multicluster-runtime`, tagged `k8s.io/api`, `apimachinery`, `client-go`, … (`v0.N.x`), `sigs.k8s.io/json`, `sigs.k8s.io/randfill`, envtest Makefile/workflow pins | Grouped in one **Kubernetes platform** PR |
+| **Follower** (Renovate does **not** propose bumps) | `k8s.io/kube-openapi`, `sigs.k8s.io/structured-merge-diff/vN` | **`make mod-tidy`** in the platform post-upgrade task, after the anchor bump, picks the digest and `/vN` module path from controller-runtime’s resolved graph |
+
+### Why `kube-openapi` and structured-merge-diff are followers
+
+**`k8s.io/kube-openapi`** is not released as `v0.37.0`; it uses **pseudo-version digests**. Renovate can only offer **digest** updates. A newer digest may track **kubernetes/master** (e.g. structured-merge-diff **v7**) while **`k8s.io/apimachinery@v0.37.0`** on **release-1.37** still uses **v6**. That produces compile errors such as:
+
+```text
+cannot use typeSchema.Types ([]structured-merge-diff/v7/schema.TypeDef)
+as []structured-merge-diff/v6/schema.TypeDef
+```
+
+**`sigs.k8s.io/structured-merge-diff/vN`** uses a **new Go module path** per major (`/v6`, `/v7`, …), not a semver bump of `/v6`. It moves with the **controller-runtime / controller-tools** line for a Kubernetes minor (e.g. v6 for 1.37, v7 for 1.38), not on its own release cadence. Bumping it independently (or via `gomodUpdateImportPaths` without a matching apimachinery/controller-gen stack) broke platform PRs such as [#1980](https://github.com/argoproj-labs/gitops-promoter/pull/1980).
+
+### Post-upgrade flow for platform PRs
+
+After Renovate bumps the anchor deps, the platform **postUpgradeTasks** run:
+
+1. `install-tool golang …`
+2. **`make mod-tidy`** — root module and `hack/celcost`; syncs follower versions to the new controller-runtime graph
+3. **`make build-installer`** — CRDs, applyconfiguration (via **controller-tools**), dist bundles
+4. **`make generate-apiserver`** / **`make generate-ui-types`**
+
+**controller-tools** (`CONTROLLER_TOOLS_VERSION` in the Makefile) has its own Renovate rule but should stay on the **same Kubernetes minor** as controller-runtime; it determines which SMD `/vN` import appears in generated `applyconfiguration/`.
+
+### Reasonable expectation
+
+- On **Kubernetes 1.37 / controller-runtime 0.25**: stay on **structured-merge-diff v6** and the **kube-openapi digest** that CR 0.25’s `go.mod` pulls in—not the latest digest on main.
+- On **1.38 / controller-runtime 0.26** (when released): expect **v7** and a new openapi digest **together** in one platform PR, driven by the CR bump—not by separate Renovate updates to openapi or SMD.
 
 ## Troubleshooting
 
@@ -235,8 +279,10 @@ To test the workflow without making real changes:
 
 The workflow only allows specific commands in `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS`:
 - `go mod tidy` - Safe, only updates dependency checksums
+- `make mod-tidy` - Root and `hack/celcost` modules; syncs follower deps after Kubernetes platform bumps
 - `make go-fix` - Runs `go fix ./...` (stdlib modernizations for the new Go version)
 - `make lint-fix` - Runs golangci-lint with auto-fix
+- `make build-installer`, `make generate-apiserver`, `make generate-ui-types`, … - Platform/codegen post-upgrade tasks
 
 If you need to add more commands, update both:
 1. The workflow file (`.github/workflows/renovate.yaml`)

--- a/renovate.json5
+++ b/renovate.json5
@@ -75,9 +75,9 @@
     },
     // ----------------------------------------------------------------------
     // Group A: Kubernetes platform (gomod + Makefile + e2e workflow, lockstep)
-    // controller-runtime <-> multicluster-runtime <-> k8s.io/* <-> setup-envtest
-    // SMD uses /vN module paths (v6 vs v7 with k8s 1.37). Keep majors in this
-    // group (separateMajorMinor: false) so they land with the CR/k8s bump.
+    // Anchor: controller-runtime + tagged k8s.io/* (v0.N.x). See RENOVATE_SETUP.md.
+    // Followers (kube-openapi digests, structured-merge-diff /vN) are NOT listed
+    // here; make mod-tidy after a CR bump picks the versions from CR's go.mod.
     // ----------------------------------------------------------------------
     {
       description: 'Renovate owns the coupled Kubernetes platform gomod deps so they bump in lockstep',
@@ -88,7 +88,6 @@
         'k8s.io/**',
         'sigs.k8s.io/controller-runtime',
         'sigs.k8s.io/multicluster-runtime',
-        'sigs.k8s.io/structured-merge-diff/**',
         'sigs.k8s.io/json',
         'sigs.k8s.io/randfill',
       ],
@@ -102,8 +101,7 @@
       // k8s.io OpenAPI/types flow into committed view codegen and CRDs. Without this,
       // a platform bump leaves zz_generated.openapi.go referencing removed types
       // (e.g. core/v1.PodStatusResult in 0.37) and Check Codegen fails.
-      // gomodUpdateImportPaths adds SMD /vN+1 but leaves the old /vN require when
-      // nothing imports SMD; make mod-tidy drops the unused major before generate.
+      // make mod-tidy syncs follower deps (kube-openapi digest, SMD /vN) to CR.
       postUpgradeTasks: {
         commands: [
           'install-tool golang 1.27.1',
@@ -178,47 +176,27 @@
       },
     },
     {
-      // SMD majors are a new module path (/v6 -> /v7), not a semver bump of /v6.
-      // gomodUpdateImportPaths adds the new module path. With no SMD imports in
-      // this repo it does not drop the old require; platform make mod-tidy does.
-      description: 'SMD /vN majors: rewrite module path in the Kubernetes platform PR',
+      // kube-openapi has no v0.N semver tags; Renovate only sees digest bumps.
+      // A newer digest can jump structured-merge-diff major ahead of apimachinery
+      // on the same k8s minor (e.g. 0.37 stays on SMD v6 until 0.38).
+      description: 'kube-openapi follows controller-runtime; do not bump digests independently',
       matchManagers: [
         'gomod',
       ],
       matchPackageNames: [
-        'sigs.k8s.io/structured-merge-diff/**',
+        'k8s.io/kube-openapi',
       ],
-      matchDepTypes: [
-        'require',
-      ],
-      enabled: true,
-      groupName: 'Kubernetes platform',
-      separateMajorMinor: false,
-      semanticCommits: 'enabled',
-      semanticCommitType: 'chore',
-      semanticCommitScope: 'deps',
-      automerge: false,
-      postUpdateOptions: [
-        'gomodUpdateImportPaths',
-        'gomodTidy',
-      ],
+      enabled: false,
     },
     {
-      // Same as go-github: an indirect /vN major is a new module path. Bumping
-      // v6 to v7.0.0 without rewriting the path fails; gomodTidy follows the
-      // direct require rewrite instead.
-      description: 'Block indirect SMD majors; gomodTidy follows the direct /vN rewrite',
+      // /vN is a new module path, not a semver bump. It moves with the CR /
+      // controller-tools release for that k8s minor, not on its own schedule.
+      description: 'structured-merge-diff follows controller-runtime; do not bump independently',
       matchManagers: [
         'gomod',
       ],
       matchPackageNames: [
         'sigs.k8s.io/structured-merge-diff/**',
-      ],
-      matchDepTypes: [
-        'indirect',
-      ],
-      matchUpdateTypes: [
-        'major',
       ],
       enabled: false,
     },


### PR DESCRIPTION
Been chasing my tail on this, but I think we're getting closer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated dependency maintenance guidance to explain Kubernetes platform alignment, anchor and follower packages, and related update workflows.
  - Clarified Renovate scheduling, grouping, and permitted post-update commands.

- **Chores**
  - Updated automated dependency management so selected Kubernetes follower packages are synchronized through platform updates rather than receiving independent update requests.
  - Clarified ownership of Kubernetes package updates between dependency management tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->