### PR TITLE
chore(dscs): filter PromotionStrategy watch events for gate-relevant changes

### DIFF
--- a/internal/controller/dependentssuccessfulcommitstatus_controller.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -577,6 +578,106 @@ func (r *DependentsSuccessfulCommitStatusReconciler) createOrUpdateDependentsSuc
 	}, nil
 }
 
+// promotionStrategyGateRelevantPredicate limits PromotionStrategy watch events to create/delete
+// and updates where fields that affect DependentsSuccessfulCommitStatus gate evaluation changed.
+func promotionStrategyGateRelevantPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPS, okOld := e.ObjectOld.(*promoterv1alpha1.PromotionStrategy)
+			newPS, okNew := e.ObjectNew.(*promoterv1alpha1.PromotionStrategy)
+			if !okOld || !okNew {
+				return true
+			}
+			return promotionStrategySpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+				promotionStrategyStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// promotionStrategySpecEnvironmentsGateRelevantChange reports whether spec.environments changed
+// in a way that affects DependentsSuccessfulCommitStatus. Only branch names and their order
+// matter: when DSCS spec.environments is empty, the controller infers a linear DAG from this list.
+func promotionStrategySpecEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.Environment) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+	}
+	return false
+}
+
+// promotionStrategyStatusEnvironmentsGateRelevantChange reports whether any environment status
+// changed in a way that affects DependentsSuccessfulCommitStatus gate evaluation.
+func promotionStrategyStatusEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.EnvironmentStatus) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+		if promotionStrategyEnvironmentStatusGateRelevantChange(oldEnvs[i], newEnvs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// promotionStrategyEnvironmentStatusGateRelevantChange reports whether a single environment's
+// PromotionStrategy status changed in a way that affects DependentsSuccessfulCommitStatus.
+func promotionStrategyEnvironmentStatusGateRelevantChange(oldEnv, newEnv promoterv1alpha1.EnvironmentStatus) bool {
+	if oldEnv.Active.Dry.Sha != newEnv.Active.Dry.Sha {
+		// Active dry SHA drives the no-proposed-change short-circuit and whether an upstream has merged the target change.
+		return true
+	}
+	if oldEnv.Proposed.Dry.Sha != newEnv.Proposed.Dry.Sha {
+		// Proposed dry SHA drives the no-proposed-change short-circuit and pending-change detection.
+		return true
+	}
+	if oldEnv.Proposed.Hydrated.Sha != newEnv.Proposed.Hydrated.Sha {
+		// Child CommitStatus resources are keyed to the proposed hydrated SHA.
+		return true
+	}
+	if getNoteDrySha(oldEnv.Proposed.Note) != getNoteDrySha(newEnv.Proposed.Note) {
+		// getEffectiveHydratedDrySha prefers the hydrator note dry SHA over proposed.dry.sha.
+		return true
+	}
+	if !oldEnv.Active.Dry.CommitTime.Equal(&newEnv.Active.Dry.CommitTime) {
+		// When an upstream has merged the target dry SHA, commit-time ordering guards against stale promotions.
+		return true
+	}
+	return activeCommitStatusesGateRelevantChange(oldEnv.Active.CommitStatuses, newEnv.Active.CommitStatuses)
+}
+
+// activeCommitStatusesGateRelevantChange reports whether active commit status health changed.
+// isUpstreamPending consults only key and phase via checkCommitStatusesPassing.
+func activeCommitStatusesGateRelevantChange(oldStatuses, newStatuses []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase) bool {
+	if len(oldStatuses) != len(newStatuses) {
+		return true
+	}
+	for i := range oldStatuses {
+		if oldStatuses[i].Key != newStatuses[i].Key {
+			return true
+		}
+		if oldStatuses[i].Phase != newStatuses[i].Phase {
+			return true
+		}
+	}
+	return false
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *DependentsSuccessfulCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	// Use Direct methods to read configuration from the API server without cache during setup.
@@ -593,7 +694,8 @@ func (r *DependentsSuccessfulCommitStatusReconciler) SetupWithManager(ctx contex
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.DependentsSuccessfulCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueDependentsSuccessfulCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueDependentsSuccessfulCommitStatusForPromotionStrategy(),
+			builder.WithPredicates(promotionStrategyGateRelevantPredicate())).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Named("dependentssuccessfulcommitstatus").
 		Complete(r)

--- a/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
@@ -30,12 +30,10 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
-	"github.com/argoproj-labs/gitops-promoter/internal/settings"
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
@@ -577,114 +575,6 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
 
-		Context("When PromotionStrategy status churns", func() {
-			BeforeEach(func() {
-				setDependentsSuccessfulCommitStatusRequeueDuration(ctx, time.Hour)
-			})
-
-			It("should reconcile DSCS when upstream commit status health changes", func() {
-				dependentsSuccessfulCommitStatus = &promoterv1alpha1.DependentsSuccessfulCommitStatus{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name + "-ps-predicate-health",
-						Namespace: "default",
-					},
-					Spec: promoterv1alpha1.DependentsSuccessfulCommitStatusSpec{
-						PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: name},
-						Key:                  promoterv1alpha1.DependentsSuccessfulCommitStatusKey,
-						Environments: []promoterv1alpha1.DependentEnvironment{
-							{Branch: testBranchDevelopment},
-							{Branch: testBranchStaging, DependsOn: []string{testBranchDevelopment}},
-							{Branch: testBranchProduction, DependsOn: []string{testBranchStaging}},
-						},
-						URL: promoterv1alpha1.URLConfig{
-							Template: "https://example.com/ui?env={{ .Environment }}",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, dependentsSuccessfulCommitStatus)).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					updated := &promoterv1alpha1.DependentsSuccessfulCommitStatus{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dependentsSuccessfulCommitStatus), updated)).To(Succeed())
-					readyCondition := meta.FindStatusCondition(updated.Status.Conditions, string(promoterConditions.Ready))
-					g.Expect(readyCondition).ToNot(BeNil())
-					g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
-				}, constants.EventuallyTimeout).Should(Succeed())
-
-				gitPath, err := os.MkdirTemp("", "*")
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() { _ = os.RemoveAll(gitPath) })
-				makeChangeAndHydrateRepo(gitPath, gitRepo, "ps predicate health flip", "")
-
-				stagingCSName := utils.CommitStatusResourceName(ctx, dependentsSuccessfulCommitStatus, testBranchStaging)
-				waitForPromotionStrategyEnvironmentInFlight := func(branch string) {
-					Eventually(func(g Gomega) {
-						ps := &promoterv1alpha1.PromotionStrategy{}
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(promotionStrategy), ps)).To(Succeed())
-						for _, env := range ps.Status.Environments {
-							if env.Branch != branch {
-								continue
-							}
-							g.Expect(env.Proposed.Dry.Sha).ToNot(BeEmpty())
-							g.Expect(env.Active.Dry.Sha).ToNot(Equal(env.Proposed.Dry.Sha),
-								"environment %s has no in-flight promotion", branch)
-							return
-						}
-						g.Expect(false).To(BeTrue(), "environment %s not found in PromotionStrategy status", branch)
-					}, constants.EventuallyTimeout).Should(Succeed())
-				}
-				setPromotionStrategyCommitStatusPhase := func(branch, key string, phase promoterv1alpha1.CommitStatusPhase) {
-					Eventually(func(g Gomega) {
-						ps := &promoterv1alpha1.PromotionStrategy{}
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(promotionStrategy), ps)).To(Succeed())
-						for i := range ps.Status.Environments {
-							if ps.Status.Environments[i].Branch != branch {
-								continue
-							}
-							found := false
-							for j := range ps.Status.Environments[i].Active.CommitStatuses {
-								if ps.Status.Environments[i].Active.CommitStatuses[j].Key != key {
-									continue
-								}
-								ps.Status.Environments[i].Active.CommitStatuses[j].Phase = string(phase)
-								found = true
-							}
-							if !found {
-								ps.Status.Environments[i].Active.CommitStatuses = append(
-									ps.Status.Environments[i].Active.CommitStatuses,
-									promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{Key: key, Phase: string(phase)},
-								)
-							}
-						}
-						g.Expect(k8sClient.Status().Update(ctx, ps)).To(Succeed())
-					}, constants.EventuallyTimeout).Should(Succeed())
-				}
-
-				waitForPromotionStrategyEnvironmentInFlight(testBranchStaging)
-
-				Eventually(func(g Gomega) {
-					cs := &promoterv1alpha1.CommitStatus{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
-					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
-				}, constants.EventuallyTimeout).Should(Succeed())
-
-				setPromotionStrategyCommitStatusPhase(testBranchDevelopment, "argocd-health", promoterv1alpha1.CommitPhasePending)
-
-				Eventually(func(g Gomega) {
-					cs := &promoterv1alpha1.CommitStatus{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
-					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhasePending))
-				}, constants.EventuallyTimeout).Should(Succeed())
-
-				setPromotionStrategyCommitStatusPhase(testBranchDevelopment, "argocd-health", promoterv1alpha1.CommitPhaseSuccess)
-
-				Eventually(func(g Gomega) {
-					cs := &promoterv1alpha1.CommitStatus{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
-					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
-				}, constants.EventuallyTimeout).Should(Succeed())
-			})
-		})
 	})
 })
 
