### PR TITLE
chore: more PS predicates to reduce reconciles

### DIFF
--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -425,8 +425,7 @@ func promotionStrategyGitCommitStatusGateRelevantPredicate() predicate.Predicate
 			if !okOld || !okNew {
 				return true
 			}
-			return oldPS.Spec.RepositoryReference.Name != newPS.Spec.RepositoryReference.Name ||
-				promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+			return promotionStrategyGitCommitStatusSpecGateRelevantChange(oldPS.Spec, newPS.Spec) ||
 				promotionStrategyGitCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {
@@ -438,14 +437,48 @@ func promotionStrategyGitCommitStatusGateRelevantPredicate() predicate.Predicate
 	}
 }
 
+// promotionStrategyGitCommitStatusSpecGateRelevantChange reports whether PromotionStrategy spec
+// changed in a way that affects which environments GitCommitStatus evaluates.
+func promotionStrategyGitCommitStatusSpecGateRelevantChange(oldSpec, newSpec promoterv1alpha1.PromotionStrategySpec) bool {
+	if oldSpec.RepositoryReference.Name != newSpec.RepositoryReference.Name {
+		return true
+	}
+	if commitStatusSelectorsGateRelevantChange(oldSpec.ProposedCommitStatuses, newSpec.ProposedCommitStatuses) {
+		return true
+	}
+	if commitStatusSelectorsGateRelevantChange(oldSpec.ActiveCommitStatuses, newSpec.ActiveCommitStatuses) {
+		return true
+	}
+	return promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldSpec.Environments, newSpec.Environments)
+}
+
 // promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange reports whether spec.environments
-// changed in a way that affects GitCommitStatus. Only branch names and their order matter.
+// changed in a way that affects GitCommitStatus. Branch names, their order, and per-environment
+// commit-status selectors determine which environments are evaluated.
 func promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.Environment) bool {
 	if len(oldEnvs) != len(newEnvs) {
 		return true
 	}
 	for i := range oldEnvs {
 		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+		if commitStatusSelectorsGateRelevantChange(oldEnvs[i].ProposedCommitStatuses, newEnvs[i].ProposedCommitStatuses) {
+			return true
+		}
+		if commitStatusSelectorsGateRelevantChange(oldEnvs[i].ActiveCommitStatuses, newEnvs[i].ActiveCommitStatuses) {
+			return true
+		}
+	}
+	return false
+}
+
+func commitStatusSelectorsGateRelevantChange(oldSelectors, newSelectors []promoterv1alpha1.CommitStatusSelector) bool {
+	if len(oldSelectors) != len(newSelectors) {
+		return true
+	}
+	for i := range oldSelectors {
+		if oldSelectors[i].Key != newSelectors[i].Key {
 			return true
 		}
 	}

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -425,7 +425,8 @@ func promotionStrategyGitCommitStatusGateRelevantPredicate() predicate.Predicate
 			if !okOld || !okNew {
 				return true
 			}
-			return promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+			return oldPS.Spec.RepositoryReference.Name != newPS.Spec.RepositoryReference.Name ||
+				promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
 				promotionStrategyGitCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {

--- a/internal/controller/gitcommitstatus_controller.go
+++ b/internal/controller/gitcommitstatus_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -153,7 +154,8 @@ func (r *GitCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr ct
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.GitCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueGitCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueGitCommitStatusForPromotionStrategy(),
+			builder.WithPredicates(promotionStrategyGitCommitStatusGateRelevantPredicate())).
 		Named("gitcommitstatus").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
@@ -408,6 +410,91 @@ func (r *GitCommitStatusReconciler) evaluateExpression(expression string, commit
 		return promoterv1alpha1.CommitPhaseSuccess, new(true), nil
 	}
 	return promoterv1alpha1.CommitPhaseFailure, new(false), nil
+}
+
+// promotionStrategyGitCommitStatusGateRelevantPredicate limits PromotionStrategy watch events to create/delete
+// and updates where fields that affect GitCommitStatus validation changed.
+func promotionStrategyGitCommitStatusGateRelevantPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPS, okOld := e.ObjectOld.(*promoterv1alpha1.PromotionStrategy)
+			newPS, okNew := e.ObjectNew.(*promoterv1alpha1.PromotionStrategy)
+			if !okOld || !okNew {
+				return true
+			}
+			return promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+				promotionStrategyGitCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange reports whether spec.environments
+// changed in a way that affects GitCommitStatus. Only branch names and their order matter.
+func promotionStrategyGitCommitStatusSpecEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.Environment) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+	}
+	return false
+}
+
+// promotionStrategyGitCommitStatusStatusEnvironmentsGateRelevantChange reports whether any environment
+// status changed in a way that affects GitCommitStatus validation.
+func promotionStrategyGitCommitStatusStatusEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.EnvironmentStatus) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+		if promotionStrategyGitCommitStatusEnvironmentStatusGateRelevantChange(oldEnvs[i], newEnvs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// promotionStrategyGitCommitStatusEnvironmentStatusGateRelevantChange reports whether a single environment's
+// PromotionStrategy status changed in a way that affects GitCommitStatus validation.
+func promotionStrategyGitCommitStatusEnvironmentStatusGateRelevantChange(oldEnv, newEnv promoterv1alpha1.EnvironmentStatus) bool {
+	if gitCommitStatusHydratedCommitExpressionDataChanged(oldEnv.Active.Hydrated, newEnv.Active.Hydrated) {
+		return true
+	}
+	return gitCommitStatusHydratedCommitExpressionDataChanged(oldEnv.Proposed.Hydrated, newEnv.Proposed.Hydrated)
+}
+
+func gitCommitStatusHydratedCommitExpressionDataChanged(oldState, newState promoterv1alpha1.CommitShaState) bool {
+	if oldState.Sha != newState.Sha {
+		// Drives which commit is validated and the CommitStatus resource key.
+		return true
+	}
+	if oldState.Author != newState.Author {
+		// Exposed to expression evaluation as commit author.
+		return true
+	}
+	if oldState.Subject != newState.Subject {
+		// Exposed to expression evaluation as commit subject.
+		return true
+	}
+	if oldState.Body != newState.Body {
+		// Exposed to expression evaluation as commit body and parsed trailers.
+		return true
+	}
+	return false
 }
 
 // enqueueGitCommitStatusForPromotionStrategy returns a handler that enqueues all GitCommitStatus resources

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -30,8 +30,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
@@ -1342,5 +1344,100 @@ var _ = Describe("GitCommitStatus Controller", Ordered, func() {
 				"stagingProposedSha", stagingProposedSha,
 				"prodProposedSha", prodProposedSha)
 		})
