### PR TITLE
fix(controller): drop DSCS legacy cleanup annotation stamp

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -37,14 +37,6 @@ const DependentsSuccessfulCommitStatusKey = "dependents-successful"
 // TODO(v1.0): Remove with cleanupLegacyPreviousEnvironmentCommitStatuses.
 const LegacyPreviousEnvironmentCommitStatusKey = "promoter-previous-environment"
 
-// LegacyPreviousEnvironmentCleanupAnnotation is set on DependentsSuccessfulCommitStatus once legacy
-// promoter-previous-environment CommitStatuses for the referenced PromotionStrategy are gone, so
-// subsequent reconciles skip the migration cleanup. The legacy key was auto-injected by the
-// PromotionStrategy controller ≤ 0.37 and is not a reliable signal in the PS spec.
-//
-// TODO(v1.0): Remove with cleanupLegacyPreviousEnvironmentCommitStatuses.
-const LegacyPreviousEnvironmentCleanupAnnotation = "promoter.argoproj.io/legacy-previous-environment-cleaned"
-
 // Finalizer constants for preventing premature resource deletion
 
 // PullRequestFinalizer prevents deletion of PullRequest until the PR is closed in the SCM

--- a/internal/controller/dependentssuccessfulcommitstatus_controller.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller.go
@@ -284,8 +284,8 @@ func (r *DependentsSuccessfulCommitStatusReconciler) updateDependentsSuccessfulC
 // PromotionStrategy, those statuses are orphaned and safe to remove.
 //
 // Legacy CommitStatus names are deterministic from the PromotionStrategy name and environment
-// branch, so this uses per-object Get instead of namespace List. After all legacy objects are
-// gone, an annotation on the DependentsSuccessfulCommitStatus skips further cleanup work.
+// branch, so this uses per-object Get instead of namespace List. The scan runs every reconcile
+// until this migration helper is removed.
 //
 // TODO(v1.0): Remove once clusters are upgraded past the 0.38 promotion-ordering-gate migration.
 func (r *DependentsSuccessfulCommitStatusReconciler) cleanupLegacyPreviousEnvironmentCommitStatuses(
@@ -293,18 +293,16 @@ func (r *DependentsSuccessfulCommitStatusReconciler) cleanupLegacyPreviousEnviro
 	dcs *promoterv1alpha1.DependentsSuccessfulCommitStatus,
 	ps *promoterv1alpha1.PromotionStrategy,
 ) error {
-	if dcs.Annotations[promoterv1alpha1.LegacyPreviousEnvironmentCleanupAnnotation] == "true" {
-		return nil
-	}
-
 	logger := logf.FromContext(ctx)
-	deletedAny := false
 
 	// The old PromotionStrategy controller only created previous-environment CommitStatuses for
 	// environments after the first (each non-root environment waits on upstreams).
 	for i := 1; i < len(ps.Spec.Environments); i++ {
 		branch := ps.Spec.Environments[i].Branch
-		commitStatusName := legacyPreviousEnvironmentCommitStatusName(ps.Name, branch)
+		commitStatusName := utils.KubeSafeUniqueName(
+			promoterv1alpha1.PreviousEnvProposedCommitPrefixNameLabel +
+				utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(ps.Name, branch)),
+		)
 
 		cs := &promoterv1alpha1.CommitStatus{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: dcs.Namespace, Name: commitStatusName}, cs); err != nil {
@@ -331,40 +329,9 @@ func (r *DependentsSuccessfulCommitStatusReconciler) cleanupLegacyPreviousEnviro
 			return fmt.Errorf("failed to delete legacy previous-environment CommitStatus %q: %w", cs.Name, err)
 		}
 
-		deletedAny = true
 		r.Recorder.Eventf(dcs, nil, "Normal", constants.OrphanedCommitStatusDeletedReason, "CleaningOrphanedResources", constants.OrphanedCommitStatusDeletedMessage, cs.Name)
 	}
 
-	if deletedAny {
-		return nil
-	}
-
-	return r.markLegacyPreviousEnvironmentCommitStatusesCleaned(ctx, dcs)
-}
-
-// legacyPreviousEnvironmentCommitStatusName returns the Kubernetes name used by PromotionStrategy ≤ 0.37
-// for a previous-environment CommitStatus on the given environment branch.
-func legacyPreviousEnvironmentCommitStatusName(psName, branch string) string {
-	ctpName := utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(psName, branch))
-	return utils.KubeSafeUniqueName(promoterv1alpha1.PreviousEnvProposedCommitPrefixNameLabel + ctpName)
-}
-
-func (r *DependentsSuccessfulCommitStatusReconciler) markLegacyPreviousEnvironmentCommitStatusesCleaned(
-	ctx context.Context,
-	dcs *promoterv1alpha1.DependentsSuccessfulCommitStatus,
-) error {
-	if dcs.Annotations[promoterv1alpha1.LegacyPreviousEnvironmentCleanupAnnotation] == "true" {
-		return nil
-	}
-
-	patchBase := dcs.DeepCopy()
-	if dcs.Annotations == nil {
-		dcs.Annotations = map[string]string{}
-	}
-	dcs.Annotations[promoterv1alpha1.LegacyPreviousEnvironmentCleanupAnnotation] = "true"
-	if err := r.Patch(ctx, dcs, client.MergeFrom(patchBase)); err != nil {
-		return fmt.Errorf("failed to mark legacy previous-environment CommitStatuses cleaned on DependentsSuccessfulCommitStatus %q: %w", dcs.Name, err)
-	}
 	return nil
 }
 

--- a/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
@@ -522,7 +522,10 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 		})
 
 		It("should cleanup legacy promoter-previous-environment CommitStatuses once configured", func() {
-			legacyCommitStatusName := legacyPreviousEnvironmentCommitStatusName(name, testBranchStaging)
+			legacyCommitStatusName := utils.KubeSafeUniqueName(
+				promoterv1alpha1.PreviousEnvProposedCommitPrefixNameLabel +
+					utils.KubeSafeUniqueName(utils.GetChangeTransferPolicyName(name, testBranchStaging)),
+			)
 			legacyCommitStatus := &promoterv1alpha1.CommitStatus{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      legacyCommitStatusName,
@@ -563,16 +566,11 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 			}, constants.EventuallyTimeout).Should(Succeed())
 
-			By("Verifying the legacy CommitStatus is deleted and cleanup is marked complete")
+			By("Verifying the legacy CommitStatus is deleted")
 			Eventually(func(g Gomega) {
 				cs := &promoterv1alpha1.CommitStatus{}
 				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: legacyCommitStatusName}, cs)
 				g.Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "legacy previous-environment CommitStatus should be deleted")
-
-				updated := &promoterv1alpha1.DependentsSuccessfulCommitStatus{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dependentsSuccessfulCommitStatus), updated)).To(Succeed())
-				g.Expect(updated.Annotations).To(HaveKeyWithValue(
-					promoterv1alpha1.LegacyPreviousEnvironmentCleanupAnnotation, "true"))
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
The migration helper no longer patches DependentsSuccessfulCommitStatus metadata, avoiding a forbidden error where the controller SA lacks patch on the main resource. Legacy previous-environment CommitStatuses are still deleted; the per-object Get scan runs each reconcile until v1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of legacy previous-environment commit statuses by checking for and removing them during every reconciliation.
  * Removed reliance on a cleanup marker, ensuring stale resources can still be detected and deleted after earlier cleanup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->