@@ -906,24 +796,6 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })
-
-// setDependentsSuccessfulCommitStatusRequeueDuration patches the singleton ControllerConfiguration's
-// dependentsSuccessfulCommitStatus.workQueue.requeueDuration for the current test.
-func setDependentsSuccessfulCommitStatusRequeueDuration(ctx context.Context, d time.Duration) {
-	var cc promoterv1alpha1.ControllerConfiguration
-	key := types.NamespacedName{Namespace: "default", Name: settings.ControllerConfigurationName}
-	Expect(k8sClient.Get(ctx, key, &cc)).To(Succeed())
-	original := cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration
-	cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration = metav1.Duration{Duration: d}
-	Expect(k8sClient.Update(ctx, &cc)).To(Succeed())
-
-	DeferCleanup(func() {
-		var cc promoterv1alpha1.ControllerConfiguration
-		Expect(k8sClient.Get(ctx, key, &cc)).To(Succeed())
-		cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration = original
-		Expect(k8sClient.Update(ctx, &cc)).To(Succeed())
-	})
-}
 
 var _ = Describe("DAG URL template helpers", func() {
 	Describe("buildDependsOnQuery", func() {

--- a/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
@@ -30,9 +30,12 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	"github.com/argoproj-labs/gitops-promoter/internal/settings"
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
@@ -573,8 +576,238 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 				g.Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "legacy previous-environment CommitStatus should be deleted")
 			}, constants.EventuallyTimeout).Should(Succeed())
 		})