+	})
+})
+
+var _ = Describe("promotionStrategyGitCommitStatusGateRelevantPredicate", func() {
+	pred := promotionStrategyGitCommitStatusGateRelevantPredicate()
+
+	basePS := func() *promoterv1alpha1.PromotionStrategy {
+		return &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				Environments: []promoterv1alpha1.Environment{
+					{Branch: "dev"},
+					{Branch: "stg"},
+				},
+			},
+			Status: promoterv1alpha1.PromotionStrategyStatus{
+				Environments: []promoterv1alpha1.EnvironmentStatus{
+					{
+						Branch: "dev",
+						Active: promoterv1alpha1.CommitBranchState{
+							Hydrated: promoterv1alpha1.CommitShaState{
+								Sha:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+								Author:  "alice",
+								Subject: "active subject",
+								Body:    "active body",
+							},
+						},
+						Proposed: promoterv1alpha1.CommitBranchState{
+							Hydrated: promoterv1alpha1.CommitShaState{
+								Sha:     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+								Author:  "bob",
+								Subject: "proposed subject",
+								Body:    "proposed body",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	It("allows create and delete events", func() {
+		ps := basePS()
+		Expect(pred.Create(event.CreateEvent{Object: ps})).To(BeTrue())
+		Expect(pred.Delete(event.DeleteEvent{Object: ps})).To(BeTrue())
+	})
+
+	It("ignores metadata and obvious status noise", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Generation = 99
+		newPS.ResourceVersion = "999"
+		newPS.Status.ObservedGeneration = 42
+		instanceID := "new-instance"
+		newPS.Status.InstanceID = &instanceID
+		meta.SetStatusCondition(&newPS.Status.Conditions, metav1.Condition{
+			Type:               string(promoterConditions.Ready),
+			Status:             metav1.ConditionFalse,
+			Reason:             "Test",
+			Message:            "not gate relevant",
+			ObservedGeneration: newPS.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("ignores hydrated repo URL churn", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Hydrated.RepoURL = "https://example.com/other.git"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when spec.environments branches change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments = []promoterv1alpha1.Environment{
+			{Branch: "dev"},
+			{Branch: "prd"},
+		}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when proposed hydrated commit body changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Hydrated.Body = "updated body"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active hydrated sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Hydrated.Sha = "dddddddddddddddddddddddddddddddddddddddd"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -32,11 +32,10 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
-	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
-	"github.com/argoproj-labs/gitops-promoter/internal/utils"
-
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
 // This Ordered suite shares one PromotionStrategy. Each spec must use a distinct
@@ -1432,6 +1431,15 @@ var _ = Describe("promotionStrategyGitCommitStatusGateRelevantPredicate", func()
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
 		newPS.Spec.RepositoryReference.Name = "other-repo"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when per-environment proposed commit status selectors change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments[0].ProposedCommitStatuses = []promoterv1alpha1.CommitStatusSelector{
+			{Key: "gcs-cleanup"},
+		}
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 

--- a/internal/controller/gitcommitstatus_controller_test.go
+++ b/internal/controller/gitcommitstatus_controller_test.go
@@ -1354,6 +1354,7 @@ var _ = Describe("promotionStrategyGitCommitStatusGateRelevantPredicate", func()
 		return &promoterv1alpha1.PromotionStrategy{
 			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
 			Spec: promoterv1alpha1.PromotionStrategySpec{
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "demo-repo"},
 				Environments: []promoterv1alpha1.Environment{
 					{Branch: "dev"},
 					{Branch: "stg"},
@@ -1427,6 +1428,13 @@ var _ = Describe("promotionStrategyGitCommitStatusGateRelevantPredicate", func()
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 
+	It("enqueues when spec.repositoryReference changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.RepositoryReference.Name = "other-repo"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
 	It("enqueues when proposed hydrated commit body changes", func() {
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
@@ -1438,6 +1446,20 @@ var _ = Describe("promotionStrategyGitCommitStatusGateRelevantPredicate", func()
 		oldPS := basePS()
 		newPS := oldPS.DeepCopy()
 		newPS.Status.Environments[0].Active.Hydrated.Sha = "dddddddddddddddddddddddddddddddddddddddd"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when proposed hydrated author changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Hydrated.Author = "carol"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when proposed hydrated subject changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Hydrated.Subject = "updated subject"
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })

--- a/internal/controller/scheduledcommitstatus_controller.go
+++ b/internal/controller/scheduledcommitstatus_controller.go
@@ -323,7 +323,8 @@ func promotionStrategyScheduledCommitStatusGateRelevantPredicate() predicate.Pre
 			if !okOld || !okNew {
 				return true
 			}
-			return promotionStrategyScheduledCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+			return oldPS.Spec.RepositoryReference.Name != newPS.Spec.RepositoryReference.Name ||
+				promotionStrategyScheduledCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
 				promotionStrategyScheduledCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {

--- a/internal/controller/scheduledcommitstatus_controller.go
+++ b/internal/controller/scheduledcommitstatus_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -140,7 +141,8 @@ func (r *ScheduledCommitStatusReconciler) SetupWithManager(ctx context.Context, 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.ScheduledCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueScheduledCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueScheduledCommitStatusForPromotionStrategy(),
+			builder.WithPredicates(promotionStrategyScheduledCommitStatusGateRelevantPredicate())).
 		Named("scheduledcommitstatus").
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
@@ -306,6 +308,66 @@ func (r *ScheduledCommitStatusReconciler) calculateRequeueDuration(ctx context.C
 	}
 
 	return defaultDuration
+}
+
+// promotionStrategyScheduledCommitStatusGateRelevantPredicate limits PromotionStrategy watch events to
+// create/delete and updates where fields that affect ScheduledCommitStatus gate evaluation changed.
+func promotionStrategyScheduledCommitStatusGateRelevantPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPS, okOld := e.ObjectOld.(*promoterv1alpha1.PromotionStrategy)
+			newPS, okNew := e.ObjectNew.(*promoterv1alpha1.PromotionStrategy)
+			if !okOld || !okNew {
+				return true
+			}
+			return promotionStrategyScheduledCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+				promotionStrategyScheduledCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func promotionStrategyScheduledCommitStatusSpecEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.Environment) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+	}
+	return false
+}
+
+func promotionStrategyScheduledCommitStatusStatusEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.EnvironmentStatus) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+		if promotionStrategyScheduledCommitStatusEnvironmentStatusGateRelevantChange(oldEnvs[i], newEnvs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func promotionStrategyScheduledCommitStatusEnvironmentStatusGateRelevantChange(oldEnv, newEnv promoterv1alpha1.EnvironmentStatus) bool {
+	if oldEnv.Proposed.Hydrated.Sha != newEnv.Proposed.Hydrated.Sha {
+		// CommitStatus is keyed to the proposed hydrated SHA being gated.
+		return true
+	}
+	return false
 }
 
 func (r *ScheduledCommitStatusReconciler) enqueueScheduledCommitStatusForPromotionStrategy() handler.EventHandler {

--- a/internal/controller/scheduledcommitstatus_controller_test.go
+++ b/internal/controller/scheduledcommitstatus_controller_test.go
@@ -927,7 +927,8 @@ var _ = Describe("promotionStrategyScheduledCommitStatusGateRelevantPredicate", 
 		return &promoterv1alpha1.PromotionStrategy{
 			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
 			Spec: promoterv1alpha1.PromotionStrategySpec{
-				Environments: []promoterv1alpha1.Environment{{Branch: "dev"}},
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "demo-repo"},
+				Environments:        []promoterv1alpha1.Environment{{Branch: "dev"}},
 			},
 			Status: promoterv1alpha1.PromotionStrategyStatus{
 				Environments: []promoterv1alpha1.EnvironmentStatus{{
@@ -965,6 +966,20 @@ var _ = Describe("promotionStrategyScheduledCommitStatusGateRelevantPredicate", 
 		newPS.Status.Environments[0].Active.Hydrated.Sha = "ffffffffffffffffffffffffffffffffffffffff"
 		newPS.Status.Environments[0].Proposed.Hydrated.Subject = "new subject"
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when spec.environments branches change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments = []promoterv1alpha1.Environment{{Branch: "prd"}}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when spec.repositoryReference changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.RepositoryReference.Name = "other-repo"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 
 	It("enqueues when proposed hydrated sha changes", func() {

--- a/internal/controller/scheduledcommitstatus_controller_test.go
+++ b/internal/controller/scheduledcommitstatus_controller_test.go
@@ -30,8 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var _ = Describe("ScheduledCommitStatus Controller", Ordered, func() {
@@ -915,5 +917,60 @@ var _ = Describe("evaluateWindows", func() {
 		Expect(err).NotTo(HaveOccurred())
 		// 10:00 UTC = 12:00 Paris — inside window (11:00-17:00 Paris)
 		Expect(result.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+	})
+})
+
+var _ = Describe("promotionStrategyScheduledCommitStatusGateRelevantPredicate", func() {
+	pred := promotionStrategyScheduledCommitStatusGateRelevantPredicate()
+
+	basePS := func() *promoterv1alpha1.PromotionStrategy {
+		return &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				Environments: []promoterv1alpha1.Environment{{Branch: "dev"}},
+			},
+			Status: promoterv1alpha1.PromotionStrategyStatus{
+				Environments: []promoterv1alpha1.EnvironmentStatus{{
+					Branch: "dev",
+					Active: promoterv1alpha1.CommitBranchState{
+						Hydrated: promoterv1alpha1.CommitShaState{Sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+					},
+					Proposed: promoterv1alpha1.CommitBranchState{
+						Hydrated: promoterv1alpha1.CommitShaState{Sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+					},
+				}},
+			},
+		}
+	}
+
+	It("allows create and delete events", func() {
+		ps := basePS()
+		Expect(pred.Create(event.CreateEvent{Object: ps})).To(BeTrue())
+		Expect(pred.Delete(event.DeleteEvent{Object: ps})).To(BeTrue())
+	})
+
+	It("ignores metadata, active hydrated churn, and status noise", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Generation = 99
+		newPS.Status.ObservedGeneration = 42
+		meta.SetStatusCondition(&newPS.Status.Conditions, metav1.Condition{
+			Type:               string(promoterConditions.Ready),
+			Status:             metav1.ConditionFalse,
+			Reason:             "Test",
+			Message:            "not gate relevant",
+			ObservedGeneration: newPS.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		newPS.Status.Environments[0].Active.Hydrated.Sha = "ffffffffffffffffffffffffffffffffffffffff"
+		newPS.Status.Environments[0].Proposed.Hydrated.Subject = "new subject"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when proposed hydrated sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Proposed.Hydrated.Sha = "dddddddddddddddddddddddddddddddddddddddd"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -344,7 +344,8 @@ func promotionStrategyTimedCommitStatusGateRelevantPredicate() predicate.Predica
 			if !okOld || !okNew {
 				return true
 			}
-			return promotionStrategyTimedCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+			return oldPS.Spec.RepositoryReference.Name != newPS.Spec.RepositoryReference.Name ||
+				promotionStrategyTimedCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
 				promotionStrategyTimedCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {

--- a/internal/controller/timedcommitstatus_controller.go
+++ b/internal/controller/timedcommitstatus_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -152,7 +153,8 @@ func (r *TimedCommitStatusReconciler) SetupWithManager(ctx context.Context, mgr 
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&promoterv1alpha1.TimedCommitStatus{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueTimedCommitStatusForPromotionStrategy()).
+		Watches(&promoterv1alpha1.PromotionStrategy{}, r.enqueueTimedCommitStatusForPromotionStrategy(),
+			builder.WithPredicates(promotionStrategyTimedCommitStatusGateRelevantPredicate())).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles, RateLimiter: rateLimiter}).
 		Complete(r)
 	if err != nil {
@@ -327,6 +329,70 @@ func (r *TimedCommitStatusReconciler) calculateRequeueDuration(ctx context.Conte
 	}
 
 	return defaultDuration
+}
+
+// promotionStrategyTimedCommitStatusGateRelevantPredicate limits PromotionStrategy watch events to create/delete
+// and updates where fields that affect TimedCommitStatus gate evaluation changed.
+func promotionStrategyTimedCommitStatusGateRelevantPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPS, okOld := e.ObjectOld.(*promoterv1alpha1.PromotionStrategy)
+			newPS, okNew := e.ObjectNew.(*promoterv1alpha1.PromotionStrategy)
+			if !okOld || !okNew {
+				return true
+			}
+			return promotionStrategyTimedCommitStatusSpecEnvironmentsGateRelevantChange(oldPS.Spec.Environments, newPS.Spec.Environments) ||
+				promotionStrategyTimedCommitStatusStatusEnvironmentsGateRelevantChange(oldPS.Status.Environments, newPS.Status.Environments)
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func promotionStrategyTimedCommitStatusSpecEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.Environment) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+	}
+	return false
+}
+
+func promotionStrategyTimedCommitStatusStatusEnvironmentsGateRelevantChange(oldEnvs, newEnvs []promoterv1alpha1.EnvironmentStatus) bool {
+	if len(oldEnvs) != len(newEnvs) {
+		return true
+	}
+	for i := range oldEnvs {
+		if oldEnvs[i].Branch != newEnvs[i].Branch {
+			return true
+		}
+		if promotionStrategyTimedCommitStatusEnvironmentStatusGateRelevantChange(oldEnvs[i], newEnvs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func promotionStrategyTimedCommitStatusEnvironmentStatusGateRelevantChange(oldEnv, newEnv promoterv1alpha1.EnvironmentStatus) bool {
+	if oldEnv.Active.Hydrated.Sha != newEnv.Active.Hydrated.Sha {
+		// Timer resets when the active hydrated SHA changes.
+		return true
+	}
+	if !oldEnv.Active.Hydrated.CommitTime.Equal(&newEnv.Active.Hydrated.CommitTime) {
+		// Elapsed time is measured from active hydrated commit time.
+		return true
+	}
+	return false
 }
 
 // enqueueTimedCommitStatusForPromotionStrategy returns a handler that enqueues all TimedCommitStatus resources

--- a/internal/controller/timedcommitstatus_controller_test.go
+++ b/internal/controller/timedcommitstatus_controller_test.go
@@ -30,9 +30,12 @@ import (
 	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
 	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
+	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
 )
 
 var _ = Describe("TimedCommitStatus Controller", Ordered, func() {
@@ -719,5 +722,70 @@ var _ = Describe("TimedCommitStatus Controller - Missing PromotionStrategy", fun
 				g.Expect(tcs.Status.Environments).To(BeEmpty())
 			}, 2*time.Second, 500*time.Millisecond).Should(Succeed())
 		})
+	})
+})
+
+var _ = Describe("promotionStrategyTimedCommitStatusGateRelevantPredicate", func() {
+	pred := promotionStrategyTimedCommitStatusGateRelevantPredicate()
+
+	basePS := func() *promoterv1alpha1.PromotionStrategy {
+		return &promoterv1alpha1.PromotionStrategy{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
+			Spec: promoterv1alpha1.PromotionStrategySpec{
+				Environments: []promoterv1alpha1.Environment{{Branch: "dev"}},
+			},
+			Status: promoterv1alpha1.PromotionStrategyStatus{
+				Environments: []promoterv1alpha1.EnvironmentStatus{{
+					Branch: "dev",
+					Active: promoterv1alpha1.CommitBranchState{
+						Hydrated: promoterv1alpha1.CommitShaState{
+							Sha:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+							CommitTime: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+						},
+					},
+					Proposed: promoterv1alpha1.CommitBranchState{
+						Hydrated: promoterv1alpha1.CommitShaState{Sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+					},
+				}},
+			},
+		}
+	}
+
+	It("allows create and delete events", func() {
+		ps := basePS()
+		Expect(pred.Create(event.CreateEvent{Object: ps})).To(BeTrue())
+		Expect(pred.Delete(event.DeleteEvent{Object: ps})).To(BeTrue())
+	})
+
+	It("ignores metadata, proposed hydrated churn, and status noise", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Generation = 99
+		newPS.Status.ObservedGeneration = 42
+		meta.SetStatusCondition(&newPS.Status.Conditions, metav1.Condition{
+			Type:               string(promoterConditions.Ready),
+			Status:             metav1.ConditionFalse,
+			Reason:             "Test",
+			Message:            "not gate relevant",
+			ObservedGeneration: newPS.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		newPS.Status.Environments[0].Proposed.Hydrated.Sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+		newPS.Status.Environments[0].Active.Hydrated.Author = "someone else"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when active hydrated sha changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Hydrated.Sha = "ffffffffffffffffffffffffffffffffffffffff"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when active hydrated commit time changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Status.Environments[0].Active.Hydrated.CommitTime = metav1.NewTime(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 })

--- a/internal/controller/timedcommitstatus_controller_test.go
+++ b/internal/controller/timedcommitstatus_controller_test.go
@@ -732,7 +732,8 @@ var _ = Describe("promotionStrategyTimedCommitStatusGateRelevantPredicate", func
 		return &promoterv1alpha1.PromotionStrategy{
 			ObjectMeta: metav1.ObjectMeta{Name: "demo-ps", Namespace: "default"},
 			Spec: promoterv1alpha1.PromotionStrategySpec{
-				Environments: []promoterv1alpha1.Environment{{Branch: "dev"}},
+				RepositoryReference: promoterv1alpha1.ObjectReference{Name: "demo-repo"},
+				Environments:        []promoterv1alpha1.Environment{{Branch: "dev"}},
 			},
 			Status: promoterv1alpha1.PromotionStrategyStatus{
 				Environments: []promoterv1alpha1.EnvironmentStatus{{
@@ -773,6 +774,20 @@ var _ = Describe("promotionStrategyTimedCommitStatusGateRelevantPredicate", func
 		newPS.Status.Environments[0].Proposed.Hydrated.Sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 		newPS.Status.Environments[0].Active.Hydrated.Author = "someone else"
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeFalse())
+	})
+
+	It("enqueues when spec.environments branches change", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.Environments = []promoterv1alpha1.Environment{{Branch: "prd"}}
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
+	})
+
+	It("enqueues when spec.repositoryReference changes", func() {
+		oldPS := basePS()
+		newPS := oldPS.DeepCopy()
+		newPS.Spec.RepositoryReference.Name = "other-repo"
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: oldPS, ObjectNew: newPS})).To(BeTrue())
 	})
 
 	It("enqueues when active hydrated sha changes", func() {

--- a/internal/controller/timedcommitstatus_controller_test.go
+++ b/internal/controller/timedcommitstatus_controller_test.go
@@ -25,17 +25,16 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
-	"github.com/argoproj-labs/gitops-promoter/internal/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	promoterv1alpha1 "github.com/argoproj-labs/gitops-promoter/api/v1alpha1"
 	promoterConditions "github.com/argoproj-labs/gitops-promoter/internal/types/conditions"
+	"github.com/argoproj-labs/gitops-promoter/internal/types/constants"
+	"github.com/argoproj-labs/gitops-promoter/internal/utils"
 )
 
 var _ = Describe("TimedCommitStatus Controller", Ordered, func() {


### PR DESCRIPTION
I went with duplication instead of DRY just for easy reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary status recalculations when promotion strategy updates affect only unrelated metadata, status information, or other irrelevant fields.
  * Reconciliation now responds to relevant branch, repository reference, commit, and commit-time changes.

* **Reliability**
  * Ensured relevant promotion strategy changes continue to update Git, scheduled, and timed commit status results.
  * Preserved processing for newly created and deleted promotion strategies.
  * Added coverage to verify that relevant updates are processed while unrelated changes are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->