+
+		Context("When PromotionStrategy status churns", func() {
+			BeforeEach(func() {
+				setDependentsSuccessfulCommitStatusRequeueDuration(ctx, time.Hour)
+			})
+
+			It("should reconcile DSCS when upstream commit status health changes", func() {
+				dependentsSuccessfulCommitStatus = &promoterv1alpha1.DependentsSuccessfulCommitStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name + "-ps-predicate-health",
+						Namespace: "default",
+					},
+					Spec: promoterv1alpha1.DependentsSuccessfulCommitStatusSpec{
+						PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: name},
+						Key:                  promoterv1alpha1.DependentsSuccessfulCommitStatusKey,
+						Environments: []promoterv1alpha1.DependentEnvironment{
+							{Branch: testBranchDevelopment},
+							{Branch: testBranchStaging, DependsOn: []string{testBranchDevelopment}},
+							{Branch: testBranchProduction, DependsOn: []string{testBranchStaging}},
+						},
+						URL: promoterv1alpha1.URLConfig{
+							Template: "https://example.com/ui?env={{ .Environment }}",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, dependentsSuccessfulCommitStatus)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					updated := &promoterv1alpha1.DependentsSuccessfulCommitStatus{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dependentsSuccessfulCommitStatus), updated)).To(Succeed())
+					readyCondition := meta.FindStatusCondition(updated.Status.Conditions, string(promoterConditions.Ready))
+					g.Expect(readyCondition).ToNot(BeNil())
+					g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				gitPath, err := os.MkdirTemp("", "*")
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { _ = os.RemoveAll(gitPath) })
+				makeChangeAndHydrateRepo(gitPath, gitRepo, "ps predicate health flip", "")
+
+				stagingCSName := utils.CommitStatusResourceName(ctx, dependentsSuccessfulCommitStatus, testBranchStaging)
+				setPromotionStrategyCommitStatusPhase := func(branch, key string, phase promoterv1alpha1.CommitStatusPhase) {
+					Eventually(func(g Gomega) {
+						ps := &promoterv1alpha1.PromotionStrategy{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(promotionStrategy), ps)).To(Succeed())
+						for i := range ps.Status.Environments {
+							if ps.Status.Environments[i].Branch != branch {
+								continue
+							}
+							found := false
+							for j := range ps.Status.Environments[i].Active.CommitStatuses {
+								if ps.Status.Environments[i].Active.CommitStatuses[j].Key != key {
+									continue
+								}
+								ps.Status.Environments[i].Active.CommitStatuses[j].Phase = string(phase)
+								found = true
+							}
+							if !found {
+								ps.Status.Environments[i].Active.CommitStatuses = append(
+									ps.Status.Environments[i].Active.CommitStatuses,
+									promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{Key: key, Phase: string(phase)},
+								)
+							}
+						}
+						g.Expect(k8sClient.Status().Update(ctx, ps)).To(Succeed())
+					}, constants.EventuallyTimeout).Should(Succeed())
+				}
+
+				Eventually(func(g Gomega) {
+					cs := &promoterv1alpha1.CommitStatus{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				setPromotionStrategyCommitStatusPhase(testBranchDevelopment, "argocd-health", promoterv1alpha1.CommitPhasePending)
+
+				Eventually(func(g Gomega) {
+					cs := &promoterv1alpha1.CommitStatus{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
+					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhasePending))
+				}, constants.EventuallyTimeout).Should(Succeed())
+
+				setPromotionStrategyCommitStatusPhase(testBranchDevelopment, "argocd-health", promoterv1alpha1.CommitPhaseSuccess)
+
+				Eventually(func(g Gomega) {
+					cs := &promoterv1alpha1.CommitStatus{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
+					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+				}, constants.EventuallyTimeout).Should(Succeed())
+			})
+		})
 	})
 })
+
+var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
+	pred := promotionStrategyGateRelevantPredicate()
+
+	basePS := func() *promoterv1alpha1.PromotionStrategy {
+		return &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				Environments: []promoterv1alpha1.Environment{
+					{Branch: "dev"},
+					{Branch: "stg"},
+				},
+			},
+			Status: promoterv1alpha1.PromotionStrategyStatus{
+				Environments: []promoterv1alpha1.EnvironmentStatus{
+					{
+						Branch: "dev",
+						Active: promoterv1alpha1.CommitBranchState{
+							Dry: promoterv1alpha1.CommitShaState{
+								Sha:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+								CommitTime: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+							},
+							CommitStatuses: []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{
+								{Key: "argocd-health", Phase: string(promoterv1alpha1.CommitPhaseSuccess)},
+							},
+						},
+						Proposed: promoterv1alpha1.CommitBranchState{
+							Dry:      promoterv1alpha1.CommitShaState{Sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+							Hydrated: promoterv1alpha1.CommitShaState{Sha: "cccccccccccccccccccccccccccccccccccccccc"},
+							Note:     &promoterv1alpha1.HydratorMetadata{DrySha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	It("allows create and delete events", func() {
+		ps := basePS()
+		Expect(pred.Create(event.CreateEvent{Object: ps})).To(BeTrue())
+		Expect(pred.Delete(event.DeleteEvent{Object: ps})).To(BeTrue())
+	})
+
+	It("ignores metadata, generation, and unrelated spec changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Generation = 99
+		newPS.ResourceVersion = "999"
+		newPS.Labels = map[string]string{"extra": "label"}
+		newPS.Spec.RepositoryReference.Name = "other-repo"
+		newPS.Spec.ActiveCommitStatuses = []promoterv1alpha1.CommitStatusSelector{{Key: "other-gate"}}
+		autoMerge := false
+		newPS.Spec.Environments[0].AutoMerge = &autoMerge
+		newPS.Spec.Environments[0].ActivePath = "apps/demo"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("ignores commit and hydrator metadata churn", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Dry.Author = "someone else"
+		newPS.Status.Environments[0].Proposed.Hydrated.Subject = "new subject"
+		newPS.Status.Environments[0].Proposed.Note.RepoURL = "https://example.com/other.git"
+		newPS.Status.Environments[0].Active.CommitStatuses[0].Url = "https://example.com/status"
+		newPS.Status.Environments[0].Active.CommitStatuses[0].Description = "cosmetic"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("ignores obvious status-only noise", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.ObservedGeneration = 42
+		instanceID := "new-instance"
+		newPS.Status.InstanceID = &instanceID
+		newPS.Status.Environments[0].History = []promoterv1alpha1.History{{
+			Active: promoterv1alpha1.CommitBranchState{
+				Dry: promoterv1alpha1.CommitShaState{Sha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+			},
+		}}
+		newPS.Status.Environments[0].LastHealthyDryShas = []promoterv1alpha1.HealthyDryShas{
+			{Sha: "ffffffffffffffffffffffffffffffffffffffff", Time: metav1.Now()},
+		}
+		newPS.Status.Environments[0].PullRequest = &promoterv1alpha1.PullRequestCommonStatus{
+			ID:    "99",
+			State: promoterv1alpha1.PullRequestOpen,
+			Url:   "https://example.com/pr/99",
+		}
+		meta.SetStatusCondition(&newPS.Status.Conditions, metav1.Condition{
+			Type:               string(promoterConditions.Ready),
+			Status:             metav1.ConditionFalse,
+			Reason:             "Test",
+			Message:            "not gate relevant",
+			ObservedGeneration: newPS.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when spec.environments branches change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments = []promoterv1alpha1.Environment{
+			{Branch: "dev"},
+			{Branch: "prd"},
+		}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when proposed dry sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Dry.Sha = "dddddddddddddddddddddddddddddddddddddddd"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active commit status phase changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.CommitStatuses[0].Phase = string(promoterv1alpha1.CommitPhasePending)
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+})
+
+// setDependentsSuccessfulCommitStatusRequeueDuration patches the singleton ControllerConfiguration's
+// dependentsSuccessfulCommitStatus.workQueue.requeueDuration for the current test.
+func setDependentsSuccessfulCommitStatusRequeueDuration(ctx context.Context, d time.Duration) {
+	var cc promoterv1alpha1.ControllerConfiguration
+	key := types.NamespacedName{Namespace: "default", Name: settings.ControllerConfigurationName}
+	Expect(k8sClient.Get(ctx, key, &cc)).To(Succeed())
+	original := cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration
+	cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration = metav1.Duration{Duration: d}
+	Expect(k8sClient.Update(ctx, &cc)).To(Succeed())
+
+	DeferCleanup(func() {
+		var cc promoterv1alpha1.ControllerConfiguration
+		Expect(k8sClient.Get(ctx, key, &cc)).To(Succeed())
+		cc.Spec.DependentsSuccessfulCommitStatus.WorkQueue.RequeueDuration = original
+		Expect(k8sClient.Update(ctx, &cc)).To(Succeed())
+	})
+}
 
 var _ = Describe("DAG URL template helpers", func() {
 	Describe("buildDependsOnQuery", func() {

--- a/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
@@ -617,6 +617,22 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 				makeChangeAndHydrateRepo(gitPath, gitRepo, "ps predicate health flip", "")
 
 				stagingCSName := utils.CommitStatusResourceName(ctx, dependentsSuccessfulCommitStatus, testBranchStaging)
+				waitForPromotionStrategyEnvironmentInFlight := func(branch string) {
+					Eventually(func(g Gomega) {
+						ps := &promoterv1alpha1.PromotionStrategy{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(promotionStrategy), ps)).To(Succeed())
+						for _, env := range ps.Status.Environments {
+							if env.Branch != branch {
+								continue
+							}
+							g.Expect(env.Proposed.Dry.Sha).ToNot(BeEmpty())
+							g.Expect(env.Active.Dry.Sha).ToNot(Equal(env.Proposed.Dry.Sha),
+								"environment %s has no in-flight promotion", branch)
+							return
+						}
+						g.Expect(false).To(BeTrue(), "environment %s not found in PromotionStrategy status", branch)
+					}, constants.EventuallyTimeout).Should(Succeed())
+				}
 				setPromotionStrategyCommitStatusPhase := func(branch, key string, phase promoterv1alpha1.CommitStatusPhase) {
 					Eventually(func(g Gomega) {
 						ps := &promoterv1alpha1.PromotionStrategy{}
@@ -644,9 +660,12 @@ var _ = Describe("DependentsSuccessfulCommitStatus Controller", func() {
 					}, constants.EventuallyTimeout).Should(Succeed())
 				}
 
+				waitForPromotionStrategyEnvironmentInFlight(testBranchStaging)
+
 				Eventually(func(g Gomega) {
 					cs := &promoterv1alpha1.CommitStatus{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: stagingCSName}, cs)).To(Succeed())
+					g.Expect(cs.Spec.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
 				}, constants.EventuallyTimeout).Should(Succeed())
 
 				setPromotionStrategyCommitStatusPhase(testBranchDevelopment, "argocd-health", promoterv1alpha1.CommitPhasePending)
@@ -709,6 +728,7 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 		ps := basePS()
 		Expect(pred.Create(event.CreateEvent{Object: ps})).To(BeTrue())
 		Expect(pred.Delete(event.DeleteEvent{Object: ps})).To(BeTrue())
+		Expect(pred.Generic(event.GenericEvent{Object: ps})).To(BeFalse())
 	})
 
 	It("ignores metadata, generation, and unrelated spec changes", func() {
@@ -776,6 +796,20 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 
+	It("enqueues when spec.environments length changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments = append(newPS.Spec.Environments, promoterv1alpha1.Environment{Branch: "prd"})
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active dry sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Dry.Sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
 	It("enqueues when proposed dry sha changes", func() {
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
@@ -783,10 +817,75 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 
+	It("enqueues when proposed hydrated sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Hydrated.Sha = "ffffffffffffffffffffffffffffffffffffffff"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when hydrator note dry sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Note.DrySha = "dddddddddddddddddddddddddddddddddddddddd"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when hydrator note is removed", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Note = nil
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active dry commit time changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Dry.CommitTime = metav1.NewTime(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
 	It("enqueues when active commit status phase changes", func() {
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
 		newPS.Status.Environments[0].Active.CommitStatuses[0].Phase = string(promoterv1alpha1.CommitPhasePending)
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when status.environments length changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments = append(newPS.Status.Environments, promoterv1alpha1.EnvironmentStatus{Branch: "prd"})
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when status.environments branch order changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments = []promoterv1alpha1.EnvironmentStatus{
+			{Branch: "stg"},
+			{Branch: "dev"},
+		}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active commit status keys change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.CommitStatuses[0].Key = "other-gate"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active commit status count changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.CommitStatuses = append(
+			newPS.Status.Environments[0].Active.CommitStatuses,
+			promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{
+				Key:   "smoke",
+				Phase: string(promoterv1alpha1.CommitPhaseSuccess),
+			},
+		)
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })

--- a/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
+++ b/internal/controller/dependentssuccessfulcommitstatus_controller_test.go
@@ -719,6 +719,23 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 							Note:     &promoterv1alpha1.HydratorMetadata{DrySha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
 						},
 					},
+					{
+						Branch: "stg",
+						Active: promoterv1alpha1.CommitBranchState{
+							Dry: promoterv1alpha1.CommitShaState{
+								Sha:        "dddddddddddddddddddddddddddddddddddddddd",
+								CommitTime: metav1.NewTime(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)),
+							},
+							CommitStatuses: []promoterv1alpha1.ChangeRequestPolicyCommitStatusPhase{
+								{Key: "argocd-health", Phase: string(promoterv1alpha1.CommitPhaseSuccess)},
+							},
+						},
+						Proposed: promoterv1alpha1.CommitBranchState{
+							Dry:      promoterv1alpha1.CommitShaState{Sha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+							Hydrated: promoterv1alpha1.CommitShaState{Sha: "ffffffffffffffffffffffffffffffffffffffff"},
+							Note:     &promoterv1alpha1.HydratorMetadata{DrySha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+						},
+					},
 				},
 			},
 		}
@@ -863,8 +880,8 @@ var _ = Describe("promotionStrategyGateRelevantPredicate", func() {
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
 		newPS.Status.Environments = []promoterv1alpha1.EnvironmentStatus{
-			{Branch: "stg"},
-			{Branch: "dev"},
+			oldPS.Status.Environments[1],
+			oldPS.Status.Environments[0],
 		}
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})


### PR DESCRIPTION
## Summary

- Add `promotionStrategyGateRelevantPredicate` on the PromotionStrategy watch in `DependentsSuccessfulCommitStatusReconciler` so status-only churn (Ready condition, history, instanceID, PR mirror, commit metadata, etc.) does not enqueue DSCS reconciles.
- Compare gate-relevant fields explicitly per environment: spec branch/order, active/proposed dry SHAs, proposed hydrated SHA, hydrator note dry SHA, active dry commit time, and active commit status key+phase.
- Unit tests for the predicate plus an integration test confirming upstream commit status health changes still enqueue DSCS.

Fixes #2011

## Test plan

- [x] `go test ./internal/controller/ -ginkgo.focus="promotionStrategyGateRelevantPredicate|upstream commit status health"`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary reconciliation when PromotionStrategy metadata, unrelated specification fields, or status-only noise changes.
  * Preserved reconciliation for changes affecting environment ordering, environment branches, proposed dry-run SHAs, and active commit status phases.
  * Improved dependent commit status synchronization when upstream commit status phases or other gate-relevant conditions change.
  * Prevented irrelevant configuration updates from triggering unnecessary status synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->